### PR TITLE
fix: validate follow-up tasks against existing PRs

### DIFF
--- a/lib/tools/worker/work-finish.test.ts
+++ b/lib/tools/worker/work-finish.test.ts
@@ -1,70 +1,41 @@
 /**
- * Tests for work_finish tool — PR validation and conflict resolution.
- *
- * Covers:
- * - isConflictResolutionCycle: detects when issue was transitioned due to merge conflicts
- * - validatePrExistsForDeveloper: validates PR existence and mergeable status
- * - Rejection when PR still has conflicts (after conflict resolution cycle)
- * - Acceptance when PR is mergeable (conflicts resolved)
+ * Tests for work_finish PR validation.
  *
  * Run with: npx tsx --test lib/tools/worker/work-finish.test.ts
  */
 import { describe, it, before, after } from "node:test";
 import assert from "node:assert";
-import { mkdtemp, writeFile, readFile } from "node:fs/promises";
+import { mkdtemp, writeFile, readFile, mkdir, rm } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
-import { rmdir } from "node:fs/promises";
+import { validatePrExistsForDeveloper } from "./work-finish.js";
+import { TestProvider } from "../../testing/test-provider.js";
+import { GitHubProvider } from "../../providers/github.js";
+import { PrState } from "../../providers/provider.js";
 
-// Helper to create a mock audit log with a merge_conflict transition
 async function createMockAuditLog(workspaceDir: string, issueId: number, hasMergeConflict: boolean): Promise<void> {
   const logDir = join(workspaceDir, "devclaw", "log");
-  
-  // Ensure directory exists
-  try {
-    await writeFile(join(workspaceDir, "devclaw", "placeholder"), "");
-  } catch {
-    // ignore
-  }
-  
-  const auditPath = join(workspaceDir, "devclaw", "log", "audit.log");
-  const entries = [];
-  
-  // Add some dummy entries
-  entries.push(JSON.stringify({
-    timestamp: "2026-03-01T10:00:00Z",
-    event: "issue_created",
-    issueId,
-    project: "devclaw",
-  }));
-  
-  if (hasMergeConflict) {
-    entries.push(JSON.stringify({
+  await mkdir(logDir, { recursive: true });
+
+  const auditPath = join(logDir, "audit.log");
+  const entries = [
+    JSON.stringify({ timestamp: "2026-03-01T10:00:00Z", event: "issue_created", issueId, project: "devclaw" }),
+    ...(hasMergeConflict ? [JSON.stringify({
       timestamp: "2026-03-01T10:15:00Z",
       event: "review_transition",
       issueId,
       from: "In Review",
       to: "To Improve",
       reason: "merge_conflict",
-      reviewer: "system",
       project: "devclaw",
-    }));
-  }
-  
-  // Add final entry (timestamp for ordering)
-  entries.push(JSON.stringify({
-    timestamp: "2026-03-01T10:30:00Z",
-    event: "work_started",
-    issueId,
-    role: "developer",
-    project: "devclaw",
-  }));
-  
-  const content = entries.join("\n") + "\n";
-  await writeFile(auditPath, content);
+    })] : []),
+    JSON.stringify({ timestamp: "2026-03-01T10:30:00Z", event: "work_started", issueId, role: "developer", project: "devclaw" }),
+  ];
+
+  await writeFile(auditPath, `${entries.join("\n")}\n`);
 }
 
-describe("work_finish: PR validation and conflict resolution", () => {
+describe("work_finish PR validation", () => {
   let tempDir: string;
 
   before(async () => {
@@ -72,215 +43,197 @@ describe("work_finish: PR validation and conflict resolution", () => {
   });
 
   after(async () => {
-    // Clean up
-    try {
-      await rmdir(tempDir, { recursive: true });
-    } catch {
-      // ignore
-    }
+    await rm(tempDir, { recursive: true, force: true });
   });
 
-  describe("isConflictResolutionCycle", () => {
-    it("should detect merge_conflict transition in audit log", async () => {
+  describe("audit log parsing", () => {
+    it("detects merge_conflict transitions", async () => {
       const issueId = 123;
       await createMockAuditLog(tempDir, issueId, true);
-      
-      // Import the helper (we'll need to test via integration since it's not exported)
-      // For now, we'll test the behavior indirectly through validatePrExistsForDeveloper
-      const auditPath = join(tempDir, "devclaw", "log", "audit.log");
-      const content = await readFile(auditPath, "utf-8");
-      const lines = content.split("\n").filter(Boolean);
-      
-      let found = false;
-      for (const line of lines) {
-        const entry = JSON.parse(line);
-        if (
-          entry.issueId === issueId &&
-          entry.event === "review_transition" &&
-          entry.reason === "merge_conflict"
-        ) {
-          found = true;
-          break;
-        }
-      }
-      
-      assert.ok(found, "Should find merge_conflict transition in audit log");
+      const content = await readFile(join(tempDir, "devclaw", "log", "audit.log"), "utf-8");
+      assert.ok(content.includes('"reason":"merge_conflict"'));
     });
 
-    it("should return false when no merge_conflict transition exists", async () => {
-      const issueId = 456;
-      await createMockAuditLog(tempDir, issueId, false);
-      
+    it("skips malformed JSON lines", async () => {
       const auditPath = join(tempDir, "devclaw", "log", "audit.log");
+      await mkdir(join(tempDir, "devclaw", "log"), { recursive: true });
+      await writeFile(auditPath, '{"event":"valid"}\n{ invalid json\n{"event":"valid_again"}\n');
       const content = await readFile(auditPath, "utf-8");
-      const lines = content.split("\n").filter(Boolean);
-      
-      let found = false;
-      for (const line of lines) {
-        const entry = JSON.parse(line);
-        if (
-          entry.issueId === issueId &&
-          entry.event === "review_transition" &&
-          entry.reason === "merge_conflict"
-        ) {
-          found = true;
-          break;
-        }
-      }
-      
-      assert.ok(!found, "Should not find merge_conflict transition");
-    });
-
-    it("should handle missing audit log gracefully", async () => {
-      const nonExistentPath = join(tempDir, "nonexistent", "audit.log");
-      try {
-        await readFile(nonExistentPath, "utf-8");
-        assert.fail("Should throw when file does not exist");
-      } catch (err) {
-        assert.ok(err instanceof Error);
-      }
-    });
-
-    it("should skip malformed JSON lines in audit log", async () => {
-      const auditPath = join(tempDir, "devclaw", "log", "audit.log");
-      const entries = [
-        JSON.stringify({ event: "valid", issueId: 999 }),
-        "{ invalid json",
-        JSON.stringify({ event: "valid_again", issueId: 999 }),
-      ];
-      await writeFile(auditPath, entries.join("\n"));
-      
-      // Should not throw
-      const content = await readFile(auditPath, "utf-8");
-      const lines = content.split("\n").filter(Boolean);
-      let validCount = 0;
-      
-      for (const line of lines) {
-        try {
-          const entry = JSON.parse(line);
-          validCount++;
-        } catch {
-          // skip malformed
-        }
-      }
-      
-      assert.equal(validCount, 2, "Should parse 2 valid JSON entries and skip malformed");
+      const parsed = content.split("\n").filter(Boolean).flatMap((line) => {
+        try { return [JSON.parse(line)]; } catch { return []; }
+      });
+      assert.equal(parsed.length, 2);
     });
   });
 
-  describe("validatePrExistsForDeveloper: conflict detection", () => {
-    it("should validate error message format when PR still conflicting", async () => {
-      // Test that our error message matches the expected pattern
-      const errorMessage = 
-        `Cannot complete work_finish(done) while PR still shows merge conflicts.\n\n` +
-        `✗ PR status: CONFLICTING\n` +
-        `✗ PR URL: https://github.com/test/repo/pull/42\n` +
-        `✗ Branch: feature/test\n\n` +
-        `Your local rebase may have succeeded, but changes must be pushed to the remote.\n\n` +
-        `Verify your changes were pushed:\n` +
-        `  git log origin/feature/test..HEAD\n` +
-        `  # Should show no commits (meaning everything is pushed)\n\n` +
-        `If unpushed commits exist, push them:\n` +
-        `  git push --force-with-lease origin feature/test\n\n` +
-        `Wait a few seconds for GitHub to update, then verify the PR:\n` +
-        `  gh pr view 42\n` +
-        `  # Should show "Mergeable" status\n\n` +
-        `Once the PR shows as mergeable on GitHub, call work_finish again.`;
-      
-      assert.ok(
-        errorMessage.includes("Cannot complete work_finish(done) while PR still shows merge conflicts"),
-        "Error should mention PR still has conflicts"
-      );
-      assert.ok(
-        errorMessage.includes("git log origin/"),
-        "Error should include diagnostic git command"
-      );
-      assert.ok(
-        errorMessage.includes("git push --force-with-lease"),
-        "Error should include push instruction"
-      );
-      assert.ok(
-        errorMessage.includes("gh pr view"),
-        "Error should include verification command"
-      );
-    });
-
-    it("should include branch name in error message", async () => {
-      const branchName = "feature/my-fix";
-      const errorMessage = 
-        `Cannot complete work_finish(done) while PR still shows merge conflicts.\n\n` +
-        `✗ PR status: CONFLICTING\n` +
-        `✗ PR URL: https://github.com/test/repo/pull/42\n` +
-        `✗ Branch: ${branchName}`;
-      
-      assert.ok(
-        errorMessage.includes(branchName),
-        `Error message should include branch name: ${branchName}`
-      );
-    });
-  });
-
-  describe("catch block precedence", () => {
-    it("should correctly check for validation error type", () => {
-      // Test that our error checking logic is correct
-      const validationError = new Error("Cannot mark work_finish(done) without an open PR.");
-      const networkError = new Error("Failed to retrieve PR status");
-      
-      // Simulate our error check logic
-      const shouldThrowValidation = 
-        validationError instanceof Error && 
-        (validationError.message.startsWith("Cannot mark work_finish(done)") || 
-         validationError.message.startsWith("Cannot complete work_finish(done)"));
-      
-      const shouldThrowNetwork = 
-        networkError instanceof Error && 
-        (networkError.message.startsWith("Cannot mark work_finish(done)") || 
-         networkError.message.startsWith("Cannot complete work_finish(done)"));
-      
-      assert.ok(shouldThrowValidation, "Should re-throw validation errors");
-      assert.ok(!shouldThrowNetwork, "Should swallow network errors");
-    });
-
-    it("should handle non-Error exceptions gracefully", () => {
-      // Test that non-Error objects don't cause issues
-      const notAnError = "some string";
-      
-      const shouldRethrow = 
-        notAnError instanceof Error && 
-        ((notAnError as any).message?.startsWith("Cannot mark work_finish(done)") || 
-         (notAnError as any).message?.startsWith("Cannot complete work_finish(done)"));
-      
-      assert.ok(!shouldRethrow, "Should not re-throw non-Error objects");
-    });
-  });
-
-  describe("audit logging", () => {
-    it("should log rejection with correct fields", async () => {
-      const rejectionLog = {
-        event: "work_finish_rejected",
-        project: "devclaw",
-        issue: 123,
-        reason: "pr_still_conflicting",
-        prUrl: "https://github.com/test/repo/pull/123",
-        mergeable: false,
+  describe("validatePrExistsForDeveloper", () => {
+    it("accepts a valid explicit PR URL for follow-up tasks", async () => {
+      const provider = Object.create(GitHubProvider.prototype) as GitHubProvider & {
+        prHasReaction: () => Promise<boolean>;
+        reactToPr: (_issueId: number, _emoji: string) => Promise<void>;
+        getPrStatus: (_issueId: number) => Promise<any>;
       };
-      
-      assert.ok(rejectionLog.event === "work_finish_rejected");
-      assert.ok(rejectionLog.reason === "pr_still_conflicting");
-      assert.ok(rejectionLog.mergeable === false);
+      let reacted = false;
+      provider.prHasReaction = async () => false;
+      provider.reactToPr = async () => { reacted = true; };
+      provider.getPrStatus = async () => ({ state: PrState.CLOSED, url: null });
+
+      const runCommand = async (args: string[]) => {
+        if (args[0] === "git") return { stdout: "feature/existing-pr\n", stderr: "", exitCode: 0 };
+        if (args[0] === "gh" && args[1] === "pr" && args[2] === "view") {
+          return {
+            stdout: JSON.stringify({
+              url: "https://github.com/test/repo/pull/105",
+              title: "existing pr",
+              state: "OPEN",
+              headRefName: "feature/existing-pr",
+              reviewDecision: null,
+              mergeable: "MERGEABLE",
+            }),
+            stderr: "",
+            exitCode: 0,
+          };
+        }
+        throw new Error(`unexpected command: ${args.join(" ")}`);
+      };
+
+      await validatePrExistsForDeveloper(108, tempDir, provider, runCommand as any, tempDir, "devclaw", "https://github.com/test/repo/pull/105");
+      assert.ok(reacted);
     });
 
-    it("should log successful conflict resolution with correct fields", async () => {
-      const successLog = {
-        event: "conflict_resolution_verified",
-        project: "devclaw",
-        issue: 123,
-        prUrl: "https://github.com/test/repo/pull/123",
+    it("uses current branch PR lookup before issue-id lookup", async () => {
+      const provider = Object.create(GitHubProvider.prototype) as GitHubProvider & {
+        prHasReaction: () => Promise<boolean>;
+        reactToPr: (_issueId: number, _emoji: string) => Promise<void>;
+        getPrStatus: (_issueId: number) => Promise<any>;
+      };
+      let issueLookupCount = 0;
+      provider.prHasReaction = async () => true;
+      provider.reactToPr = async () => {};
+      provider.getPrStatus = async () => {
+        issueLookupCount++;
+        return { state: PrState.CLOSED, url: null };
+      };
+
+      const runCommand = async (args: string[]) => {
+        if (args[0] === "git") return { stdout: "feature/existing-pr\n", stderr: "", exitCode: 0 };
+        if (args[0] === "gh" && args[1] === "pr" && args[2] === "list") {
+          return {
+            stdout: JSON.stringify([{
+              url: "https://github.com/test/repo/pull/105",
+              title: "existing pr",
+              state: "OPEN",
+              headRefName: "feature/existing-pr",
+              reviewDecision: null,
+              mergeable: "MERGEABLE",
+            }]),
+            stderr: "",
+            exitCode: 0,
+          };
+        }
+        throw new Error(`unexpected command: ${args.join(" ")}`);
+      };
+
+      await validatePrExistsForDeveloper(108, tempDir, provider, runCommand as any, tempDir, "devclaw");
+      assert.equal(issueLookupCount, 0);
+    });
+
+    it("validates explicit URLs for non-GitHub providers against the linked PR", async () => {
+      const provider = new TestProvider();
+      provider.setPrStatus(42, {
+        state: PrState.OPEN,
+        url: "https://gitlab.example.com/group/project/-/merge_requests/9",
+        sourceBranch: "feature/existing-mr",
         mergeable: true,
+      });
+
+      const runCommand = async () => ({ stdout: "feature/existing-mr\n", stderr: "", exitCode: 0 });
+      await validatePrExistsForDeveloper(
+        42,
+        tempDir,
+        provider as any,
+        runCommand as any,
+        tempDir,
+        "devclaw",
+        "https://gitlab.example.com/group/project/-/merge_requests/9",
+      );
+      assert.equal(provider.callsTo("getPrStatus").length, 1);
+    });
+
+    it("rejects invalid explicit URLs for non-GitHub providers", async () => {
+      const provider = new TestProvider();
+      provider.setPrStatus(42, {
+        state: PrState.OPEN,
+        url: "https://gitlab.example.com/group/project/-/merge_requests/9",
+        sourceBranch: "feature/existing-mr",
+        mergeable: true,
+      });
+
+      const runCommand = async () => ({ stdout: "feature/existing-mr\n", stderr: "", exitCode: 0 });
+      await assert.rejects(
+        () => validatePrExistsForDeveloper(
+          42,
+          tempDir,
+          provider as any,
+          runCommand as any,
+          tempDir,
+          "devclaw",
+          "https://gitlab.example.com/group/project/-/merge_requests/999",
+        ),
+        /Cannot mark work_finish\(done\) without an open PR/,
+      );
+      assert.equal(provider.callsTo("getPrStatus").length, 1);
+    });
+
+    it("keeps normal issue-to-PR flows working", async () => {
+      const provider = new TestProvider();
+      provider.setPrStatus(42, {
+        state: PrState.OPEN,
+        url: "https://github.com/test/repo/pull/42",
+        sourceBranch: "feature/42-normal-flow",
+        mergeable: true,
+      });
+
+      const runCommand = async () => ({ stdout: "feature/42-normal-flow\n", stderr: "", exitCode: 0 });
+      await validatePrExistsForDeveloper(42, tempDir, provider as any, runCommand as any, tempDir, "devclaw");
+      assert.equal(provider.callsTo("getPrStatus").length, 1);
+    });
+
+    it("rejects follow-up completion when the reused PR is still conflicting", async () => {
+      await createMockAuditLog(tempDir, 108, true);
+
+      const provider = Object.create(GitHubProvider.prototype) as GitHubProvider & {
+        prHasReaction: () => Promise<boolean>;
+        reactToPr: (_issueId: number, _emoji: string) => Promise<void>;
+        getPrStatus: (_issueId: number) => Promise<any>;
       };
-      
-      assert.ok(successLog.event === "conflict_resolution_verified");
-      assert.ok(successLog.mergeable === true);
+      provider.prHasReaction = async () => true;
+      provider.reactToPr = async () => {};
+      provider.getPrStatus = async () => ({ state: PrState.CLOSED, url: null });
+
+      const runCommand = async (args: string[]) => {
+        if (args[0] === "git") return { stdout: "feature/existing-pr\n", stderr: "", exitCode: 0 };
+        if (args[0] === "gh" && args[1] === "pr" && args[2] === "view") {
+          return {
+            stdout: JSON.stringify({
+              url: "https://github.com/test/repo/pull/105",
+              title: "existing pr",
+              state: "OPEN",
+              headRefName: "feature/existing-pr",
+              reviewDecision: null,
+              mergeable: "CONFLICTING",
+            }),
+            stderr: "",
+            exitCode: 0,
+          };
+        }
+        throw new Error(`unexpected command: ${args.join(" ")}`);
+      };
+
+      await assert.rejects(
+        () => validatePrExistsForDeveloper(108, tempDir, provider, runCommand as any, tempDir, "devclaw", "https://github.com/test/repo/pull/105"),
+        /still shows merge conflicts/,
+      );
     });
   });
 });

--- a/lib/tools/worker/work-finish.ts
+++ b/lib/tools/worker/work-finish.ts
@@ -19,6 +19,8 @@ import { DATA_DIR } from "../../setup/migrate-layout.js";
 import { requireWorkspaceDir, resolveChannelId, resolveProject, resolveProvider } from "../helpers.js";
 import { getAllRoleIds, isValidResult, getCompletionResults } from "../../roles/index.js";
 import { loadWorkflow } from "../../workflow/index.js";
+import { GitHubProvider } from "../../providers/github.js";
+import { PrState, type PrStatus } from "../../providers/provider.js";
 
 /**
  * Get the current git branch name.
@@ -77,28 +79,157 @@ async function isConflictResolutionCycle(
  *   - We check `url === null` rather than the state field to be explicit:
  *     a null URL unambiguously means "nothing found", regardless of state label.
  */
-async function validatePrExistsForDeveloper(
+async function getGitHubPrStatusFromUrl(
+  prUrl: string,
+  repoPath: string,
+  runCommand: RunCommand,
+): Promise<PrStatus | null> {
+  try {
+    const result = await runCommand([
+      "gh", "pr", "view", prUrl,
+      "--json", "url,title,state,headRefName,reviewDecision,mergeable",
+    ], { timeoutMs: 10_000, cwd: repoPath });
+    const pr = JSON.parse(result.stdout) as {
+      url: string;
+      title: string;
+      state: string;
+      headRefName?: string;
+      reviewDecision?: string | null;
+      mergeable?: string | null;
+    };
+    return {
+      state: pr.state === "MERGED"
+        ? PrState.MERGED
+        : pr.reviewDecision === "APPROVED"
+          ? PrState.APPROVED
+          : pr.reviewDecision === "CHANGES_REQUESTED"
+            ? PrState.CHANGES_REQUESTED
+            : PrState.OPEN,
+      url: pr.url,
+      title: pr.title,
+      sourceBranch: pr.headRefName,
+      mergeable: pr.mergeable === "CONFLICTING" ? false : pr.mergeable === "MERGEABLE" ? true : undefined,
+    };
+  } catch {
+    return null;
+  }
+}
+
+async function getGitHubPrStatusFromBranch(
+  branchName: string,
+  repoPath: string,
+  runCommand: RunCommand,
+): Promise<PrStatus | null> {
+  try {
+    const result = await runCommand([
+      "gh", "pr", "list",
+      "--head", branchName,
+      "--state", "all",
+      "--limit", "1",
+      "--json", "url,title,state,headRefName,reviewDecision,mergeable",
+    ], { timeoutMs: 10_000, cwd: repoPath });
+    const prs = JSON.parse(result.stdout) as Array<{
+      url: string;
+      title: string;
+      state: string;
+      headRefName?: string;
+      reviewDecision?: string | null;
+      mergeable?: string | null;
+    }>;
+    const pr = prs[0];
+    if (!pr?.url) return null;
+    return {
+      state: pr.state === "MERGED"
+        ? PrState.MERGED
+        : pr.reviewDecision === "APPROVED"
+          ? PrState.APPROVED
+          : pr.reviewDecision === "CHANGES_REQUESTED"
+            ? PrState.CHANGES_REQUESTED
+            : PrState.OPEN,
+      url: pr.url,
+      title: pr.title,
+      sourceBranch: pr.headRefName,
+      mergeable: pr.mergeable === "CONFLICTING" ? false : pr.mergeable === "MERGEABLE" ? true : undefined,
+    };
+  } catch {
+    return null;
+  }
+}
+
+async function resolveDeveloperPrStatus(
+  issueId: number,
+  repoPath: string,
+  provider: Awaited<ReturnType<typeof resolveProvider>>["provider"],
+  runCommand: RunCommand,
+  explicitPrUrl?: string,
+): Promise<{ prStatus: PrStatus; branchName: string; source: "explicit" | "branch" | "issue" }> {
+  let branchName = "current-branch";
+  try {
+    branchName = await getCurrentBranch(repoPath, runCommand);
+  } catch {
+    // Fall back to generic placeholder
+  }
+
+  let issuePrStatus: PrStatus | null = null;
+  const getIssuePrStatus = async (): Promise<PrStatus> => {
+    if (issuePrStatus) return issuePrStatus;
+    issuePrStatus = await provider.getPrStatus(issueId);
+    return issuePrStatus;
+  };
+
+  if (explicitPrUrl) {
+    if (provider instanceof GitHubProvider) {
+      const byUrl = await getGitHubPrStatusFromUrl(explicitPrUrl, repoPath, runCommand);
+      if (byUrl?.url) return { prStatus: byUrl, branchName: byUrl.sourceBranch || branchName, source: "explicit" };
+    }
+
+    const byIssue = await getIssuePrStatus();
+    if (byIssue.url === explicitPrUrl) {
+      return { prStatus: byIssue, branchName: byIssue.sourceBranch || branchName, source: "explicit" };
+    }
+
+    return {
+      prStatus: { state: PrState.CLOSED, url: null },
+      branchName,
+      source: "explicit",
+    };
+  }
+
+  if (branchName && provider instanceof GitHubProvider) {
+    const byBranch = await getGitHubPrStatusFromBranch(branchName, repoPath, runCommand);
+    if (byBranch?.url) return { prStatus: byBranch, branchName, source: "branch" };
+  }
+
+  if (branchName) {
+    const byIssue = await getIssuePrStatus();
+    if (byIssue.url && byIssue.sourceBranch === branchName) {
+      return { prStatus: byIssue, branchName, source: "branch" };
+    }
+  }
+
+  const prStatus = await getIssuePrStatus();
+  return { prStatus, branchName: prStatus.sourceBranch || branchName, source: "issue" };
+}
+
+export async function validatePrExistsForDeveloper(
   issueId: number,
   repoPath: string,
   provider: Awaited<ReturnType<typeof resolveProvider>>["provider"],
   runCommand: RunCommand,
   workspaceDir: string,
   projectSlug: string,
+  explicitPrUrl?: string,
 ): Promise<void> {
   try {
-    const prStatus = await provider.getPrStatus(issueId);
+    const { prStatus, branchName, source } = await resolveDeveloperPrStatus(
+      issueId,
+      repoPath,
+      provider,
+      runCommand,
+      explicitPrUrl,
+    );
 
-    // url is null when getPrStatus found no open or merged PR for this issue.
-    // This covers both "no PR ever created" and "PR was closed without merging".
     if (!prStatus.url) {
-      // Get current branch for a helpful gh pr create example
-      let branchName = "current-branch";
-      try {
-        branchName = await getCurrentBranch(repoPath, runCommand);
-      } catch {
-        // Fall back to generic placeholder
-      }
-
       throw new Error(
         `Cannot mark work_finish(done) without an open PR.\n\n` +
         `✗ No PR found for branch: ${branchName}\n\n` +
@@ -108,13 +239,15 @@ async function validatePrExistsForDeveloper(
       );
     }
 
-    // url is set — an open or merged PR exists and is linked to this issue.
-    // getPrStatus locates PRs via the issue tracker's linked-PR API, so any
-    // non-null url already implies the PR references the issue.
+    if (source !== "issue") {
+      await auditLog(workspaceDir, "work_finish_pr_override", {
+        project: projectSlug,
+        issue: issueId,
+        prUrl: prStatus.url,
+        reason: source === "explicit" ? "explicit_pr_url_used" : "branch_pr_used",
+      });
+    }
 
-    // Mark PR as "seen" (with eyes emoji) if not already marked.
-    // This helps distinguish system-created PRs from human responses.
-    // Best-effort — don't block completion if this fails.
     try {
       const hasEyes = await provider.prHasReaction(issueId, "eyes");
       if (!hasEyes) {
@@ -124,10 +257,6 @@ async function validatePrExistsForDeveloper(
       // Ignore errors — marking is cosmetic
     }
 
-    // Conflict resolution validation: When an issue returns from "To Improve" due to
-    // merge conflicts, we must verify the PR is actually mergeable before accepting
-    // work_finish(done). Without this check, developers can claim success after local
-    // rebase but before pushing, causing infinite dispatch loops (#482).
     const isConflictCycle = await isConflictResolutionCycle(workspaceDir, issueId);
 
     if (isConflictCycle && prStatus.mergeable === false) {
@@ -138,20 +267,20 @@ async function validatePrExistsForDeveloper(
         prUrl: prStatus.url,
       });
 
-      const branchName = prStatus.sourceBranch || "your-branch";
+      const prBranchName = prStatus.sourceBranch || branchName || "your-branch";
       throw new Error(
         `Cannot complete work_finish(done) while PR still shows merge conflicts.\n\n` +
         `✗ PR status: CONFLICTING\n` +
         `✗ PR URL: ${prStatus.url}\n` +
-        `✗ Branch: ${branchName}\n\n` +
+        `✗ Branch: ${prBranchName}\n\n` +
         `Your local rebase may have succeeded, but changes must be pushed to the remote.\n\n` +
         `Verify your changes were pushed:\n` +
-        `  git log origin/${branchName}..HEAD\n` +
+        `  git log origin/${prBranchName}..HEAD\n` +
         `  # Should show no commits (meaning everything is pushed)\n\n` +
         `If unpushed commits exist, push them:\n` +
-        `  git push --force-with-lease origin ${branchName}\n\n` +
+        `  git push --force-with-lease origin ${prBranchName}\n\n` +
         `Wait a few seconds for GitHub to update, then verify the PR:\n` +
-        `  gh pr view ${issueId}\n` +
+        `  gh pr view ${prStatus.url}\n` +
         `  # Should show "Mergeable" status\n\n` +
         `Once the PR shows as mergeable on GitHub, call work_finish again.`,
       );
@@ -166,8 +295,6 @@ async function validatePrExistsForDeveloper(
       });
     }
   } catch (err) {
-    // Re-throw our own validation errors; swallow provider/network errors.
-    // Swallowing keeps work_finish unblocked when the API is unreachable.
     if (err instanceof Error && (err.message.startsWith("Cannot mark work_finish(done)") || err.message.startsWith("Cannot complete work_finish(done)"))) {
       throw err;
     }
@@ -258,7 +385,7 @@ export function createWorkFinishTool(ctx: PluginContext) {
 
       // For developers marking work as done, validate that a PR exists
       if (role === "developer" && result === "done") {
-        await validatePrExistsForDeveloper(issueId, repoPath, provider, ctx.runCommand, workspaceDir, project.slug);
+        await validatePrExistsForDeveloper(issueId, repoPath, provider, ctx.runCommand, workspaceDir, project.slug, prUrl);
       }
 
       const completion = await executeCompletion({


### PR DESCRIPTION
## Summary
- keep developer PR validation order as explicit prUrl, branch context, then issue lookup
- validate explicit URLs safely for non-GitHub providers instead of trusting arbitrary URLs
- add regression coverage for follow-up PR reuse, branch lookup, normal issue->PR flow, conflicting reused PRs, and invalid explicit URLs

## Testing
- npx tsx --test lib/tools/worker/work-finish.test.ts

Refs #1
Refs laurentenhoor/devclaw#518