### PR TITLE
feat: detect duplicate issues before creation

### DIFF
--- a/lib/services/issue-dedup.test.ts
+++ b/lib/services/issue-dedup.test.ts
@@ -1,0 +1,131 @@
+/**
+ * Tests for duplicate issue preflight detection.
+ *
+ * Run with: npx tsx --test lib/services/issue-dedup.test.ts
+ */
+import { describe, it } from "node:test";
+import assert from "node:assert";
+import { findDuplicateCandidates, buildDuplicateConfirmationMessage } from "./issue-dedup.js";
+import { DEFAULT_WORKFLOW } from "../workflow/index.js";
+import type { Issue } from "../providers/provider.js";
+
+function issue(overrides: Partial<Issue> & { iid: number; title: string }): Issue {
+  return {
+    iid: overrides.iid,
+    title: overrides.title,
+    description: overrides.description ?? "",
+    labels: overrides.labels ?? ["Planning"],
+    state: overrides.state ?? "opened",
+    web_url: overrides.web_url ?? `https://example.com/issues/${overrides.iid}`,
+  };
+}
+
+describe("findDuplicateCandidates", () => {
+  it("classifies obvious duplicate titles as high confidence", () => {
+    const result = findDuplicateCandidates(
+      {
+        title: "Update star catalog docs to cite al-Sufi's Book of Fixed Stars",
+        description: "Document the source in the star catalog docs.",
+      },
+      [
+        issue({
+          iid: 119,
+          title: "Update star catalog docs to note the source from al-Sufi's Book of Fixed Stars",
+          description: "Please cite the historical source in the star catalog docs.",
+          labels: ["Doing"],
+        }),
+      ],
+      DEFAULT_WORKFLOW,
+    );
+
+    assert.strictEqual(result.confidence, "high");
+    assert.strictEqual(result.shouldRequireConfirmation, true);
+    assert.strictEqual(result.shouldBlockWithoutConfirmation, true);
+    assert.strictEqual(result.candidates[0]?.issueId, 119);
+    assert.ok(result.candidates[0]?.reasons.some((reason) => reason.includes("shared title tokens")));
+  });
+
+  it("classifies partial overlap as medium confidence", () => {
+    const result = findDuplicateCandidates(
+      {
+        title: "Add duplicate issue detection before creating tasks",
+        description: "Compare new tasks against open work before creating them.",
+      },
+      [
+        issue({
+          iid: 32,
+          title: "Research duplicate issue detection before task creation",
+          description: "Analyze how to compare new issues with open work.",
+          labels: ["Planning"],
+        }),
+      ],
+      DEFAULT_WORKFLOW,
+    );
+
+    assert.strictEqual(result.confidence, "medium");
+    assert.strictEqual(result.shouldRequireConfirmation, true);
+    assert.strictEqual(result.candidates[0]?.issueId, 32);
+  });
+
+  it("ignores unrelated issues and terminal-state issues", () => {
+    const result = findDuplicateCandidates(
+      {
+        title: "Implement SSH key rotation reminders",
+        description: "Add reminder scheduling for stale SSH keys.",
+      },
+      [
+        issue({ iid: 7, title: "Improve release notes formatting", labels: ["Planning"] }),
+        issue({ iid: 8, title: "Implement SSH key rotation reminders", labels: ["Done"], state: "closed" }),
+      ],
+      DEFAULT_WORKFLOW,
+    );
+
+    assert.strictEqual(result.confidence, "low");
+    assert.strictEqual(result.shouldRequireConfirmation, false);
+    assert.deepStrictEqual(result.candidates, []);
+  });
+
+  it("orders candidates deterministically by confidence, score, then issue id", () => {
+    const result = findDuplicateCandidates(
+      {
+        title: "Normalize duplicate issue detection results",
+        description: "Keep duplicate warnings deterministic.",
+      },
+      [
+        issue({ iid: 20, title: "Normalize duplicate issue detection output", labels: ["Planning"] }),
+        issue({ iid: 11, title: "Normalize duplicate issue detection results", labels: ["To Do"] }),
+        issue({ iid: 15, title: "Duplicate issue warning normalization", labels: ["Doing"] }),
+      ],
+      DEFAULT_WORKFLOW,
+    );
+
+    assert.deepStrictEqual(result.candidates.map((candidate) => candidate.issueId), [11, 20]);
+  });
+});
+
+describe("buildDuplicateConfirmationMessage", () => {
+  it("includes issue ids, links, scores, and reasons", () => {
+    const check = findDuplicateCandidates(
+      {
+        title: "Update star catalog docs to cite al-Sufi's Book of Fixed Stars",
+        description: "Document the historical source in the docs.",
+      },
+      [
+        issue({
+          iid: 119,
+          title: "Update star catalog docs to note the source from al-Sufi's Book of Fixed Stars",
+          description: "Document the source in the star catalog docs.",
+          labels: ["Doing"],
+        }),
+      ],
+      DEFAULT_WORKFLOW,
+    );
+
+    const message = buildDuplicateConfirmationMessage(check);
+    assert.ok(message.includes("Possible duplicate detected") || message.includes("Confirm before creating"));
+    assert.ok(message.includes("#119"));
+    assert.ok(message.includes("https://example.com/issues/119"));
+    assert.ok(message.includes("score"));
+    assert.ok(message.includes("Reasons:"));
+  });
+});

--- a/lib/services/issue-dedup.ts
+++ b/lib/services/issue-dedup.ts
@@ -1,0 +1,191 @@
+/**
+ * issue-dedup.ts — deterministic duplicate issue preflight checks.
+ *
+ * Keeps provider logic transport-focused and lets task creation paths decide
+ * whether a new issue should proceed, warn, or pause for explicit confirmation.
+ */
+import type { Issue } from "../providers/provider.js";
+import { type WorkflowConfig, StateType } from "../workflow/index.js";
+
+const STOP_WORDS = new Set([
+  "a", "an", "and", "are", "as", "at", "be", "by", "for", "from", "in", "into", "is", "it", "of", "on", "or", "that", "the", "to", "with",
+  "add", "create", "implement", "issue", "task", "work", "update",
+]);
+
+export type DuplicateConfidence = "high" | "medium" | "low";
+
+export type DuplicateCandidate = {
+  issueId: number;
+  title: string;
+  url: string;
+  stateLabel: string | null;
+  confidence: DuplicateConfidence;
+  score: number;
+  reasons: string[];
+};
+
+export type DuplicateCheckResult = {
+  confidence: DuplicateConfidence;
+  shouldRequireConfirmation: boolean;
+  shouldBlockWithoutConfirmation: boolean;
+  candidates: DuplicateCandidate[];
+  summary: string;
+};
+
+function normalize(text: string): string {
+  return text
+    .toLowerCase()
+    .replace(/['’`]/g, "")
+    .replace(/[^a-z0-9]+/g, " ")
+    .trim();
+}
+
+function stem(token: string): string {
+  if (token.length <= 4) return token;
+  if (token.endsWith("ies") && token.length > 5) return `${token.slice(0, -3)}y`;
+  if (token.endsWith("ing") && token.length > 6) return token.slice(0, -3);
+  if (token.endsWith("ed") && token.length > 5) return token.slice(0, -2);
+  if (token.endsWith("es") && token.length > 4) return token.slice(0, -2);
+  if (token.endsWith("s") && token.length > 4) return token.slice(0, -1);
+  return token;
+}
+
+function tokenize(text: string): string[] {
+  return normalize(text)
+    .split(/\s+/)
+    .map(stem)
+    .filter((token) => token.length >= 3 && !STOP_WORDS.has(token));
+}
+
+function tokenSet(text: string): Set<string> {
+  return new Set(tokenize(text));
+}
+
+function overlapScore(a: Set<string>, b: Set<string>): number {
+  if (a.size === 0 || b.size === 0) return 0;
+  let intersection = 0;
+  for (const token of a) if (b.has(token)) intersection += 1;
+  return intersection / Math.max(a.size, b.size);
+}
+
+function sharedTokens(a: Set<string>, b: Set<string>): string[] {
+  const shared: string[] = [];
+  for (const token of a) if (b.has(token)) shared.push(token);
+  return shared.sort();
+}
+
+function getNonTerminalStateLabels(workflow: WorkflowConfig): Set<string> {
+  return new Set(
+    Object.values(workflow.states)
+      .filter((state) => state.type !== StateType.TERMINAL)
+      .map((state) => state.label),
+  );
+}
+
+function getCurrentStateLabel(issue: Issue, workflow: WorkflowConfig): string | null {
+  const allowed = getNonTerminalStateLabels(workflow);
+  return issue.labels.find((label) => allowed.has(label)) ?? null;
+}
+
+function classifyConfidence(score: number, exactTitle: boolean, titleContained: boolean, sharedTitleCount: number): DuplicateConfidence {
+  if (exactTitle || (titleContained && sharedTitleCount >= 3) || sharedTitleCount >= 5 || score >= 0.78) return "high";
+  if (score >= 0.52 || (titleContained && sharedTitleCount >= 2) || sharedTitleCount >= 3) return "medium";
+  return "low";
+}
+
+function buildSummary(candidates: DuplicateCandidate[], requestedTitle: string): string {
+  const lead = candidates[0];
+  if (!lead) return `No likely duplicate found for \"${requestedTitle}\".`;
+  const prefix = lead.confidence === "high" ? "Potential duplicate blocked" : "Potential duplicate needs confirmation";
+  const details = candidates
+    .map((candidate) => {
+      const state = candidate.stateLabel ? `, state: ${candidate.stateLabel}` : "";
+      const reason = candidate.reasons[0] ? ` (${candidate.reasons[0]})` : "";
+      return `#${candidate.issueId} \"${candidate.title}\"${state}${reason}`;
+    })
+    .join("; ");
+  return `${prefix}: ${details}`;
+}
+
+export function findDuplicateCandidates(
+  draft: { title: string; description?: string },
+  openIssues: Issue[],
+  workflow: WorkflowConfig,
+): DuplicateCheckResult {
+  const requestedTitle = draft.title ?? "";
+  const requestedDescription = draft.description ?? "";
+  const requestedTitleNorm = normalize(requestedTitle);
+  const requestedTitleTokens = tokenSet(requestedTitle);
+  const requestedBodyTokens = tokenSet(requestedDescription);
+  const candidates: DuplicateCandidate[] = [];
+  const nonTerminalLabels = getNonTerminalStateLabels(workflow);
+
+  for (const issue of openIssues) {
+    const stateLabel = getCurrentStateLabel(issue, workflow);
+    if (!stateLabel || !nonTerminalLabels.has(stateLabel)) continue;
+
+    const candidateTitleNorm = normalize(issue.title);
+    const candidateTitleTokens = tokenSet(issue.title);
+    const candidateBodyTokens = tokenSet(issue.description ?? "");
+    const titleScore = overlapScore(requestedTitleTokens, candidateTitleTokens);
+    const bodyScore = overlapScore(requestedBodyTokens, candidateBodyTokens);
+    const crossScore = Math.max(
+      overlapScore(requestedTitleTokens, candidateBodyTokens),
+      overlapScore(requestedBodyTokens, candidateTitleTokens),
+    );
+    const exactTitle = requestedTitleNorm.length > 0 && requestedTitleNorm === candidateTitleNorm;
+    const titleContained = requestedTitleNorm.length > 0 && candidateTitleNorm.length > 0 && (
+      requestedTitleNorm.includes(candidateTitleNorm) || candidateTitleNorm.includes(requestedTitleNorm)
+    );
+    const sharedTitle = sharedTokens(requestedTitleTokens, candidateTitleTokens);
+    const score = Number((titleScore * 0.65 + bodyScore * 0.2 + crossScore * 0.15).toFixed(3));
+    const confidence = classifyConfidence(score, exactTitle, titleContained, sharedTitle.length);
+    if (confidence === "low") continue;
+
+    const reasons: string[] = [];
+    if (exactTitle) reasons.push("same normalized title");
+    else if (titleContained) reasons.push("one normalized title contains the other");
+    if (sharedTitle.length > 0) reasons.push(`shared title tokens: ${sharedTitle.join(", ")}`);
+    if (bodyScore >= 0.45) reasons.push(`body similarity ${bodyScore.toFixed(2)}`);
+    if (crossScore >= 0.45) reasons.push(`title/body overlap ${crossScore.toFixed(2)}`);
+
+    candidates.push({
+      issueId: issue.iid,
+      title: issue.title,
+      url: issue.web_url,
+      stateLabel,
+      confidence,
+      score,
+      reasons,
+    });
+  }
+
+  candidates.sort((a, b) => {
+    const rank = { high: 2, medium: 1, low: 0 };
+    const confidenceDiff = rank[b.confidence] - rank[a.confidence];
+    if (confidenceDiff !== 0) return confidenceDiff;
+    if (b.score !== a.score) return b.score - a.score;
+    return a.issueId - b.issueId;
+  });
+
+  const top = candidates[0];
+  const confidence = top?.confidence ?? "low";
+  return {
+    confidence,
+    shouldRequireConfirmation: confidence !== "low",
+    shouldBlockWithoutConfirmation: confidence === "high" || confidence === "medium",
+    candidates: candidates.slice(0, 5),
+    summary: buildSummary(candidates.slice(0, 5), requestedTitle),
+  };
+}
+
+export function buildDuplicateConfirmationMessage(check: DuplicateCheckResult): string {
+  if (check.candidates.length === 0) return check.summary;
+  const heading = check.confidence === "high"
+    ? "Possible duplicate detected. Creation is paused until you confirm."
+    : "This may overlap with existing work. Confirm before creating it.";
+  const items = check.candidates
+    .map((candidate) => `- #${candidate.issueId} ${candidate.title} (${candidate.stateLabel ?? "unknown"}, score ${candidate.score.toFixed(2)})\n  ${candidate.url}\n  Reasons: ${candidate.reasons.join("; ") || "similar title/body"}`)
+    .join("\n");
+  return `${heading}\n${items}`;
+}

--- a/lib/tools/tasks/research-task.ts
+++ b/lib/tools/tasks/research-task.ts
@@ -21,9 +21,10 @@ import { dispatchTask } from "../../dispatch/index.js";
 import { log as auditLog } from "../../audit.js";
 import { requireWorkspaceDir, resolveChannelId, resolveProject, resolveProvider, autoAssignOwnerLabel, applyNotifyLabel } from "../helpers.js";
 import { loadConfig } from "../../config/index.js";
-import { getActiveLabel } from "../../workflow/index.js";
+import { getActiveLabel, loadWorkflow } from "../../workflow/index.js";
 import { selectLevel } from "../../roles/model-selector.js";
 import { resolveModel } from "../../roles/index.js";
+import { findDuplicateCandidates, buildDuplicateConfirmationMessage } from "../../services/issue-dedup.js";
 
 /** Queue label for research tasks. */
 const TO_RESEARCH_LABEL = "To Research";
@@ -82,6 +83,10 @@ Example:
           type: "boolean",
           description: "Preview without executing. Defaults to false.",
         },
+        confirmDuplicate: {
+          type: "boolean",
+          description: "Confirm creation even when DevClaw detects likely overlapping open work. Required for medium/high-confidence duplicate warnings.",
+        },
       },
     },
 
@@ -92,6 +97,7 @@ Example:
       const focusAreas = (params.focusAreas as string[]) ?? [];
       const complexity = (params.complexity as "simple" | "medium" | "complex") ?? "medium";
       const dryRun = (params.dryRun as boolean) ?? false;
+      const confirmDuplicate = (params.confirmDuplicate as boolean) ?? false;
       const workspaceDir = requireWorkspaceDir(toolCtx);
 
       if (!title) throw new Error("title is required");
@@ -99,6 +105,7 @@ Example:
 
       const { project } = await resolveProject(workspaceDir, channelId);
       const { provider } = await resolveProvider(project, ctx.runCommand);
+      const workflow = await loadWorkflow(workspaceDir, project.name);
       const pluginConfig = ctx.pluginConfig;
       const role = "architect";
 
@@ -109,8 +116,14 @@ Example:
       }
       const issueBody = bodyParts.join("\n");
 
+      const openIssues = await provider.listIssues({ state: "open" });
+      const duplicateCheck = findDuplicateCandidates({ title, description: issueBody }, openIssues, workflow);
+
       await auditLog(workspaceDir, "research_task", {
         project: project.name, title, complexity, focusAreas, dryRun,
+        duplicateConfidence: duplicateCheck.confidence,
+        duplicateConfirmed: confirmDuplicate,
+        duplicateCandidates: duplicateCheck.candidates.map((candidate) => candidate.issueId),
       });
 
       // Select level: use complexity hint to guide the heuristic
@@ -126,8 +139,29 @@ Example:
           success: true,
           dryRun: true,
           issue: { title, label: TO_RESEARCH_LABEL },
+          duplicateCheck: {
+            confidence: duplicateCheck.confidence,
+            requiresConfirmation: duplicateCheck.shouldRequireConfirmation,
+            blocked: duplicateCheck.shouldBlockWithoutConfirmation,
+            candidates: duplicateCheck.candidates,
+            summary: duplicateCheck.summary,
+          },
           research: { level, model, status: "dry_run" },
           announcement: `\u{1f4d0} [DRY RUN] Would create research ticket and dispatch ${role} (${level}) for: ${title}`,
+        });
+      }
+
+      if (duplicateCheck.shouldRequireConfirmation && !confirmDuplicate) {
+        return jsonResult({
+          success: false,
+          duplicateCheck: {
+            confidence: duplicateCheck.confidence,
+            requiresConfirmation: true,
+            blocked: duplicateCheck.shouldBlockWithoutConfirmation,
+            candidates: duplicateCheck.candidates,
+            summary: duplicateCheck.summary,
+          },
+          announcement: buildDuplicateConfirmationMessage(duplicateCheck),
         });
       }
 
@@ -196,7 +230,16 @@ Example:
           status: "in_progress",
         },
         project: project.name,
-        announcement: dr.announcement,
+        duplicateCheck: {
+          confidence: duplicateCheck.confidence,
+          requiresConfirmation: false,
+          blocked: false,
+          candidates: duplicateCheck.candidates,
+          summary: duplicateCheck.summary,
+        },
+        announcement: confirmDuplicate && duplicateCheck.candidates.length > 0
+          ? `${dr.announcement}\nConfirmed despite possible overlap with ${duplicateCheck.candidates.map((candidate) => `#${candidate.issueId}`).join(", ")}.`
+          : dr.announcement,
       });
     },
   });

--- a/lib/tools/tasks/task-create.ts
+++ b/lib/tools/tasks/task-create.ts
@@ -13,7 +13,8 @@ import { jsonResult } from "openclaw/plugin-sdk";
 import type { PluginContext } from "../../context.js";
 import type { ToolContext } from "../../types.js";
 import { log as auditLog } from "../../audit.js";
-import { DEFAULT_WORKFLOW } from "../../workflow/index.js";
+import { DEFAULT_WORKFLOW, loadWorkflow } from "../../workflow/index.js";
+import { findDuplicateCandidates, buildDuplicateConfirmationMessage } from "../../services/issue-dedup.js";
 import { requireWorkspaceDir, resolveChannelId, resolveProject, resolveProvider, autoAssignOwnerLabel, applyNotifyLabel } from "../helpers.js";
 
 /** Derive the initial state label from the workflow config. */
@@ -49,6 +50,10 @@ export function createTaskCreateTool(ctx: PluginContext) {
           type: "boolean",
           description: "If true, immediately pick up this issue for DEV after creation. Defaults to false.",
         },
+        confirmDuplicate: {
+          type: "boolean",
+          description: "Confirm creation even when DevClaw detects likely overlapping open work. Required for medium/high-confidence duplicate warnings.",
+        },
       },
     },
 
@@ -59,10 +64,27 @@ export function createTaskCreateTool(ctx: PluginContext) {
       const label = INITIAL_LABEL;
       const assignees = (params.assignees as string[] | undefined) ?? [];
       const pickup = (params.pickup as boolean) ?? false;
+      const confirmDuplicate = (params.confirmDuplicate as boolean) ?? false;
       const workspaceDir = requireWorkspaceDir(toolCtx);
 
       const { project } = await resolveProject(workspaceDir, channelId);
       const { provider, type: providerType } = await resolveProvider(project, ctx.runCommand);
+      const workflow = await loadWorkflow(workspaceDir, project.name);
+      const openIssues = await provider.listIssues({ state: "open" });
+      const duplicateCheck = findDuplicateCandidates({ title, description }, openIssues, workflow);
+      if (duplicateCheck.shouldRequireConfirmation && !confirmDuplicate) {
+        return jsonResult({
+          success: false,
+          duplicateCheck: {
+            confidence: duplicateCheck.confidence,
+            requiresConfirmation: true,
+            blocked: duplicateCheck.shouldBlockWithoutConfirmation,
+            candidates: duplicateCheck.candidates,
+            summary: duplicateCheck.summary,
+          },
+          announcement: buildDuplicateConfirmationMessage(duplicateCheck),
+        });
+      }
 
       const issue = await provider.createIssue(title, description, label, assignees);
 
@@ -78,6 +100,9 @@ export function createTaskCreateTool(ctx: PluginContext) {
       await auditLog(workspaceDir, "task_create", {
         project: project.name, issueId: issue.iid,
         title, label, provider: providerType, pickup,
+        duplicateConfidence: duplicateCheck.confidence,
+        duplicateConfirmed: confirmDuplicate,
+        duplicateCandidates: duplicateCheck.candidates.map((candidate) => candidate.issueId),
       });
 
       const hasBody = description && description.trim().length > 0;
@@ -85,10 +110,20 @@ export function createTaskCreateTool(ctx: PluginContext) {
       if (hasBody) announcement += "\nWith detailed description.";
       announcement += `\n🔗 [Issue #${issue.iid}](${issue.web_url})`;
       announcement += pickup ? "\nPicking up for DEV..." : "\nReady for pickup when needed.";
+      if (confirmDuplicate && duplicateCheck.candidates.length > 0) {
+        announcement += `\nConfirmed despite possible overlap with ${duplicateCheck.candidates.map((candidate) => `#${candidate.issueId}`).join(", ")}.`;
+      }
 
       return jsonResult({
         success: true,
         issue: { id: issue.iid, title: issue.title, body: hasBody ? description : null, url: issue.web_url, label },
+        duplicateCheck: {
+          confidence: duplicateCheck.confidence,
+          requiresConfirmation: false,
+          blocked: false,
+          candidates: duplicateCheck.candidates,
+          summary: duplicateCheck.summary,
+        },
         project: project.name, provider: providerType, pickup, announcement,
       });
     },


### PR DESCRIPTION
Addresses issue #33

## Summary
- add a shared duplicate-issue preflight service for deterministic semantic overlap checks
- gate task_create and research_task behind medium/high confidence confirmation with clear suspected-duplicate explanations
- add focused tests covering confidence thresholds, non-terminal filtering, and deterministic candidate ordering

## Validation
- npx tsx --test lib/services/issue-dedup.test.ts

## Notes
- repo-wide type checking is currently blocked by unrelated existing issues in this branch base, including missing test-only dependencies (vitest/openclaw plugin-sdk test path) and unresolved reconcileCanonicalPr references in lib/providers/gitlab.ts