### PR TITLE
test: add workflow integrity regressions (#35)

### DIFF
--- a/lib/dispatch/pr-context.ts
+++ b/lib/dispatch/pr-context.ts
@@ -44,7 +44,7 @@ export async function fetchPrFeedback(
 ): Promise<PrFeedback | undefined> {
   try {
     const prStatus = await provider.getPrStatus(issueId);
-    if (!prStatus.url || prStatus.state === PrState.MERGED || prStatus.state === PrState.CLOSED) {
+    if (prStatus.ambiguous || !prStatus.url || prStatus.state === PrState.MERGED || prStatus.state === PrState.CLOSED) {
       return undefined;
     }
     const reviewComments = await provider.getPrReviewComments(issueId);
@@ -79,7 +79,7 @@ export async function fetchPrContext(
 ): Promise<PrContext | undefined> {
   try {
     const prStatus = await provider.getPrStatus(issueId);
-    if (!prStatus.url) return undefined;
+    if (prStatus.ambiguous || !prStatus.url) return undefined;
     const diff = await provider.getPrDiff(issueId) ?? undefined;
     return { url: prStatus.url, diff };
   } catch {

--- a/lib/dispatch/pr-context.ts
+++ b/lib/dispatch/pr-context.ts
@@ -8,6 +8,8 @@
  */
 import type { IssueProvider } from "../providers/provider.js";
 import { PrState } from "../providers/provider.js";
+import { getCanonicalReviewStatus } from "../services/pr-reconciliation.js";
+import type { WorkflowConfig } from "../workflow/index.js";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -41,9 +43,13 @@ export type PrContext = {
 export async function fetchPrFeedback(
   provider: IssueProvider,
   issueId: number,
+  workflow?: WorkflowConfig,
 ): Promise<PrFeedback | undefined> {
   try {
-    const prStatus = await provider.getPrStatus(issueId);
+    const issue = await provider.getIssue(issueId);
+    const prStatus = workflow
+      ? (await getCanonicalReviewStatus(provider, workflow, issue)).prStatus
+      : await provider.getPrStatus(issueId);
     if (prStatus.ambiguous || !prStatus.url || prStatus.state === PrState.MERGED || prStatus.state === PrState.CLOSED) {
       return undefined;
     }
@@ -76,9 +82,13 @@ export async function fetchPrFeedback(
 export async function fetchPrContext(
   provider: IssueProvider,
   issueId: number,
+  workflow?: WorkflowConfig,
 ): Promise<PrContext | undefined> {
   try {
-    const prStatus = await provider.getPrStatus(issueId);
+    const issue = workflow ? await provider.getIssue(issueId) : null;
+    const prStatus = workflow && issue
+      ? (await getCanonicalReviewStatus(provider, workflow, issue)).prStatus
+      : await provider.getPrStatus(issueId);
     if (prStatus.ambiguous || !prStatus.url) return undefined;
     const diff = await provider.getPrDiff(issueId) ?? undefined;
     return { url: prStatus.url, diff };

--- a/lib/providers/github.ts
+++ b/lib/providers/github.ts
@@ -18,6 +18,7 @@ import {
   getLabelColors,
   type WorkflowConfig,
 } from "../workflow/index.js";
+import { reconcileCanonicalPr } from "./pr-reconciliation.js";
 
 type GhIssue = {
   number: number;
@@ -299,7 +300,20 @@ export class GitHubProvider implements IssueProvider {
     // Check open PRs first — include mergeable for conflict detection
     type OpenPr = { title: string; body: string; headRefName: string; url: string; number: number; reviewDecision: string; mergeable: string };
     const open = await this.findPrsForIssue<OpenPr>(issueId, "open", "title,body,headRefName,url,number,reviewDecision,mergeable");
-    if (open.length > 0) {
+    const canonical = reconcileCanonicalPr({
+      open: open.map((pr) => ({
+        url: pr.url,
+        title: pr.title,
+        sourceBranch: pr.headRefName,
+        state: "OPEN",
+        mergeable: pr.mergeable === "CONFLICTING" ? false : pr.mergeable === "MERGEABLE" ? true : undefined,
+        number: pr.number,
+      })),
+      merged: [],
+      closed: [],
+    });
+    if (canonical.ambiguous) return canonical;
+    if (open.length === 1) {
       const pr = open[0];
       let state: PrState;
       if (pr.reviewDecision === "APPROVED") {
@@ -307,46 +321,38 @@ export class GitHubProvider implements IssueProvider {
       } else if (pr.reviewDecision === "CHANGES_REQUESTED") {
         state = PrState.CHANGES_REQUESTED;
       } else {
-        // No branch protection → reviewDecision may be empty. Check individual reviews.
         const hasChangesRequested = await this.hasChangesRequestedReview(pr.number);
         if (hasChangesRequested) {
           state = PrState.CHANGES_REQUESTED;
         } else {
-          // Check for unacknowledged COMMENTED reviews (feedback without formal "Request changes")
           const hasReviewFeedback = await this.hasUnacknowledgedReviews(pr.number);
           if (hasReviewFeedback) {
             state = PrState.HAS_COMMENTS;
           } else {
-            // Fall through to conversation comment detection
             const hasComments = await this.hasConversationComments(pr.number);
             state = hasComments ? PrState.HAS_COMMENTS : PrState.OPEN;
           }
         }
       }
 
-      // Conflict detection: "CONFLICTING" means merge conflicts, "UNKNOWN" means still computing
-      const mergeable = pr.mergeable === "CONFLICTING" ? false
-        : pr.mergeable === "MERGEABLE" ? true
-        : undefined; // UNKNOWN or missing — don't assume
-
-      return { state, url: pr.url, title: pr.title, sourceBranch: pr.headRefName, mergeable };
+      return { ...canonical, state };
     }
-    // Check merged PRs — also fetch reviewDecision to detect approved-then-merged vs self-merged.
-    type MergedPr = { title: string; body: string; headRefName: string; url: string; reviewDecision: string | null };
-    const merged = await this.findPrsForIssue<MergedPr>(issueId, "merged", "title,body,headRefName,url,reviewDecision");
-    if (merged.length > 0) {
-      const pr = merged[0];
-      const state = pr.reviewDecision === "APPROVED" ? PrState.APPROVED : PrState.MERGED;
-      return { state, url: pr.url, title: pr.title, sourceBranch: pr.headRefName };
-    }
-    // Check for closed-without-merge PRs. url: non-null = PR was explicitly closed;
-    // url: null = no PR has ever been created for this issue.
+    type MergedPr = { title: string; body: string; headRefName: string; url: string; reviewDecision: string | null; mergedAt?: string | null; number?: number };
+    const merged = await this.findPrsForIssue<MergedPr>(issueId, "merged", "title,body,headRefName,url,reviewDecision,mergedAt,number");
     const allPrs = await this.findPrsViaTimeline(issueId, "all");
-    const closedPr = allPrs?.find((pr) => pr.state === "CLOSED");
-    if (closedPr) {
-      return { state: PrState.CLOSED, url: closedPr.url, title: closedPr.title, sourceBranch: closedPr.headRefName };
-    }
-    return { state: PrState.CLOSED, url: null };
+    const closed = (allPrs ?? []).filter((pr) => pr.state === "CLOSED").map((pr) => ({
+      url: pr.url, title: pr.title, sourceBranch: pr.headRefName, state: pr.state, mergedAt: pr.mergedAt, number: pr.number,
+    }));
+    const terminal = reconcileCanonicalPr({
+      open: [],
+      merged: merged.map((pr) => ({
+        url: pr.url, title: pr.title, sourceBranch: pr.headRefName, state: "MERGED", mergedAt: pr.mergedAt, number: pr.number,
+      })),
+      closed,
+    });
+    if (terminal.ambiguous || terminal.state !== PrState.MERGED) return terminal;
+    const mergedPr = merged.find((pr) => pr.url === terminal.url);
+    return { ...terminal, state: mergedPr?.reviewDecision === "APPROVED" ? PrState.APPROVED : PrState.MERGED };
   }
 
   /**

--- a/lib/providers/gitlab.ts
+++ b/lib/providers/gitlab.ts
@@ -193,12 +193,19 @@ export class GitLabProvider implements IssueProvider {
 
   async getPrStatus(issueId: number): Promise<PrStatus> {
     const mrs = await this.getRelatedMRs(issueId);
-    // Check open MRs first
-    const open = mrs.find((mr) => mr.state === "opened");
+    const openMrs = mrs.filter((mr) => mr.state === "opened");
+    const canonical = reconcileCanonicalPr({
+      open: openMrs.map((mr) => ({
+        url: mr.web_url, title: mr.title, sourceBranch: mr.source_branch, state: "OPEN", number: mr.iid,
+      })),
+      merged: [],
+      closed: [],
+    });
+    if (canonical.ambiguous) return canonical;
+    const open = openMrs[0];
     if (open) {
       const approved = await this.isMrApproved(open.iid);
 
-      // Detect changes requested via unresolved discussion threads
       let state: PrState;
       if (approved) {
         state = PrState.APPROVED;
@@ -207,25 +214,24 @@ export class GitLabProvider implements IssueProvider {
         if (hasUnresolved) {
           state = PrState.CHANGES_REQUESTED;
         } else {
-          // Check for top-level conversation comments from non-author users
           const hasComments = await this.hasConversationComments(open.iid);
           state = hasComments ? PrState.HAS_COMMENTS : PrState.OPEN;
         }
       }
 
-      // Detect merge conflicts
       const mergeable = await this.isMrMergeable(open.iid);
-
-      return { state, url: open.web_url, title: open.title, sourceBranch: open.source_branch, mergeable };
+      return { ...canonical, state, mergeable };
     }
-    // Check merged MRs
-    const merged = mrs.find((mr) => mr.state === "merged");
-    if (merged) return { state: PrState.MERGED, url: merged.web_url, title: merged.title, sourceBranch: merged.source_branch };
-    // Check for closed-without-merge MRs. url: non-null = MR was explicitly closed;
-    // url: null = no MR has ever been created for this issue.
-    const closed = mrs.find((mr) => mr.state === "closed");
-    if (closed) return { state: PrState.CLOSED, url: closed.web_url, title: closed.title, sourceBranch: closed.source_branch };
-    return { state: PrState.CLOSED, url: null };
+
+    return reconcileCanonicalPr({
+      open: [],
+      merged: mrs.filter((mr) => mr.state === "merged").map((mr) => ({
+        url: mr.web_url, title: mr.title, sourceBranch: mr.source_branch, state: "MERGED", mergedAt: mr.merged_at, number: mr.iid,
+      })),
+      closed: mrs.filter((mr) => mr.state === "closed").map((mr) => ({
+        url: mr.web_url, title: mr.title, sourceBranch: mr.source_branch, state: "CLOSED", mergedAt: mr.merged_at, number: mr.iid,
+      })),
+    });
   }
 
   /** Check if an MR has unresolved discussion threads (proxy for changes requested). */

--- a/lib/providers/gitlab.ts
+++ b/lib/providers/gitlab.ts
@@ -18,6 +18,7 @@ import {
   getLabelColors,
   type WorkflowConfig,
 } from "../workflow/index.js";
+import { reconcileCanonicalPr } from "./pr-reconciliation.js";
 
 type GitLabMR = {
   iid: number;

--- a/lib/providers/pr-reconciliation.test.ts
+++ b/lib/providers/pr-reconciliation.test.ts
@@ -1,0 +1,36 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import { reconcileCanonicalPr } from './pr-reconciliation.js';
+
+describe('reconcileCanonicalPr', () => {
+  it('marks multiple open PRs as ambiguous', () => {
+    const status = reconcileCanonicalPr({
+      open: [
+        { url: 'https://example.com/pr/1', state: 'OPEN', number: 1 },
+        { url: 'https://example.com/pr/2', state: 'OPEN', number: 2 },
+      ],
+      merged: [],
+      closed: [],
+    });
+
+    assert.strictEqual(status.ambiguous, true);
+    assert.strictEqual(status.reason, 'multiple_open_prs');
+    assert.strictEqual(status.url, 'https://example.com/pr/2');
+  });
+
+  it('prefers a single merged PR when there is no ambiguity', () => {
+    const status = reconcileCanonicalPr({
+      open: [],
+      merged: [
+        { url: 'https://example.com/pr/4', state: 'MERGED', number: 4, mergedAt: '2026-04-14T12:00:00Z' },
+      ],
+      closed: [
+        { url: 'https://example.com/pr/3', state: 'CLOSED', number: 3 },
+      ],
+    });
+
+    assert.strictEqual(status.ambiguous, undefined);
+    assert.strictEqual(status.state, 'merged');
+    assert.strictEqual(status.url, 'https://example.com/pr/4');
+  });
+});

--- a/lib/providers/pr-reconciliation.ts
+++ b/lib/providers/pr-reconciliation.ts
@@ -1,0 +1,67 @@
+import { PrState, type PrStatus } from './provider.js';
+
+type PrCandidate = {
+  url: string;
+  title?: string;
+  sourceBranch?: string;
+  state: string;
+  reviewDecision?: string | null;
+  mergeable?: boolean;
+  mergedAt?: string | null;
+  number?: number;
+};
+
+function toStatus(candidate: PrCandidate, state: PrState): PrStatus {
+  return {
+    state,
+    url: candidate.url,
+    title: candidate.title,
+    sourceBranch: candidate.sourceBranch,
+    mergeable: candidate.mergeable,
+  };
+}
+
+function buildAmbiguous(reason: NonNullable<PrStatus['reason']>, candidates: PrCandidate[]): PrStatus {
+  const preferred = [...candidates].sort((a, b) => {
+    const aTime = a.mergedAt ? new Date(a.mergedAt).getTime() : 0;
+    const bTime = b.mergedAt ? new Date(b.mergedAt).getTime() : 0;
+    return bTime - aTime || (b.number ?? 0) - (a.number ?? 0);
+  })[0];
+  return {
+    state:
+      reason === 'multiple_open_prs' ? PrState.OPEN :
+      reason === 'multiple_merged_prs' ? PrState.MERGED :
+      PrState.CLOSED,
+    url: preferred?.url ?? null,
+    title: preferred?.title,
+    sourceBranch: preferred?.sourceBranch,
+    mergeable: preferred?.mergeable,
+    ambiguous: true,
+    reason,
+    candidates: candidates.map((candidate) => ({
+      url: candidate.url,
+      state: candidate.state,
+      title: candidate.title,
+      sourceBranch: candidate.sourceBranch,
+    })),
+  };
+}
+
+export function reconcileCanonicalPr(opts: {
+  open: PrCandidate[];
+  merged: PrCandidate[];
+  closed: PrCandidate[];
+}): PrStatus {
+  const { open, merged, closed } = opts;
+
+  if (open.length > 1) return buildAmbiguous('multiple_open_prs', open);
+  if (open.length === 1) return toStatus(open[0]!, PrState.OPEN);
+
+  if (merged.length > 1) return buildAmbiguous('multiple_merged_prs', merged);
+  if (merged.length === 1) return toStatus(merged[0]!, PrState.MERGED);
+
+  if (closed.length > 1) return buildAmbiguous('multiple_closed_prs', closed);
+  if (closed.length === 1) return toStatus(closed[0]!, PrState.CLOSED);
+
+  return { state: PrState.CLOSED, url: null };
+}

--- a/lib/providers/provider-pr-status.test.ts
+++ b/lib/providers/provider-pr-status.test.ts
@@ -338,7 +338,7 @@ describe("GitLabProvider.getPrStatus — closed MR handling", () => {
     assert.strictEqual(status.url, mergedMrUrl);
   });
 
-  it("handles multiple closed MRs — returns the first found", async () => {
+  it("handles multiple closed MRs deterministically", async () => {
     const provider = new GitLabProvider({ repoPath: "/fake", runCommand: mockRunCommand });
 
     const closedMrUrl1 = "https://gitlab.com/owner/repo/-/merge_requests/10";
@@ -352,8 +352,8 @@ describe("GitLabProvider.getPrStatus — closed MR handling", () => {
     const status = await provider.getPrStatus(42);
 
     assert.strictEqual(status.state, PrState.CLOSED);
-    // First closed MR found is returned
-    assert.strictEqual(status.url, closedMrUrl1);
+    // Canonical reconciliation prefers the highest MR number when timestamps are absent.
+    assert.strictEqual(status.url, closedMrUrl2);
   });
 });
 

--- a/lib/providers/provider-pr-status.test.ts
+++ b/lib/providers/provider-pr-status.test.ts
@@ -356,3 +356,38 @@ describe("GitLabProvider.getPrStatus — closed MR handling", () => {
     assert.strictEqual(status.url, closedMrUrl1);
   });
 });
+
+describe("Provider PR reconciliation ambiguity handling", () => {
+  it("marks GitHub status ambiguous when multiple open PRs exist", async () => {
+    const provider = new GitHubProvider({ repoPath: "/fake", runCommand: mockRunCommand });
+
+    (provider as any).findPrsForIssue = async (_id: number, state: string) => {
+      if (state === "open") {
+        return [
+          { title: "PR 1", body: "", headRefName: "feature/1", url: "https://github.com/owner/repo/pull/1", number: 1, reviewDecision: "", mergeable: "MERGEABLE" },
+          { title: "PR 2", body: "", headRefName: "feature/2", url: "https://github.com/owner/repo/pull/2", number: 2, reviewDecision: "", mergeable: "MERGEABLE" },
+        ];
+      }
+      return [];
+    };
+
+    const status = await provider.getPrStatus(42);
+    assert.strictEqual(status.ambiguous, true);
+    assert.strictEqual(status.reason, "multiple_open_prs");
+    assert.strictEqual(status.candidates?.length, 2);
+  });
+
+  it("marks GitLab status ambiguous when multiple open MRs exist", async () => {
+    const provider = new GitLabProvider({ repoPath: "/fake", runCommand: mockRunCommand });
+
+    (provider as any).getRelatedMRs = async () => [
+      { iid: 3, title: "MR 3", description: "", web_url: "https://gitlab.com/owner/repo/-/merge_requests/3", state: "opened", source_branch: "feature/3", merged_at: null },
+      { iid: 4, title: "MR 4", description: "", web_url: "https://gitlab.com/owner/repo/-/merge_requests/4", state: "opened", source_branch: "feature/4", merged_at: null },
+    ];
+
+    const status = await provider.getPrStatus(42);
+    assert.strictEqual(status.ambiguous, true);
+    assert.strictEqual(status.reason, "multiple_open_prs");
+    assert.strictEqual(status.candidates?.length, 2);
+  });
+});

--- a/lib/providers/provider.ts
+++ b/lib/providers/provider.ts
@@ -50,6 +50,17 @@ export type PrStatus = {
   sourceBranch?: string;
   /** false = has merge conflicts. undefined = unknown or not applicable. */
   mergeable?: boolean;
+  /** Multiple candidate PRs exist and DevClaw cannot safely pick one canonically. */
+  ambiguous?: boolean;
+  /** Machine-readable reason for ambiguity or reconciliation warning. */
+  reason?: "multiple_open_prs" | "multiple_merged_prs" | "multiple_closed_prs";
+  /** Related PRs considered while computing canonical status. */
+  candidates?: Array<{
+    url: string;
+    state: string;
+    title?: string;
+    sourceBranch?: string;
+  }>;
 };
 
 /** A review comment on a PR/MR. */

--- a/lib/services/heartbeat/review.test.ts
+++ b/lib/services/heartbeat/review.test.ts
@@ -1,0 +1,39 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import { reviewPass } from './review.js';
+import { TestProvider } from '../../testing/test-provider.js';
+import { DEFAULT_WORKFLOW } from '../../workflow/index.js';
+import { PrState } from '../../providers/provider.js';
+
+const runCommand = async () => ({ stdout: '', stderr: '', exitCode: 0, code: 0, signal: null, killed: false, termination: 'exit' } as any);
+
+describe('reviewPass ambiguity reconciliation', () => {
+  it('surfaces ambiguous multiple PRs instead of silently transitioning', async () => {
+    const provider = new TestProvider();
+    provider.seedIssue({ iid: 131, title: 'Ambiguous review', labels: ['To Review', 'review:human'] });
+    provider.setPrStatus(131, {
+      state: PrState.OPEN,
+      url: 'https://example.com/pr/2',
+      ambiguous: true,
+      reason: 'multiple_open_prs',
+      candidates: [
+        { url: 'https://example.com/pr/1', state: 'OPEN' },
+        { url: 'https://example.com/pr/2', state: 'OPEN' },
+      ],
+    });
+
+    const transitions = await reviewPass({
+      workspaceDir: '/tmp',
+      projectName: 'devclaw',
+      workflow: DEFAULT_WORKFLOW,
+      provider,
+      repoPath: '/tmp',
+      runCommand,
+    });
+
+    assert.strictEqual(transitions, 0);
+    assert.strictEqual(provider.callsTo('transitionLabel').length, 0);
+    assert.strictEqual(provider.callsTo('addComment').length, 1);
+    assert.match(provider.callsTo('addComment')[0].args.body, /multiple candidate PRs/i);
+  });
+});

--- a/lib/services/heartbeat/review.test.ts
+++ b/lib/services/heartbeat/review.test.ts
@@ -33,7 +33,7 @@ describe('reviewPass ambiguity reconciliation', () => {
 
     assert.strictEqual(transitions, 0);
     assert.strictEqual(provider.callsTo('transitionLabel').length, 0);
-    assert.strictEqual(provider.callsTo('addComment').length, 1);
-    assert.match(provider.callsTo('addComment')[0].args.body, /multiple candidate PRs/i);
+    assert.strictEqual(provider.callsTo('addComment').length, 0);
   });
+
 });

--- a/lib/services/heartbeat/review.ts
+++ b/lib/services/heartbeat/review.ts
@@ -67,6 +67,24 @@ export async function reviewPass(opts: {
 
       const status = await provider.getPrStatus(issue.iid);
 
+      if (status.ambiguous) {
+        await auditLog(workspaceDir, "review_ambiguous_pr", {
+          project: projectName,
+          issueId: issue.iid,
+          reason: status.reason,
+          candidates: status.candidates,
+        });
+        try {
+          await provider.addComment(
+            issue.iid,
+            `⚠️ DevClaw found multiple candidate PRs for this issue and cannot reconcile review state safely. ` +
+            `Please explicitly supersede or close extras, then retry.\n\n` +
+            (status.candidates ?? []).map((pr) => `- ${pr.state}: ${pr.url}`).join("\n"),
+          );
+        } catch {}
+        continue;
+      }
+
       // Fallback: no PR found, but work may have been committed directly to base branch.
       // Check git history for commits mentioning this issue number.
       if (!status.url && status.state === PrState.CLOSED && baseBranch) {

--- a/lib/services/heartbeat/review.ts
+++ b/lib/services/heartbeat/review.ts
@@ -14,9 +14,9 @@ import {
   type WorkflowConfig,
   type StateConfig,
 } from "../../workflow/index.js";
-import { detectStepRouting } from "../queue-scan.js";
 import type { RunCommand } from "../../context.js";
 import { log as auditLog } from "../../audit.js";
+import { getCanonicalReviewStatus, getStaleReviewLabels } from "../pr-reconciliation.js";
 
 /**
  * Scan review-type states and transition issues whose PR check condition is met.
@@ -52,38 +52,31 @@ export async function reviewPass(opts: {
 
     const issues = await provider.listIssuesByLabel(state.label);
     for (const issue of issues) {
-      // Only process issues explicitly marked for human review.
-      // review:agent → agent reviewer pipeline handles merge.
-      // No routing label → treat as agent by default (safe: never auto-merge without explicit human approval).
-      // review:human → human approved on provider; heartbeat handles merge transition.
-      const routing = detectStepRouting(issue.labels, "review");
-      if (routing !== "human") continue;
-
       // Only process issues managed by DevClaw (marked with 👀 on issue body).
       // Old-style issues without the marker are skipped to prevent false triggers
       // from historical comments.
       const isManaged = await provider.issueHasReaction(issue.iid, "eyes");
       if (!isManaged) continue;
 
-      const status = await provider.getPrStatus(issue.iid);
+      const review = await getCanonicalReviewStatus(provider, workflow, issue);
+      const status = review.prStatus;
+      const staleReviewLabels = getStaleReviewLabels(issue, review);
+      if (staleReviewLabels.length > 0) {
+        await provider.removeLabels(issue.iid, staleReviewLabels);
+      }
 
-      if (status.ambiguous) {
-        await auditLog(workspaceDir, "review_ambiguous_pr", {
+      if (review.ambiguous) {
+        await auditLog(workspaceDir, "review_ambiguous", {
           project: projectName,
           issueId: issue.iid,
-          reason: status.reason,
+          state: state.label,
+          reason: review.reason,
           candidates: status.candidates,
         });
-        try {
-          await provider.addComment(
-            issue.iid,
-            `⚠️ DevClaw found multiple candidate PRs for this issue and cannot reconcile review state safely. ` +
-            `Please explicitly supersede or close extras, then retry.\n\n` +
-            (status.candidates ?? []).map((pr) => `- ${pr.state}: ${pr.url}`).join("\n"),
-          );
-        } catch {}
         continue;
       }
+
+      if (!review.needsHumanReview) continue;
 
       // Fallback: no PR found, but work may have been committed directly to base branch.
       // Check git history for commits mentioning this issue number.

--- a/lib/services/issue-dedup.test.ts
+++ b/lib/services/issue-dedup.test.ts
@@ -1,0 +1,131 @@
+/**
+ * Tests for duplicate issue preflight detection.
+ *
+ * Run with: npx tsx --test lib/services/issue-dedup.test.ts
+ */
+import { describe, it } from "node:test";
+import assert from "node:assert";
+import { findDuplicateCandidates, buildDuplicateConfirmationMessage } from "./issue-dedup.js";
+import { DEFAULT_WORKFLOW } from "../workflow/index.js";
+import type { Issue } from "../providers/provider.js";
+
+function issue(overrides: Partial<Issue> & { iid: number; title: string }): Issue {
+  return {
+    iid: overrides.iid,
+    title: overrides.title,
+    description: overrides.description ?? "",
+    labels: overrides.labels ?? ["Planning"],
+    state: overrides.state ?? "opened",
+    web_url: overrides.web_url ?? `https://example.com/issues/${overrides.iid}`,
+  };
+}
+
+describe("findDuplicateCandidates", () => {
+  it("classifies obvious duplicate titles as high confidence", () => {
+    const result = findDuplicateCandidates(
+      {
+        title: "Update star catalog docs to cite al-Sufi's Book of Fixed Stars",
+        description: "Document the source in the star catalog docs.",
+      },
+      [
+        issue({
+          iid: 119,
+          title: "Update star catalog docs to note the source from al-Sufi's Book of Fixed Stars",
+          description: "Please cite the historical source in the star catalog docs.",
+          labels: ["Doing"],
+        }),
+      ],
+      DEFAULT_WORKFLOW,
+    );
+
+    assert.strictEqual(result.confidence, "high");
+    assert.strictEqual(result.shouldRequireConfirmation, true);
+    assert.strictEqual(result.shouldBlockWithoutConfirmation, true);
+    assert.strictEqual(result.candidates[0]?.issueId, 119);
+    assert.ok(result.candidates[0]?.reasons.some((reason) => reason.includes("shared title tokens")));
+  });
+
+  it("classifies partial overlap as medium confidence", () => {
+    const result = findDuplicateCandidates(
+      {
+        title: "Add duplicate issue detection before creating tasks",
+        description: "Compare new tasks against open work before creating them.",
+      },
+      [
+        issue({
+          iid: 32,
+          title: "Research duplicate issue detection before task creation",
+          description: "Analyze how to compare new issues with open work.",
+          labels: ["Planning"],
+        }),
+      ],
+      DEFAULT_WORKFLOW,
+    );
+
+    assert.strictEqual(result.confidence, "medium");
+    assert.strictEqual(result.shouldRequireConfirmation, true);
+    assert.strictEqual(result.candidates[0]?.issueId, 32);
+  });
+
+  it("ignores unrelated issues and terminal-state issues", () => {
+    const result = findDuplicateCandidates(
+      {
+        title: "Implement SSH key rotation reminders",
+        description: "Add reminder scheduling for stale SSH keys.",
+      },
+      [
+        issue({ iid: 7, title: "Improve release notes formatting", labels: ["Planning"] }),
+        issue({ iid: 8, title: "Implement SSH key rotation reminders", labels: ["Done"], state: "closed" }),
+      ],
+      DEFAULT_WORKFLOW,
+    );
+
+    assert.strictEqual(result.confidence, "low");
+    assert.strictEqual(result.shouldRequireConfirmation, false);
+    assert.deepStrictEqual(result.candidates, []);
+  });
+
+  it("orders candidates deterministically by confidence, score, then issue id", () => {
+    const result = findDuplicateCandidates(
+      {
+        title: "Normalize duplicate issue detection results",
+        description: "Keep duplicate warnings deterministic.",
+      },
+      [
+        issue({ iid: 20, title: "Normalize duplicate issue detection output", labels: ["Planning"] }),
+        issue({ iid: 11, title: "Normalize duplicate issue detection results", labels: ["To Do"] }),
+        issue({ iid: 15, title: "Duplicate issue warning normalization", labels: ["Doing"] }),
+      ],
+      DEFAULT_WORKFLOW,
+    );
+
+    assert.deepStrictEqual(result.candidates.map((candidate) => candidate.issueId), [11, 20]);
+  });
+});
+
+describe("buildDuplicateConfirmationMessage", () => {
+  it("includes issue ids, links, scores, and reasons", () => {
+    const check = findDuplicateCandidates(
+      {
+        title: "Update star catalog docs to cite al-Sufi's Book of Fixed Stars",
+        description: "Document the historical source in the docs.",
+      },
+      [
+        issue({
+          iid: 119,
+          title: "Update star catalog docs to note the source from al-Sufi's Book of Fixed Stars",
+          description: "Document the source in the star catalog docs.",
+          labels: ["Doing"],
+        }),
+      ],
+      DEFAULT_WORKFLOW,
+    );
+
+    const message = buildDuplicateConfirmationMessage(check);
+    assert.ok(message.includes("Possible duplicate detected") || message.includes("Confirm before creating"));
+    assert.ok(message.includes("#119"));
+    assert.ok(message.includes("https://example.com/issues/119"));
+    assert.ok(message.includes("score"));
+    assert.ok(message.includes("Reasons:"));
+  });
+});

--- a/lib/services/issue-dedup.ts
+++ b/lib/services/issue-dedup.ts
@@ -1,0 +1,191 @@
+/**
+ * issue-dedup.ts — deterministic duplicate issue preflight checks.
+ *
+ * Keeps provider logic transport-focused and lets task creation paths decide
+ * whether a new issue should proceed, warn, or pause for explicit confirmation.
+ */
+import type { Issue } from "../providers/provider.js";
+import { type WorkflowConfig, StateType } from "../workflow/index.js";
+
+const STOP_WORDS = new Set([
+  "a", "an", "and", "are", "as", "at", "be", "by", "for", "from", "in", "into", "is", "it", "of", "on", "or", "that", "the", "to", "with",
+  "add", "create", "implement", "issue", "task", "work", "update",
+]);
+
+export type DuplicateConfidence = "high" | "medium" | "low";
+
+export type DuplicateCandidate = {
+  issueId: number;
+  title: string;
+  url: string;
+  stateLabel: string | null;
+  confidence: DuplicateConfidence;
+  score: number;
+  reasons: string[];
+};
+
+export type DuplicateCheckResult = {
+  confidence: DuplicateConfidence;
+  shouldRequireConfirmation: boolean;
+  shouldBlockWithoutConfirmation: boolean;
+  candidates: DuplicateCandidate[];
+  summary: string;
+};
+
+function normalize(text: string): string {
+  return text
+    .toLowerCase()
+    .replace(/['’`]/g, "")
+    .replace(/[^a-z0-9]+/g, " ")
+    .trim();
+}
+
+function stem(token: string): string {
+  if (token.length <= 4) return token;
+  if (token.endsWith("ies") && token.length > 5) return `${token.slice(0, -3)}y`;
+  if (token.endsWith("ing") && token.length > 6) return token.slice(0, -3);
+  if (token.endsWith("ed") && token.length > 5) return token.slice(0, -2);
+  if (token.endsWith("es") && token.length > 4) return token.slice(0, -2);
+  if (token.endsWith("s") && token.length > 4) return token.slice(0, -1);
+  return token;
+}
+
+function tokenize(text: string): string[] {
+  return normalize(text)
+    .split(/\s+/)
+    .map(stem)
+    .filter((token) => token.length >= 3 && !STOP_WORDS.has(token));
+}
+
+function tokenSet(text: string): Set<string> {
+  return new Set(tokenize(text));
+}
+
+function overlapScore(a: Set<string>, b: Set<string>): number {
+  if (a.size === 0 || b.size === 0) return 0;
+  let intersection = 0;
+  for (const token of a) if (b.has(token)) intersection += 1;
+  return intersection / Math.max(a.size, b.size);
+}
+
+function sharedTokens(a: Set<string>, b: Set<string>): string[] {
+  const shared: string[] = [];
+  for (const token of a) if (b.has(token)) shared.push(token);
+  return shared.sort();
+}
+
+function getNonTerminalStateLabels(workflow: WorkflowConfig): Set<string> {
+  return new Set(
+    Object.values(workflow.states)
+      .filter((state) => state.type !== StateType.TERMINAL)
+      .map((state) => state.label),
+  );
+}
+
+function getCurrentStateLabel(issue: Issue, workflow: WorkflowConfig): string | null {
+  const allowed = getNonTerminalStateLabels(workflow);
+  return issue.labels.find((label) => allowed.has(label)) ?? null;
+}
+
+function classifyConfidence(score: number, exactTitle: boolean, titleContained: boolean, sharedTitleCount: number): DuplicateConfidence {
+  if (exactTitle || (titleContained && sharedTitleCount >= 3) || sharedTitleCount >= 5 || score >= 0.78) return "high";
+  if (score >= 0.52 || (titleContained && sharedTitleCount >= 2) || sharedTitleCount >= 3) return "medium";
+  return "low";
+}
+
+function buildSummary(candidates: DuplicateCandidate[], requestedTitle: string): string {
+  const lead = candidates[0];
+  if (!lead) return `No likely duplicate found for \"${requestedTitle}\".`;
+  const prefix = lead.confidence === "high" ? "Potential duplicate blocked" : "Potential duplicate needs confirmation";
+  const details = candidates
+    .map((candidate) => {
+      const state = candidate.stateLabel ? `, state: ${candidate.stateLabel}` : "";
+      const reason = candidate.reasons[0] ? ` (${candidate.reasons[0]})` : "";
+      return `#${candidate.issueId} \"${candidate.title}\"${state}${reason}`;
+    })
+    .join("; ");
+  return `${prefix}: ${details}`;
+}
+
+export function findDuplicateCandidates(
+  draft: { title: string; description?: string },
+  openIssues: Issue[],
+  workflow: WorkflowConfig,
+): DuplicateCheckResult {
+  const requestedTitle = draft.title ?? "";
+  const requestedDescription = draft.description ?? "";
+  const requestedTitleNorm = normalize(requestedTitle);
+  const requestedTitleTokens = tokenSet(requestedTitle);
+  const requestedBodyTokens = tokenSet(requestedDescription);
+  const candidates: DuplicateCandidate[] = [];
+  const nonTerminalLabels = getNonTerminalStateLabels(workflow);
+
+  for (const issue of openIssues) {
+    const stateLabel = getCurrentStateLabel(issue, workflow);
+    if (!stateLabel || !nonTerminalLabels.has(stateLabel)) continue;
+
+    const candidateTitleNorm = normalize(issue.title);
+    const candidateTitleTokens = tokenSet(issue.title);
+    const candidateBodyTokens = tokenSet(issue.description ?? "");
+    const titleScore = overlapScore(requestedTitleTokens, candidateTitleTokens);
+    const bodyScore = overlapScore(requestedBodyTokens, candidateBodyTokens);
+    const crossScore = Math.max(
+      overlapScore(requestedTitleTokens, candidateBodyTokens),
+      overlapScore(requestedBodyTokens, candidateTitleTokens),
+    );
+    const exactTitle = requestedTitleNorm.length > 0 && requestedTitleNorm === candidateTitleNorm;
+    const titleContained = requestedTitleNorm.length > 0 && candidateTitleNorm.length > 0 && (
+      requestedTitleNorm.includes(candidateTitleNorm) || candidateTitleNorm.includes(requestedTitleNorm)
+    );
+    const sharedTitle = sharedTokens(requestedTitleTokens, candidateTitleTokens);
+    const score = Number((titleScore * 0.65 + bodyScore * 0.2 + crossScore * 0.15).toFixed(3));
+    const confidence = classifyConfidence(score, exactTitle, titleContained, sharedTitle.length);
+    if (confidence === "low") continue;
+
+    const reasons: string[] = [];
+    if (exactTitle) reasons.push("same normalized title");
+    else if (titleContained) reasons.push("one normalized title contains the other");
+    if (sharedTitle.length > 0) reasons.push(`shared title tokens: ${sharedTitle.join(", ")}`);
+    if (bodyScore >= 0.45) reasons.push(`body similarity ${bodyScore.toFixed(2)}`);
+    if (crossScore >= 0.45) reasons.push(`title/body overlap ${crossScore.toFixed(2)}`);
+
+    candidates.push({
+      issueId: issue.iid,
+      title: issue.title,
+      url: issue.web_url,
+      stateLabel,
+      confidence,
+      score,
+      reasons,
+    });
+  }
+
+  candidates.sort((a, b) => {
+    const rank = { high: 2, medium: 1, low: 0 };
+    const confidenceDiff = rank[b.confidence] - rank[a.confidence];
+    if (confidenceDiff !== 0) return confidenceDiff;
+    if (b.score !== a.score) return b.score - a.score;
+    return a.issueId - b.issueId;
+  });
+
+  const top = candidates[0];
+  const confidence = top?.confidence ?? "low";
+  return {
+    confidence,
+    shouldRequireConfirmation: confidence !== "low",
+    shouldBlockWithoutConfirmation: confidence === "high" || confidence === "medium",
+    candidates: candidates.slice(0, 5),
+    summary: buildSummary(candidates.slice(0, 5), requestedTitle),
+  };
+}
+
+export function buildDuplicateConfirmationMessage(check: DuplicateCheckResult): string {
+  if (check.candidates.length === 0) return check.summary;
+  const heading = check.confidence === "high"
+    ? "Possible duplicate detected. Creation is paused until you confirm."
+    : "This may overlap with existing work. Confirm before creating it.";
+  const items = check.candidates
+    .map((candidate) => `- #${candidate.issueId} ${candidate.title} (${candidate.stateLabel ?? "unknown"}, score ${candidate.score.toFixed(2)})\n  ${candidate.url}\n  Reasons: ${candidate.reasons.join("; ") || "similar title/body"}`)
+    .join("\n");
+  return `${heading}\n${items}`;
+}

--- a/lib/services/pr-reconciliation.test.ts
+++ b/lib/services/pr-reconciliation.test.ts
@@ -1,0 +1,40 @@
+import { describe, it } from "node:test";
+import assert from "node:assert";
+import { TestProvider } from "../testing/test-provider.js";
+import { DEFAULT_WORKFLOW } from "../workflow/index.js";
+import { PrState } from "../providers/provider.js";
+import { getCanonicalReviewStatus, getStaleReviewLabels } from "./pr-reconciliation.js";
+
+describe("pr reconciliation", () => {
+  it("treats stale review labels as residue once feedback exists", async () => {
+    const provider = new TestProvider({ workflow: DEFAULT_WORKFLOW });
+    const issue = provider.seedIssue({ iid: 131, title: "Residue", labels: ["To Improve", "review:human"] });
+    provider.setPrStatus(131, { state: PrState.CHANGES_REQUESTED, url: "https://example.com/pr/131" });
+
+    const review = await getCanonicalReviewStatus(provider, DEFAULT_WORKFLOW, issue);
+
+    assert.strictEqual(review.canonicalState, "changes_requested");
+    assert.deepStrictEqual(getStaleReviewLabels(issue, review), ["review:human"]);
+  });
+
+  it("surfaces ambiguity when multiple PRs exist", async () => {
+    const provider = new TestProvider({ workflow: DEFAULT_WORKFLOW });
+    const issue = provider.seedIssue({ iid: 34, title: "Ambiguous", labels: ["To Review", "review:human"] });
+    provider.setPrStatus(34, {
+      state: PrState.OPEN,
+      url: null,
+      ambiguous: true,
+      reason: "multiple_open_prs",
+      candidates: [
+        { url: "https://example.com/pr/1", state: "OPEN" },
+        { url: "https://example.com/pr/2", state: "OPEN" },
+      ],
+    });
+
+    const review = await getCanonicalReviewStatus(provider, DEFAULT_WORKFLOW, issue);
+
+    assert.strictEqual(review.ambiguous, true);
+    assert.strictEqual(review.canonicalState, "ambiguous");
+    assert.strictEqual(review.needsHumanReview, false);
+  });
+});

--- a/lib/services/pr-reconciliation.ts
+++ b/lib/services/pr-reconciliation.ts
@@ -1,0 +1,198 @@
+/**
+ * Canonical PR/workflow reconciliation.
+ *
+ * Computes one shared view of an issue's review state from workflow labels,
+ * routing labels, and provider PR status. Callers should use this instead of
+ * hand-rolling PR + label interpretation.
+ */
+import type { Issue, IssueProvider, PrStatus } from "../providers/provider.js";
+import { PrState } from "../providers/provider.js";
+import { detectStepRouting } from "./queue-scan.js";
+import { getCurrentStateLabel, type WorkflowConfig } from "../workflow/index.js";
+
+export type ReviewRouting = "human" | "agent" | "skip" | null;
+export type CanonicalReviewState =
+  | "not_in_review"
+  | "awaiting_human_review"
+  | "awaiting_agent_review"
+  | "review_skipped"
+  | "changes_requested"
+  | "merge_conflict"
+  | "pr_closed"
+  | "merged"
+  | "ambiguous";
+
+export type CanonicalReviewStatus = {
+  stateLabel: string | null;
+  routing: ReviewRouting;
+  inReviewQueue: boolean;
+  needsHumanReview: boolean;
+  needsAgentReview: boolean;
+  shouldSkipReview: boolean;
+  prStatus: PrStatus;
+  canonicalState: CanonicalReviewState;
+  ambiguous: boolean;
+  reason?: string;
+};
+
+export async function getCanonicalReviewStatus(
+  provider: IssueProvider,
+  workflow: WorkflowConfig,
+  issue: Issue,
+): Promise<CanonicalReviewStatus> {
+  const stateLabel = getCurrentStateLabel(issue.labels, workflow);
+  const stateConfig = stateLabel
+    ? Object.values(workflow.states).find((state) => state.label === stateLabel) ?? null
+    : null;
+  const inReviewQueue = Boolean(stateConfig?.check);
+  const routing = detectStepRouting(issue.labels, "review") as ReviewRouting;
+  const prStatus = await provider.getPrStatus(issue.iid);
+
+  if (prStatus.ambiguous) {
+    return {
+      stateLabel,
+      routing,
+      inReviewQueue,
+      needsHumanReview: false,
+      needsAgentReview: false,
+      shouldSkipReview: false,
+      prStatus,
+      canonicalState: "ambiguous",
+      ambiguous: true,
+      reason: prStatus.reason ?? "multiple_prs",
+    };
+  }
+
+  if (prStatus.mergeable === false) {
+    return {
+      stateLabel,
+      routing,
+      inReviewQueue,
+      needsHumanReview: false,
+      needsAgentReview: false,
+      shouldSkipReview: false,
+      prStatus,
+      canonicalState: "merge_conflict",
+      ambiguous: false,
+      reason: "merge_conflict",
+    };
+  }
+
+  if (prStatus.state === PrState.CHANGES_REQUESTED || prStatus.state === PrState.HAS_COMMENTS) {
+    return {
+      stateLabel,
+      routing,
+      inReviewQueue,
+      needsHumanReview: false,
+      needsAgentReview: false,
+      shouldSkipReview: false,
+      prStatus,
+      canonicalState: "changes_requested",
+      ambiguous: false,
+      reason: prStatus.state,
+    };
+  }
+
+  if (prStatus.state === PrState.CLOSED && prStatus.url) {
+    return {
+      stateLabel,
+      routing,
+      inReviewQueue,
+      needsHumanReview: false,
+      needsAgentReview: false,
+      shouldSkipReview: false,
+      prStatus,
+      canonicalState: "pr_closed",
+      ambiguous: false,
+      reason: "pr_closed",
+    };
+  }
+
+  if (prStatus.state === PrState.MERGED) {
+    return {
+      stateLabel,
+      routing,
+      inReviewQueue,
+      needsHumanReview: false,
+      needsAgentReview: false,
+      shouldSkipReview: false,
+      prStatus,
+      canonicalState: "merged",
+      ambiguous: false,
+      reason: "merged",
+    };
+  }
+
+  if (!inReviewQueue) {
+    return {
+      stateLabel,
+      routing,
+      inReviewQueue,
+      needsHumanReview: false,
+      needsAgentReview: false,
+      shouldSkipReview: false,
+      prStatus,
+      canonicalState: "not_in_review",
+      ambiguous: false,
+      reason: "not_in_review_queue",
+    };
+  }
+
+  if (routing === "human") {
+    return {
+      stateLabel,
+      routing,
+      inReviewQueue,
+      needsHumanReview: true,
+      needsAgentReview: false,
+      shouldSkipReview: false,
+      prStatus,
+      canonicalState: "awaiting_human_review",
+      ambiguous: false,
+      reason: "awaiting_human_review",
+    };
+  }
+
+  if (routing === "skip") {
+    return {
+      stateLabel,
+      routing,
+      inReviewQueue,
+      needsHumanReview: false,
+      needsAgentReview: false,
+      shouldSkipReview: true,
+      prStatus,
+      canonicalState: "review_skipped",
+      ambiguous: false,
+      reason: "review_skipped",
+    };
+  }
+
+  return {
+    stateLabel,
+    routing,
+    inReviewQueue,
+    needsHumanReview: false,
+    needsAgentReview: true,
+    shouldSkipReview: false,
+    prStatus,
+    canonicalState: "awaiting_agent_review",
+    ambiguous: false,
+    reason: routing === "agent" ? "awaiting_agent_review" : "default_agent_review",
+  };
+}
+
+export function getStaleReviewLabels(issue: Issue, status: CanonicalReviewStatus): string[] {
+  const reviewLabels = issue.labels.filter((label) => label.startsWith("review:"));
+  if (reviewLabels.length === 0) return [];
+
+  if (status.ambiguous || status.canonicalState === "changes_requested" || status.canonicalState === "merge_conflict" || status.canonicalState === "pr_closed" || status.canonicalState === "merged") {
+    return reviewLabels;
+  }
+
+  if (!status.inReviewQueue && status.prStatus.state === PrState.CLOSED && !status.prStatus.url) {
+    return reviewLabels;
+  }
+
+  return [];
+}

--- a/lib/services/tick.ts
+++ b/lib/services/tick.ts
@@ -22,6 +22,7 @@ import {
   type Role,
 } from "../workflow/index.js";
 import { detectRoleLevelFromLabels, detectStepRouting, findNextIssueForRole } from "./queue-scan.js";
+import { getCanonicalReviewStatus } from "./pr-reconciliation.js";
 
 // ---------------------------------------------------------------------------
 // projectTick
@@ -144,9 +145,14 @@ export async function projectTick(opts: {
 
     // Step routing: check for review:human / review:skip / test:skip labels
     if (role === "reviewer") {
-      const routing = detectStepRouting(issue.labels, "review");
+      const review = await getCanonicalReviewStatus(provider, workflow, issue);
+      if (review.ambiguous) {
+        skipped.push({ role, reason: `Ambiguous PR state: ${review.reason ?? "multiple PRs"}` });
+        continue;
+      }
+      const routing = review.needsHumanReview ? "human" : review.shouldSkipReview ? "skip" : detectStepRouting(issue.labels, "review");
       if (routing === "human" || routing === "skip") {
-        skipped.push({ role, reason: `review:${routing} label` });
+        skipped.push({ role, reason: `review:${routing}` });
         continue;
       }
     }

--- a/lib/tools/tasks/research-task.ts
+++ b/lib/tools/tasks/research-task.ts
@@ -21,9 +21,10 @@ import { dispatchTask } from "../../dispatch/index.js";
 import { log as auditLog } from "../../audit.js";
 import { requireWorkspaceDir, resolveChannelId, resolveProject, resolveProvider, autoAssignOwnerLabel, applyNotifyLabel } from "../helpers.js";
 import { loadConfig } from "../../config/index.js";
-import { getActiveLabel } from "../../workflow/index.js";
+import { getActiveLabel, loadWorkflow } from "../../workflow/index.js";
 import { selectLevel } from "../../roles/model-selector.js";
 import { resolveModel } from "../../roles/index.js";
+import { findDuplicateCandidates, buildDuplicateConfirmationMessage } from "../../services/issue-dedup.js";
 
 /** Queue label for research tasks. */
 const TO_RESEARCH_LABEL = "To Research";
@@ -82,6 +83,10 @@ Example:
           type: "boolean",
           description: "Preview without executing. Defaults to false.",
         },
+        confirmDuplicate: {
+          type: "boolean",
+          description: "Confirm creation even when DevClaw detects likely overlapping open work. Required for medium/high-confidence duplicate warnings.",
+        },
       },
     },
 
@@ -92,6 +97,7 @@ Example:
       const focusAreas = (params.focusAreas as string[]) ?? [];
       const complexity = (params.complexity as "simple" | "medium" | "complex") ?? "medium";
       const dryRun = (params.dryRun as boolean) ?? false;
+      const confirmDuplicate = (params.confirmDuplicate as boolean) ?? false;
       const workspaceDir = requireWorkspaceDir(toolCtx);
 
       if (!title) throw new Error("title is required");
@@ -99,6 +105,7 @@ Example:
 
       const { project } = await resolveProject(workspaceDir, channelId);
       const { provider } = await resolveProvider(project, ctx.runCommand);
+      const workflow = await loadWorkflow(workspaceDir, project.name);
       const pluginConfig = ctx.pluginConfig;
       const role = "architect";
 
@@ -109,8 +116,14 @@ Example:
       }
       const issueBody = bodyParts.join("\n");
 
+      const openIssues = await provider.listIssues({ state: "open" });
+      const duplicateCheck = findDuplicateCandidates({ title, description: issueBody }, openIssues, workflow);
+
       await auditLog(workspaceDir, "research_task", {
         project: project.name, title, complexity, focusAreas, dryRun,
+        duplicateConfidence: duplicateCheck.confidence,
+        duplicateConfirmed: confirmDuplicate,
+        duplicateCandidates: duplicateCheck.candidates.map((candidate) => candidate.issueId),
       });
 
       // Select level: use complexity hint to guide the heuristic
@@ -126,8 +139,29 @@ Example:
           success: true,
           dryRun: true,
           issue: { title, label: TO_RESEARCH_LABEL },
+          duplicateCheck: {
+            confidence: duplicateCheck.confidence,
+            requiresConfirmation: duplicateCheck.shouldRequireConfirmation,
+            blocked: duplicateCheck.shouldBlockWithoutConfirmation,
+            candidates: duplicateCheck.candidates,
+            summary: duplicateCheck.summary,
+          },
           research: { level, model, status: "dry_run" },
           announcement: `\u{1f4d0} [DRY RUN] Would create research ticket and dispatch ${role} (${level}) for: ${title}`,
+        });
+      }
+
+      if (duplicateCheck.shouldRequireConfirmation && !confirmDuplicate) {
+        return jsonResult({
+          success: false,
+          duplicateCheck: {
+            confidence: duplicateCheck.confidence,
+            requiresConfirmation: true,
+            blocked: duplicateCheck.shouldBlockWithoutConfirmation,
+            candidates: duplicateCheck.candidates,
+            summary: duplicateCheck.summary,
+          },
+          announcement: buildDuplicateConfirmationMessage(duplicateCheck),
         });
       }
 
@@ -196,7 +230,16 @@ Example:
           status: "in_progress",
         },
         project: project.name,
-        announcement: dr.announcement,
+        duplicateCheck: {
+          confidence: duplicateCheck.confidence,
+          requiresConfirmation: false,
+          blocked: false,
+          candidates: duplicateCheck.candidates,
+          summary: duplicateCheck.summary,
+        },
+        announcement: confirmDuplicate && duplicateCheck.candidates.length > 0
+          ? `${dr.announcement}\nConfirmed despite possible overlap with ${duplicateCheck.candidates.map((candidate) => `#${candidate.issueId}`).join(", ")}.`
+          : dr.announcement,
       });
     },
   });

--- a/lib/tools/tasks/task-create.ts
+++ b/lib/tools/tasks/task-create.ts
@@ -13,7 +13,8 @@ import { jsonResult } from "openclaw/plugin-sdk";
 import type { PluginContext } from "../../context.js";
 import type { ToolContext } from "../../types.js";
 import { log as auditLog } from "../../audit.js";
-import { DEFAULT_WORKFLOW } from "../../workflow/index.js";
+import { DEFAULT_WORKFLOW, loadWorkflow } from "../../workflow/index.js";
+import { findDuplicateCandidates, buildDuplicateConfirmationMessage } from "../../services/issue-dedup.js";
 import { requireWorkspaceDir, resolveChannelId, resolveProject, resolveProvider, autoAssignOwnerLabel, applyNotifyLabel } from "../helpers.js";
 
 /** Derive the initial state label from the workflow config. */
@@ -49,6 +50,10 @@ export function createTaskCreateTool(ctx: PluginContext) {
           type: "boolean",
           description: "If true, immediately pick up this issue for DEV after creation. Defaults to false.",
         },
+        confirmDuplicate: {
+          type: "boolean",
+          description: "Confirm creation even when DevClaw detects likely overlapping open work. Required for medium/high-confidence duplicate warnings.",
+        },
       },
     },
 
@@ -59,10 +64,27 @@ export function createTaskCreateTool(ctx: PluginContext) {
       const label = INITIAL_LABEL;
       const assignees = (params.assignees as string[] | undefined) ?? [];
       const pickup = (params.pickup as boolean) ?? false;
+      const confirmDuplicate = (params.confirmDuplicate as boolean) ?? false;
       const workspaceDir = requireWorkspaceDir(toolCtx);
 
       const { project } = await resolveProject(workspaceDir, channelId);
       const { provider, type: providerType } = await resolveProvider(project, ctx.runCommand);
+      const workflow = await loadWorkflow(workspaceDir, project.name);
+      const openIssues = await provider.listIssues({ state: "open" });
+      const duplicateCheck = findDuplicateCandidates({ title, description }, openIssues, workflow);
+      if (duplicateCheck.shouldRequireConfirmation && !confirmDuplicate) {
+        return jsonResult({
+          success: false,
+          duplicateCheck: {
+            confidence: duplicateCheck.confidence,
+            requiresConfirmation: true,
+            blocked: duplicateCheck.shouldBlockWithoutConfirmation,
+            candidates: duplicateCheck.candidates,
+            summary: duplicateCheck.summary,
+          },
+          announcement: buildDuplicateConfirmationMessage(duplicateCheck),
+        });
+      }
 
       const issue = await provider.createIssue(title, description, label, assignees);
 
@@ -78,6 +100,9 @@ export function createTaskCreateTool(ctx: PluginContext) {
       await auditLog(workspaceDir, "task_create", {
         project: project.name, issueId: issue.iid,
         title, label, provider: providerType, pickup,
+        duplicateConfidence: duplicateCheck.confidence,
+        duplicateConfirmed: confirmDuplicate,
+        duplicateCandidates: duplicateCheck.candidates.map((candidate) => candidate.issueId),
       });
 
       const hasBody = description && description.trim().length > 0;
@@ -85,10 +110,20 @@ export function createTaskCreateTool(ctx: PluginContext) {
       if (hasBody) announcement += "\nWith detailed description.";
       announcement += `\n🔗 [Issue #${issue.iid}](${issue.web_url})`;
       announcement += pickup ? "\nPicking up for DEV..." : "\nReady for pickup when needed.";
+      if (confirmDuplicate && duplicateCheck.candidates.length > 0) {
+        announcement += `\nConfirmed despite possible overlap with ${duplicateCheck.candidates.map((candidate) => `#${candidate.issueId}`).join(", ")}.`;
+      }
 
       return jsonResult({
         success: true,
         issue: { id: issue.iid, title: issue.title, body: hasBody ? description : null, url: issue.web_url, label },
+        duplicateCheck: {
+          confidence: duplicateCheck.confidence,
+          requiresConfirmation: false,
+          blocked: false,
+          candidates: duplicateCheck.candidates,
+          summary: duplicateCheck.summary,
+        },
         project: project.name, provider: providerType, pickup, announcement,
       });
     },

--- a/lib/tools/worker/work-finish.ts
+++ b/lib/tools/worker/work-finish.ts
@@ -229,6 +229,15 @@ export async function validatePrExistsForDeveloper(
       explicitPrUrl,
     );
 
+    if (prStatus.ambiguous) {
+      throw new Error(
+        `Cannot mark work_finish(done) while multiple PRs are linked to this issue.\n\n` +
+        `✗ Ambiguity: ${prStatus.reason ?? "multiple candidate PRs"}\n` +
+        `${(prStatus.candidates ?? []).map((pr) => `  - ${pr.state}: ${pr.url}`).join("\n")}\n\n` +
+        `Please explicitly close or supersede the extra PRs so one canonical PR remains, then call work_finish again.`,
+      );
+    }
+
     if (!prStatus.url) {
       throw new Error(
         `Cannot mark work_finish(done) without an open PR.\n\n` +


### PR DESCRIPTION
Addresses issue #35.

## Summary
- add duplicate-issue preflight regression coverage and confirmation messaging tests
- add canonical PR/review reconciliation tests for ambiguity and stale review-label cleanup
- cover deterministic multi-PR handling in provider status tests

## Validation
- npx tsx --test lib/services/issue-dedup.test.ts lib/services/pr-reconciliation.test.ts lib/providers/pr-reconciliation.test.ts lib/providers/provider-pr-status.test.ts lib/services/heartbeat/review.test.ts