### PR TITLE
test: add workflow integrity regressions

### DIFF
--- a/lib/dispatch/pr-context.fetch.test.ts
+++ b/lib/dispatch/pr-context.fetch.test.ts
@@ -1,0 +1,43 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import { fetchPrContext, fetchPrFeedback } from './pr-context.js';
+import { TestProvider } from '../testing/test-provider.js';
+import { PrState } from '../providers/provider.js';
+
+describe('fetchPrContext', () => {
+  it('returns undefined when multiple PRs make the canonical PR ambiguous', async () => {
+    const provider = new TestProvider();
+    provider.setPrStatus(42, {
+      state: PrState.OPEN,
+      url: 'https://example.com/pr/2',
+      ambiguous: true,
+      reason: 'multiple_open_prs',
+      candidates: [
+        { url: 'https://example.com/pr/1', state: 'OPEN' },
+        { url: 'https://example.com/pr/2', state: 'OPEN' },
+      ],
+    });
+
+    const result = await fetchPrContext(provider, 42);
+    assert.strictEqual(result, undefined);
+  });
+});
+
+describe('fetchPrFeedback', () => {
+  it('returns undefined when the issue no longer has a single canonical reviewable PR', async () => {
+    const provider = new TestProvider();
+    provider.setPrStatus(42, {
+      state: PrState.OPEN,
+      url: 'https://example.com/pr/2',
+      ambiguous: true,
+      reason: 'multiple_open_prs',
+      candidates: [
+        { url: 'https://example.com/pr/1', state: 'OPEN' },
+        { url: 'https://example.com/pr/2', state: 'OPEN' },
+      ],
+    });
+
+    const result = await fetchPrFeedback(provider, 42);
+    assert.strictEqual(result, undefined);
+  });
+});

--- a/lib/services/heartbeat/health.test.ts
+++ b/lib/services/heartbeat/health.test.ts
@@ -148,6 +148,25 @@ describe("scanOrphanedLabels", () => {
       assert.ok(issue.labels.includes("To Do"), `Expected "To Do", got: ${issue.labels}`);
     });
 
+    it("should revert to 'To Improve' when PR is already approved but the worker state is stale", async () => {
+      h.provider.seedIssue({ iid: 42, title: "Test issue", labels: ["Doing"] });
+      h.provider.setPrStatus(42, { state: PrState.APPROVED, url: "https://github.com/test/pr/1" });
+
+      const fixes = await scanOrphanedLabels({
+        workspaceDir: h.workspaceDir,
+        projectSlug: h.project.slug,
+        project: h.project,
+        role: "developer",
+        autoFix: true,
+        provider: h.provider,
+        workflow: h.workflow,
+      });
+
+      assert.strictEqual(fixes.length, 1);
+      assert.strictEqual(fixes[0]!.fixed, true);
+      assert.strictEqual(fixes[0]!.labelReverted, "Doing → To Improve");
+    });
+
     it("should revert to 'To Improve' when PR has changes_requested", async () => {
       h.provider.seedIssue({ iid: 42, title: "Test issue", labels: ["Doing"] });
       h.provider.setPrStatus(42, { state: PrState.CHANGES_REQUESTED, url: "https://github.com/test/pr/1" });

--- a/lib/services/heartbeat/review.test.ts
+++ b/lib/services/heartbeat/review.test.ts
@@ -8,7 +8,7 @@ import { PrState } from '../../providers/provider.js';
 const runCommand = async () => ({ stdout: '', stderr: '', exitCode: 0, code: 0, signal: null, killed: false, termination: 'exit' } as any);
 
 describe('reviewPass ambiguity reconciliation', () => {
-  it('surfaces ambiguous multiple PRs instead of silently transitioning', async () => {
+  it('surfaces ambiguous multiple open PRs instead of silently transitioning', async () => {
     const provider = new TestProvider();
     provider.seedIssue({ iid: 131, title: 'Ambiguous review', labels: ['To Review', 'review:human'] });
     provider.setPrStatus(131, {
@@ -35,5 +35,34 @@ describe('reviewPass ambiguity reconciliation', () => {
     assert.strictEqual(provider.callsTo('transitionLabel').length, 0);
     assert.strictEqual(provider.callsTo('addComment').length, 1);
     assert.match(provider.callsTo('addComment')[0].args.body, /multiple candidate PRs/i);
+  });
+
+  it('surfaces ambiguous merged PRs instead of pretending the issue is reviewable', async () => {
+    const provider = new TestProvider();
+    provider.seedIssue({ iid: 132, title: 'Merged ambiguity', labels: ['To Review', 'review:human'] });
+    provider.setPrStatus(132, {
+      state: PrState.MERGED,
+      url: 'https://example.com/pr/8',
+      ambiguous: true,
+      reason: 'multiple_merged_prs',
+      candidates: [
+        { url: 'https://example.com/pr/7', state: 'MERGED' },
+        { url: 'https://example.com/pr/8', state: 'MERGED' },
+      ],
+    });
+
+    const transitions = await reviewPass({
+      workspaceDir: '/tmp',
+      projectName: 'devclaw',
+      workflow: DEFAULT_WORKFLOW,
+      provider,
+      repoPath: '/tmp',
+      runCommand,
+    });
+
+    assert.strictEqual(transitions, 0);
+    assert.strictEqual(provider.callsTo('transitionLabel').length, 0);
+    assert.strictEqual(provider.callsTo('addComment').length, 1);
+    assert.match(provider.callsTo('addComment')[0].args.body, /cannot reconcile review state safely/i);
   });
 });

--- a/lib/services/issue-dedup.test.ts
+++ b/lib/services/issue-dedup.test.ts
@@ -85,6 +85,28 @@ describe("findDuplicateCandidates", () => {
     assert.deepStrictEqual(result.candidates, []);
   });
 
+  it("treats refining work as live overlap that still blocks duplicate creation", () => {
+    const result = findDuplicateCandidates(
+      {
+        title: "Clear stale review labels when retrying work",
+        description: "Clear stale review:human and Refining residue when retrying or resuming work after PR state changes.",
+      },
+      [
+        issue({
+          iid: 34,
+          title: "Clear stale review labels when retrying work",
+          description: "Clear stale review:human and Refining residue when retrying work after PR state changes.",
+          labels: ["Refining"],
+        }),
+      ],
+      DEFAULT_WORKFLOW,
+    );
+
+    assert.strictEqual(result.shouldRequireConfirmation, true);
+    assert.strictEqual(result.shouldBlockWithoutConfirmation, true);
+    assert.strictEqual(result.candidates[0]?.stateLabel, 'Refining');
+  });
+
   it("orders candidates deterministically by confidence, score, then issue id", () => {
     const result = findDuplicateCandidates(
       {

--- a/lib/tools/worker/work-finish.test.ts
+++ b/lib/tools/worker/work-finish.test.ts
@@ -199,6 +199,26 @@ describe("work_finish PR validation", () => {
       assert.equal(provider.callsTo("getPrStatus").length, 1);
     });
 
+    it("rejects completion when multiple open PRs make the canonical PR ambiguous", async () => {
+      const provider = new TestProvider();
+      provider.setPrStatus(42, {
+        state: PrState.OPEN,
+        url: "https://github.com/test/repo/pull/43",
+        ambiguous: true,
+        reason: "multiple_open_prs",
+        candidates: [
+          { url: "https://github.com/test/repo/pull/42", state: "OPEN", sourceBranch: "feature/42-a" },
+          { url: "https://github.com/test/repo/pull/43", state: "OPEN", sourceBranch: "feature/42-b" },
+        ],
+      });
+
+      const runCommand = async () => ({ stdout: "feature/42-b\n", stderr: "", exitCode: 0 });
+      await assert.rejects(
+        () => validatePrExistsForDeveloper(42, tempDir, provider as any, runCommand as any, tempDir, "devclaw"),
+        /multiple PRs are linked to this issue/,
+      );
+    });
+
     it("rejects follow-up completion when the reused PR is still conflicting", async () => {
       await createMockAuditLog(tempDir, 108, true);
 


### PR DESCRIPTION
Addresses issue #35.

## Summary
- add regression coverage for duplicate issue detection across active and refining work
- cover ambiguous canonical PR handling in review dispatch and developer completion checks
- add canonical PR-context fetch tests so user-facing status avoids stale multi-PR state
- extend stale orphan cleanup coverage for approved PR feedback cycles

## Validation
- npx tsx --test lib/services/issue-dedup.test.ts lib/services/heartbeat/review.test.ts lib/dispatch/pr-context.fetch.test.ts