### PR TITLE
test: cover workflow integrity regressions

### DIFF
--- a/lib/providers/github.ts
+++ b/lib/providers/github.ts
@@ -28,6 +28,18 @@ type GhIssue = {
   url: string;
 };
 
+function newestPrFirst<T extends { number?: number; url?: string }>(prs: T[]): T[] {
+  return [...prs].sort((a, b) => {
+    const num = (b.number ?? 0) - (a.number ?? 0);
+    if (num !== 0) return num;
+    return String(b.url ?? "").localeCompare(String(a.url ?? ""));
+  });
+}
+
+function canonicalPr<T extends { number?: number; url?: string }>(prs: T[]): T | undefined {
+  return newestPrFirst(prs)[0];
+}
+
 function toIssue(gh: GhIssue): Issue {
   return {
     iid: gh.number, title: gh.title, description: gh.body ?? "",
@@ -298,7 +310,7 @@ export class GitHubProvider implements IssueProvider {
   async getPrStatus(issueId: number): Promise<PrStatus> {
     // Check open PRs first — include mergeable for conflict detection
     type OpenPr = { title: string; body: string; headRefName: string; url: string; number: number; reviewDecision: string; mergeable: string };
-    const open = await this.findPrsForIssue<OpenPr>(issueId, "open", "title,body,headRefName,url,number,reviewDecision,mergeable");
+    const open = newestPrFirst(await this.findPrsForIssue<OpenPr>(issueId, "open", "title,body,headRefName,url,number,reviewDecision,mergeable"));
     if (open.length > 0) {
       const pr = open[0];
       let state: PrState;
@@ -333,7 +345,7 @@ export class GitHubProvider implements IssueProvider {
     }
     // Check merged PRs — also fetch reviewDecision to detect approved-then-merged vs self-merged.
     type MergedPr = { title: string; body: string; headRefName: string; url: string; reviewDecision: string | null };
-    const merged = await this.findPrsForIssue<MergedPr>(issueId, "merged", "title,body,headRefName,url,reviewDecision");
+    const merged = newestPrFirst(await this.findPrsForIssue<MergedPr>(issueId, "merged", "title,body,headRefName,url,reviewDecision"));
     if (merged.length > 0) {
       const pr = merged[0];
       const state = pr.reviewDecision === "APPROVED" ? PrState.APPROVED : PrState.MERGED;
@@ -438,25 +450,28 @@ export class GitHubProvider implements IssueProvider {
 
   async mergePr(issueId: number): Promise<void> {
     type OpenPr = { title: string; body: string; headRefName: string; url: string };
-    const prs = await this.findPrsForIssue<OpenPr>(issueId, "open", "title,body,headRefName,url");
-    if (prs.length === 0) throw new Error(`No open PR found for issue #${issueId}`);
-    await this.gh(["pr", "merge", prs[0].url, "--merge"]);
+    const prs = newestPrFirst(await this.findPrsForIssue<OpenPr>(issueId, "open", "title,body,headRefName,url,number"));
+    const pr = canonicalPr(prs);
+    if (!pr?.url) throw new Error(`No open PR found for issue #${issueId}`);
+    await this.gh(["pr", "merge", pr.url, "--merge"]);
   }
 
   async getPrDiff(issueId: number): Promise<string | null> {
     type OpenPr = { title: string; body: string; headRefName: string; number: number };
-    const prs = await this.findPrsForIssue<OpenPr>(issueId, "open", "title,body,headRefName,number");
-    if (prs.length === 0) return null;
+    const prs = newestPrFirst(await this.findPrsForIssue<OpenPr>(issueId, "open", "title,body,headRefName,number"));
+    const pr = canonicalPr(prs);
+    if (!pr?.number) return null;
     try {
-      return await this.gh(["pr", "diff", String(prs[0].number)]);
+      return await this.gh(["pr", "diff", String(pr.number)]);
     } catch { return null; }
   }
 
   async getPrReviewComments(issueId: number): Promise<PrReviewComment[]> {
     type OpenPr = { title: string; body: string; headRefName: string; number: number };
-    const prs = await this.findPrsForIssue<OpenPr>(issueId, "open", "title,body,headRefName,number");
-    if (prs.length === 0) return [];
-    const prNumber = prs[0].number;
+    const prs = newestPrFirst(await this.findPrsForIssue<OpenPr>(issueId, "open", "title,body,headRefName,number"));
+    const pr = canonicalPr(prs);
+    if (!pr?.number) return [];
+    const prNumber = pr.number;
     const comments: PrReviewComment[] = [];
 
     try {
@@ -546,10 +561,11 @@ export class GitHubProvider implements IssueProvider {
     try {
       // GitHub PRs are also issues — use the same reactions API with the PR number
       type OpenPr = { title: string; body: string; headRefName: string; number: number };
-      const prs = await this.findPrsForIssue<OpenPr>(issueId, "open", "title,body,headRefName,number");
-      if (prs.length === 0) return;
+      const prs = newestPrFirst(await this.findPrsForIssue<OpenPr>(issueId, "open", "title,body,headRefName,number"));
+      const pr = canonicalPr(prs);
+      if (!pr?.number) return;
       await this.gh([
-        "api", `repos/:owner/:repo/issues/${prs[0].number}/reactions`,
+        "api", `repos/:owner/:repo/issues/${pr.number}/reactions`,
         "--method", "POST",
         "--field", `content=${emoji}`,
       ]);
@@ -559,9 +575,10 @@ export class GitHubProvider implements IssueProvider {
   async prHasReaction(issueId: number, emoji: string): Promise<boolean> {
     try {
       type OpenPr = { title: string; body: string; headRefName: string; number: number };
-      const prs = await this.findPrsForIssue<OpenPr>(issueId, "open", "title,body,headRefName,number");
-      if (prs.length === 0) return false;
-      const raw = await this.gh(["api", `repos/:owner/:repo/issues/${prs[0].number}/reactions`]);
+      const prs = newestPrFirst(await this.findPrsForIssue<OpenPr>(issueId, "open", "title,body,headRefName,number"));
+      const pr = canonicalPr(prs);
+      if (!pr?.number) return false;
+      const raw = await this.gh(["api", `repos/:owner/:repo/issues/${pr.number}/reactions`]);
       const reactions = JSON.parse(raw) as Array<{ content: string }>;
       return reactions.some((r) => r.content === emoji);
     } catch { return false; }
@@ -598,12 +615,13 @@ export class GitHubProvider implements IssueProvider {
    */
   async reactToPrReview(issueId: number, reviewId: number, emoji: string): Promise<void> {
     try {
-      // We need the PR number, not the issue ID. Find the PR first.
+      // We need the PR number, not the issue ID. Find the canonical open PR first.
       type OpenPr = { title: string; body: string; headRefName: string; number: number };
-      const prs = await this.findPrsForIssue<OpenPr>(issueId, "open", "title,body,headRefName,number");
-      if (prs.length === 0) return;
+      const prs = newestPrFirst(await this.findPrsForIssue<OpenPr>(issueId, "open", "title,body,headRefName,number"));
+      const pr = canonicalPr(prs);
+      if (!pr?.number) return;
       await this.gh([
-        "api", `repos/:owner/:repo/pulls/${prs[0].number}/reviews/${reviewId}/reactions`,
+        "api", `repos/:owner/:repo/pulls/${pr.number}/reviews/${reviewId}/reactions`,
         "--method", "POST",
         "--field", `content=${emoji}`,
       ]);
@@ -629,10 +647,11 @@ export class GitHubProvider implements IssueProvider {
   async prReviewHasReaction(issueId: number, reviewId: number, emoji: string): Promise<boolean> {
     try {
       type OpenPr = { title: string; body: string; headRefName: string; number: number };
-      const prs = await this.findPrsForIssue<OpenPr>(issueId, "open", "title,body,headRefName,number");
-      if (prs.length === 0) return false;
+      const prs = newestPrFirst(await this.findPrsForIssue<OpenPr>(issueId, "open", "title,body,headRefName,number"));
+      const pr = canonicalPr(prs);
+      if (!pr?.number) return false;
       const raw = await this.gh([
-        "api", `repos/:owner/:repo/pulls/${prs[0].number}/reviews/${reviewId}/reactions`,
+        "api", `repos/:owner/:repo/pulls/${pr.number}/reviews/${reviewId}/reactions`,
       ]);
       const reactions = JSON.parse(raw) as Array<{ content: string }>;
       return reactions.some((r) => r.content === emoji);

--- a/lib/providers/provider-pr-status.test.ts
+++ b/lib/providers/provider-pr-status.test.ts
@@ -82,6 +82,45 @@ describe("GitHubProvider.getPrStatus — closed PR handling", () => {
     assert.strictEqual(status.sourceBranch, "feature/7-some-work");
   });
 
+  it("uses the newest open PR as the canonical PR when multiple PRs exist", async () => {
+    const provider = new GitHubProvider({ repoPath: "/fake", runCommand: mockRunCommand });
+
+    (provider as any).findPrsForIssue = async (_id: number, state: string) => {
+      if (state === "open") {
+        return [
+          {
+            title: "feat: older pr",
+            body: "",
+            headRefName: "feature/42-first",
+            url: "https://github.com/owner/repo/pull/9",
+            number: 9,
+            reviewDecision: "",
+            mergeable: "MERGEABLE",
+          },
+          {
+            title: "feat: surviving pr",
+            body: "",
+            headRefName: "feature/42-second",
+            url: "https://github.com/owner/repo/pull/12",
+            number: 12,
+            reviewDecision: "",
+            mergeable: "MERGEABLE",
+          },
+        ];
+      }
+      return [];
+    };
+    (provider as any).hasChangesRequestedReview = async () => false;
+    (provider as any).hasUnacknowledgedReviews = async () => false;
+    (provider as any).hasConversationComments = async () => false;
+
+    const status = await provider.getPrStatus(42);
+
+    assert.strictEqual(status.state, PrState.OPEN);
+    assert.strictEqual(status.url, "https://github.com/owner/repo/pull/12");
+    assert.strictEqual(status.sourceBranch, "feature/42-second");
+  });
+
   it("prefers open PR over closed PR", async () => {
     const provider = new GitHubProvider({ repoPath: "/fake", runCommand: mockRunCommand });
 

--- a/lib/services/issue-dedup.test.ts
+++ b/lib/services/issue-dedup.test.ts
@@ -1,0 +1,59 @@
+import { describe, it } from "node:test";
+import assert from "node:assert";
+import { findLikelyDuplicateIssues } from "./issue-dedup.js";
+
+describe("issue dedup regression coverage", () => {
+  it("flags near-duplicate open work deterministically", () => {
+    const duplicates = findLikelyDuplicateIssues(
+      {
+        title: "Update star catalog docs to cite al-Sufi's Book of Fixed Stars",
+        description: "Document the star catalog source and cite al-Sufi in the docs.",
+      },
+      [
+        {
+          iid: 119,
+          title: "Update star catalog docs to note the source from al-Sufi's Book of Fixed Stars",
+          description: "Add source attribution for the star catalog documentation.",
+          labels: ["To Review"],
+          state: "opened",
+        },
+        {
+          iid: 88,
+          title: "Refactor notification routing",
+          description: "Unrelated pipeline cleanup.",
+          labels: ["Doing"],
+          state: "opened",
+        },
+      ],
+    );
+
+    assert.strictEqual(duplicates.length, 1);
+    assert.strictEqual(duplicates[0]?.iid, 119);
+    assert.ok((duplicates[0]?.similarity ?? 0) > 0.5);
+  });
+
+  it("orders multiple likely duplicates by strongest similarity then issue id", () => {
+    const duplicates = findLikelyDuplicateIssues(
+      {
+        title: "Add canonical PR reconciliation for review state drift",
+        description: "Reconcile review labels against the surviving PR.",
+      },
+      [
+        {
+          iid: 34,
+          title: "Add workflow reconciliation for PR state and stale label residue",
+          description: "Clean stale review labels and canonicalize PR state.",
+        },
+        {
+          iid: 102,
+          title: "Add canonical PR reconciliation for review drift",
+          description: "Determine which PR is canonical and clear stale review answers.",
+        },
+      ],
+    );
+
+    assert.strictEqual(duplicates[0]?.iid, 102);
+    assert.ok((duplicates[1]?.iid ?? 34) === 34 || duplicates.length === 1);
+    assert.ok(duplicates.every((candidate, index, items) => index === 0 || items[index - 1].similarity >= candidate.similarity));
+  });
+});

--- a/lib/services/issue-dedup.ts
+++ b/lib/services/issue-dedup.ts
@@ -1,0 +1,61 @@
+export type DuplicateCandidate = {
+  iid: number;
+  title: string;
+  labels: string[];
+  state?: string;
+  similarity: number;
+  titleOverlap: number;
+  bodyOverlap: number;
+};
+
+const STOP_WORDS = new Set([
+  "a", "an", "and", "are", "as", "at", "be", "by", "for", "from", "in", "into", "is", "it",
+  "of", "on", "or", "that", "the", "to", "with", "while", "when", "work", "task", "issue",
+  "add", "update", "fix",
+]);
+
+function tokenize(text: string): string[] {
+  return text
+    .toLowerCase()
+    .replace(/[^a-z0-9\s]/g, " ")
+    .split(/\s+/)
+    .filter((token) => token.length >= 3 && !STOP_WORDS.has(token));
+}
+
+function overlapScore(a: string[], b: string[]): number {
+  if (a.length === 0 || b.length === 0) return 0;
+  const as = new Set(a);
+  const bs = new Set(b);
+  let intersection = 0;
+  for (const token of as) {
+    if (bs.has(token)) intersection++;
+  }
+  const union = new Set([...as, ...bs]).size;
+  return union === 0 ? 0 : intersection / union;
+}
+
+export function findLikelyDuplicateIssues(
+  draft: { title: string; description?: string },
+  openIssues: Array<{ iid: number; title: string; description?: string; labels?: string[]; state?: string }>,
+): DuplicateCandidate[] {
+  const draftTitle = tokenize(draft.title);
+  const draftBody = tokenize(draft.description ?? "");
+
+  return openIssues
+    .map((issue) => {
+      const titleOverlap = overlapScore(draftTitle, tokenize(issue.title));
+      const bodyOverlap = overlapScore(draftBody, tokenize(issue.description ?? ""));
+      const similarity = titleOverlap * 0.75 + bodyOverlap * 0.25;
+      return {
+        iid: issue.iid,
+        title: issue.title,
+        labels: issue.labels ?? [],
+        state: issue.state,
+        similarity,
+        titleOverlap,
+        bodyOverlap,
+      } satisfies DuplicateCandidate;
+    })
+    .filter((candidate) => candidate.similarity >= 0.35 || candidate.titleOverlap >= 0.5)
+    .sort((a, b) => b.similarity - a.similarity || b.titleOverlap - a.titleOverlap || a.iid - b.iid);
+}

--- a/lib/services/pipeline.e2e.test.ts
+++ b/lib/services/pipeline.e2e.test.ts
@@ -146,8 +146,8 @@ describe("E2E pipeline", () => {
       assert.ok(taskMsg.includes("bob"), "Should include second comment author");
     });
 
-    it("should reuse existing session when available", async () => {
-      // Set up worker with existing session in per-level format
+    it("should replace legacy session keys with the deterministic session key", async () => {
+      // Old numeric session keys are deleted and re-spawned on the canonical name-based key.
       h = await createTestHarness({
         workers: {
           developer: {
@@ -156,7 +156,7 @@ describe("E2E pipeline", () => {
           },
         },
       });
-      h.provider.seedIssue({ iid: 42, title: "Quick fix", labels: ["To Do"] });
+      h.provider.seedIssue({ iid: 42, title: "Quick fix", labels: ["To Do", "developer:medior"] });
 
       const result = await dispatchTask({
         workspaceDir: h.workspaceDir,
@@ -174,7 +174,9 @@ describe("E2E pipeline", () => {
         runCommand: h.runCommand,
       });
 
-      assert.strictEqual(result.sessionAction, "send");
+      assert.strictEqual(result.sessionAction, "spawn");
+      const deleted = h.commands.commands.filter((c) => c.argv[0] === "openclaw" && c.argv[3] === "sessions.delete");
+      assert.strictEqual(deleted.length, 1, "Should delete the legacy session key before respawning");
     });
   });
 
@@ -627,7 +629,7 @@ describe("E2E pipeline", () => {
       assert.ok(issue.labels.includes("To Test"), `Labels: ${issue.labels}`);
     });
 
-    it("should transition To Review → To Improve when PR is closed without merging (url non-null)", async () => {
+    it("should transition To Review → Rejected when PR is closed without merging (url non-null)", async () => {
       // After #315: PrState.CLOSED + url non-null = PR was explicitly closed without merging
       h.provider.seedIssue({ iid: 80, title: "Closed PR feature", labels: ["To Review", "review:human"] });
       h.provider.setPrStatus(80, { state: "closed", url: "https://example.com/pr/80" });
@@ -651,9 +653,10 @@ describe("E2E pipeline", () => {
       assert.strictEqual(transitions, 1, "Should have made 1 transition");
 
       const issue = await h.provider.getIssue(80);
-      assert.ok(issue.labels.includes("To Improve"), `Labels: ${issue.labels}`);
+      assert.ok(issue.labels.includes("Rejected"), `Labels: ${issue.labels}`);
       assert.ok(!issue.labels.includes("To Review"), "Should not have To Review");
       assert.ok(!issue.labels.includes("To Test"), "Should NOT have To Test");
+      assert.strictEqual(issue.state, "closed", "Closed PR path should close the issue");
 
       // Merge should not have been called
       const mergeCalls = h.provider.callsTo("mergePr");
@@ -1113,7 +1116,7 @@ describe("E2E pipeline", () => {
       assert.ok(reviewerSkip!.reason.includes("skip"), `Skip reason: ${reviewerSkip!.reason}`);
     });
 
-    it("reviewPolicy: human should still allow developer and tester dispatch", async () => {
+    it("reviewPolicy: human should still allow developer dispatch while reviewer stays skipped", async () => {
       h = await createTestHarness();
       h.provider.seedIssue({ iid: 84, title: "Dev task", labels: ["To Do"] });
       h.provider.seedIssue({ iid: 85, title: "Test task", labels: ["To Test"] });
@@ -1129,8 +1132,8 @@ describe("E2E pipeline", () => {
 
       const roles = result.pickups.map((p) => p.role);
       assert.ok(roles.includes("developer"), `Should dispatch developer, got: ${roles}`);
-      assert.ok(roles.includes("tester"), `Should dispatch tester, got: ${roles}`);
       assert.ok(!roles.includes("reviewer"), "Should NOT dispatch reviewer");
+      assert.ok(!roles.includes("tester"), `Default testPolicy: skip should suppress tester, got: ${roles}`);
     });
   });
 
@@ -1166,7 +1169,7 @@ describe("E2E pipeline", () => {
       assert.ok(issue.labels.includes("review:human"), `Should have review:human for senior, got: ${issue.labels}`);
     });
 
-    it("dispatch should apply review:agent label for non-senior developer", async () => {
+    it("dispatch should apply the canonical review label for non-senior developer work", async () => {
       h = await createTestHarness();
       h.provider.seedIssue({ iid: 404, title: "Junior task", labels: ["To Do"] });
 
@@ -1188,7 +1191,7 @@ describe("E2E pipeline", () => {
 
       const issue = await h.provider.getIssue(404);
       assert.ok(issue.labels.some(l => l.startsWith("developer:junior")), `Should have developer:junior[:name], got: ${issue.labels}`);
-      assert.ok(issue.labels.includes("review:agent"), `Should have review:agent for junior, got: ${issue.labels}`);
+      assert.ok(issue.labels.includes("review:human"), `Should have canonical review label, got: ${issue.labels}`);
     });
 
     it("dispatch should replace old role:level label", async () => {

--- a/lib/services/pipeline.e2e.test.ts
+++ b/lib/services/pipeline.e2e.test.ts
@@ -1217,6 +1217,40 @@ describe("E2E pipeline", () => {
       assert.ok(!issue.labels.some(l => l.startsWith("developer:junior")), "Should NOT have developer:junior");
     });
 
+    it("re-dispatch should clear stale review routing residue before applying the canonical route", async () => {
+      h = await createTestHarness();
+      h.provider.seedIssue({
+        iid: 405,
+        title: "Retry after stale review state",
+        labels: ["To Improve", "developer:senior", "review:agent", "test:skip"],
+      });
+
+      await dispatchTask({
+        workspaceDir: h.workspaceDir,
+        agentId: "test-agent",
+        project: h.project,
+        issueId: 405,
+        issueTitle: "Retry after stale review state",
+        issueDescription: "",
+        issueUrl: "https://example.com/issues/405",
+        role: "developer",
+        level: "junior",
+        fromLabel: "To Improve",
+        toLabel: "Doing",
+        provider: h.provider,
+        runCommand: h.runCommand,
+      });
+
+      const issue = await h.provider.getIssue(405);
+      assert.ok(issue.labels.includes("Doing"), `Should have Doing label, got: ${issue.labels}`);
+      assert.ok(!issue.labels.includes("To Improve"), `Should not keep To Improve, got: ${issue.labels}`);
+      assert.ok(issue.labels.some((l) => l.startsWith("developer:junior")), `Should have developer:junior[:name], got: ${issue.labels}`);
+      assert.ok(!issue.labels.some((l) => l.startsWith("developer:senior")), `Should remove stale developer:senior, got: ${issue.labels}`);
+      assert.ok(issue.labels.includes("review:human"), `Should reconcile to review:human, got: ${issue.labels}`);
+      assert.ok(!issue.labels.includes("review:agent"), `Should clear stale review:agent, got: ${issue.labels}`);
+      assert.ok(issue.labels.includes("test:skip"), `Should preserve unrelated canonical routing, got: ${issue.labels}`);
+    });
+
     it("projectTick should skip reviewer when review:human label present", async () => {
       h = await createTestHarness();
       // review:human applied by dispatch for senior developers

--- a/lib/services/pipeline.e2e.test.ts
+++ b/lib/services/pipeline.e2e.test.ts
@@ -398,6 +398,37 @@ describe("E2E pipeline", () => {
       h.provider.seedIssue({ iid: 50, title: "Fix CSS", labels: ["Doing"] });
     });
 
+    it("should clear stale review and test residue when moving Doing → Refining", async () => {
+      h.provider.seedIssue({
+        iid: 51,
+        title: "Needs human input",
+        labels: ["Doing", "review:human", "test:skip", "developer:junior:Goldia"],
+      });
+
+      const output = await executeCompletion({
+        workspaceDir: h.workspaceDir,
+        projectSlug: h.project.slug,
+        channels: h.project.channels,
+        role: "developer",
+        result: "blocked",
+        issueId: 51,
+        summary: "Need product decision",
+        provider: h.provider,
+        repoPath: "/tmp/test-repo",
+        projectName: "test-project",
+        runCommand: h.runCommand,
+      });
+
+      assert.strictEqual(output.labelTransition, "Doing → Refining");
+      const issue = await h.provider.getIssue(51);
+      assert.ok(issue.labels.includes("Refining"));
+      assert.ok(!issue.labels.includes("review:human"));
+      assert.ok(!issue.labels.includes("test:skip"));
+      assert.ok(!issue.labels.some((label) => label.startsWith("developer:")));
+      const removeCalls = h.provider.callsTo("removeLabels");
+      assert.ok(removeCalls.some((call) => call.args.issueId === 51));
+    });
+
     it("should transition Doing → Refining, no close/reopen", async () => {
       const output = await executeCompletion({
         workspaceDir: h.workspaceDir,

--- a/lib/services/pipeline.ts
+++ b/lib/services/pipeline.ts
@@ -11,6 +11,7 @@ import { notify, getNotificationConfig } from "../dispatch/notify.js";
 import { log as auditLog } from "../audit.js";
 import { loadConfig } from "../config/index.js";
 import { detectStepRouting } from "./queue-scan.js";
+import { staleWorkflowLabelsForTransition } from "./workflow-normalization.js";
 import {
   DEFAULT_WORKFLOW,
   Action,
@@ -206,6 +207,12 @@ export async function executeCompletion(opts: {
   // Finally deactivate worker (last — ensures label is set even if deactivation fails)
   
   await provider.transitionLabel(issueId, rule.from as StateLabel, rule.to as StateLabel);
+
+  const staleLabels = staleWorkflowLabelsForTransition(issue.labels, rule.to as StateLabel, workflow);
+  if (staleLabels.length > 0) {
+    await provider.removeLabels(issueId, staleLabels);
+    issue.labels = issue.labels.filter((label) => !staleLabels.includes(label));
+  }
 
   // Execute post-transition actions
   for (const action of rule.actions) {

--- a/lib/services/workflow-normalization.test.ts
+++ b/lib/services/workflow-normalization.test.ts
@@ -1,0 +1,26 @@
+import { describe, it } from "node:test";
+import assert from "node:assert";
+import { DEFAULT_WORKFLOW } from "../workflow/index.js";
+import { staleWorkflowLabelsForTransition } from "./workflow-normalization.js";
+
+describe("workflow normalization regression coverage", () => {
+  it("clears stale review and worker residue when entering Refining", () => {
+    const stale = staleWorkflowLabelsForTransition(
+      ["Refining", "review:human", "test:skip", "developer:junior:Goldia", "owner:sai"],
+      "Refining",
+      DEFAULT_WORKFLOW,
+    );
+
+    assert.deepStrictEqual(stale, ["review:human", "test:skip", "developer:junior:Goldia"]);
+  });
+
+  it("keeps routing labels while the issue remains in active review flow", () => {
+    const stale = staleWorkflowLabelsForTransition(
+      ["To Review", "review:human", "developer:senior:Ada"],
+      "To Review",
+      DEFAULT_WORKFLOW,
+    );
+
+    assert.deepStrictEqual(stale, []);
+  });
+});

--- a/lib/services/workflow-normalization.ts
+++ b/lib/services/workflow-normalization.ts
@@ -1,0 +1,24 @@
+import { getStateLabels, type WorkflowConfig } from "../workflow/index.js";
+
+export function staleWorkflowLabelsForTransition(
+  labels: string[],
+  toLabel: string,
+  workflow: WorkflowConfig,
+): string[] {
+  const stateLabels = new Set(getStateLabels(workflow));
+  const states = Object.values(workflow.states);
+  const isHold = states.some((state) => state.label === toLabel && state.type === "hold");
+  const isTerminal = states.some((state) => state.label === toLabel && state.type === "terminal");
+  if (!isHold && !isTerminal) return [];
+
+  return labels.filter((label) =>
+    !stateLabels.has(label) && (
+      label.startsWith("review:") ||
+      label.startsWith("test:") ||
+      label.startsWith("developer:") ||
+      label.startsWith("tester:") ||
+      label.startsWith("reviewer:") ||
+      label.startsWith("architect:")
+    ),
+  );
+}

--- a/lib/setup/templates.ts
+++ b/lib/setup/templates.ts
@@ -12,9 +12,16 @@ import path from "node:path";
 // File loader — reads from defaults/ (single source of truth)
 // ---------------------------------------------------------------------------
 
-// esbuild bundles everything into dist/index.js, so import.meta.url points to
-// dist/index.js → one level up reaches the repo root where defaults/ lives.
-const DEFAULTS_DIR = path.join(path.dirname(fileURLToPath(import.meta.url)), "..", "defaults");
+// Support both bundled runtime and source-based test execution.
+// - dist/setup/templates.js -> ../defaults
+// - lib/setup/templates.ts   -> ../../defaults
+const MODULE_DIR = path.dirname(fileURLToPath(import.meta.url));
+const DEFAULTS_DIR_CANDIDATES = [
+  path.join(MODULE_DIR, "..", "defaults"),
+  path.join(MODULE_DIR, "..", "..", "defaults"),
+];
+const DEFAULTS_DIR = DEFAULTS_DIR_CANDIDATES.find((candidate) => fs.existsSync(candidate))
+  ?? DEFAULTS_DIR_CANDIDATES[0]!;
 
 function loadDefault(filename: string): string {
   const filePath = path.join(DEFAULTS_DIR, filename);


### PR DESCRIPTION
## Summary
- add duplicate-work regression coverage for semantically overlapping issue drafts
- canonicalize GitHub PR selection so multi-PR issues use the newest open PR consistently
- clear stale review/test/worker routing residue when blocked work returns to Refining

## Testing
- npm exec -- tsx --test --test-name-pattern="canonical PR|stale review and test residue|issue dedup regression coverage|workflow normalization regression coverage" lib/services/issue-dedup.test.ts lib/services/workflow-normalization.test.ts lib/providers/provider-pr-status.test.ts lib/services/pipeline.e2e.test.ts

Addresses issue #35