### PR TITLE
fix: add workflow integrity guardrails

### DIFF
--- a/lib/providers/github.ts
+++ b/lib/providers/github.ts
@@ -8,6 +8,7 @@ import {
   type IssueComment,
   type PrStatus,
   type PrReviewComment,
+  type IssuePrSummary,
   PrState,
 } from "./provider.js";
 import type { RunCommand } from "../context.js";
@@ -353,6 +354,50 @@ export class GitHubProvider implements IssueProvider {
     if (terminal.ambiguous || terminal.state !== PrState.MERGED) return terminal;
     const mergedPr = merged.find((pr) => pr.url === terminal.url);
     return { ...terminal, state: mergedPr?.reviewDecision === "APPROVED" ? PrState.APPROVED : PrState.MERGED };
+  }
+
+
+  async listPrsForIssue(issueId: number): Promise<IssuePrSummary[]> {
+    const summaries: IssuePrSummary[] = [];
+
+    type OpenPr = { title: string; body: string; headRefName: string; url: string; number: number; reviewDecision: string; mergeable: string };
+    const open = await this.findPrsForIssue<OpenPr>(issueId, "open", "title,body,headRefName,url,number,reviewDecision,mergeable");
+    for (const pr of open) {
+      let state: PrState;
+      if (pr.reviewDecision === "APPROVED") state = PrState.APPROVED;
+      else if (pr.reviewDecision === "CHANGES_REQUESTED") state = PrState.CHANGES_REQUESTED;
+      else if (await this.hasChangesRequestedReview(pr.number)) state = PrState.CHANGES_REQUESTED;
+      else if (await this.hasUnacknowledgedReviews(pr.number)) state = PrState.HAS_COMMENTS;
+      else state = (await this.hasConversationComments(pr.number)) ? PrState.HAS_COMMENTS : PrState.OPEN;
+
+      const mergeable = pr.mergeable === "CONFLICTING" ? false
+        : pr.mergeable === "MERGEABLE" ? true
+        : undefined;
+      summaries.push({ state, url: pr.url, title: pr.title, sourceBranch: pr.headRefName, mergeable });
+    }
+
+    type MergedPr = { title: string; body: string; headRefName: string; url: string; reviewDecision: string | null };
+    const merged = await this.findPrsForIssue<MergedPr>(issueId, "merged", "title,body,headRefName,url,reviewDecision");
+    for (const pr of merged) {
+      summaries.push({
+        state: pr.reviewDecision === "APPROVED" ? PrState.APPROVED : PrState.MERGED,
+        url: pr.url,
+        title: pr.title,
+        sourceBranch: pr.headRefName,
+      });
+    }
+
+    const allPrs = await this.findPrsViaTimeline(issueId, "all");
+    for (const pr of allPrs ?? []) {
+      if (pr.state === "CLOSED") summaries.push({ state: PrState.CLOSED, url: pr.url, title: pr.title, sourceBranch: pr.headRefName });
+    }
+
+    const seen = new Set<string>();
+    return summaries.filter((pr) => {
+      if (!pr.url || seen.has(pr.url)) return false;
+      seen.add(pr.url);
+      return true;
+    });
   }
 
   /**

--- a/lib/providers/gitlab.ts
+++ b/lib/providers/gitlab.ts
@@ -8,6 +8,7 @@ import {
   type IssueComment,
   type PrStatus,
   type PrReviewComment,
+  type IssuePrSummary,
   PrState,
 } from "./provider.js";
 import type { RunCommand } from "../context.js";
@@ -232,6 +233,32 @@ export class GitLabProvider implements IssueProvider {
         url: mr.web_url, title: mr.title, sourceBranch: mr.source_branch, state: "CLOSED", mergedAt: mr.merged_at, number: mr.iid,
       })),
     });
+  }
+
+
+  async listPrsForIssue(issueId: number): Promise<IssuePrSummary[]> {
+    const mrs = await this.getRelatedMRs(issueId);
+    const summaries: IssuePrSummary[] = [];
+    for (const mr of mrs) {
+      if (mr.state === "opened") {
+        const approved = await this.isMrApproved(mr.iid);
+        let state: PrState;
+        if (approved) state = PrState.APPROVED;
+        else if (await this.hasUnresolvedDiscussions(mr.iid)) state = PrState.CHANGES_REQUESTED;
+        else state = (await this.hasConversationComments(mr.iid)) ? PrState.HAS_COMMENTS : PrState.OPEN;
+        const mergeable = await this.isMrMergeable(mr.iid);
+        summaries.push({ state, url: mr.web_url, title: mr.title, sourceBranch: mr.source_branch, mergeable });
+        continue;
+      }
+      if (mr.state === "merged") {
+        summaries.push({ state: PrState.MERGED, url: mr.web_url, title: mr.title, sourceBranch: mr.source_branch });
+        continue;
+      }
+      if (mr.state === "closed") {
+        summaries.push({ state: PrState.CLOSED, url: mr.web_url, title: mr.title, sourceBranch: mr.source_branch });
+      }
+    }
+    return summaries;
   }
 
   /** Check if an MR has unresolved discussion threads (proxy for changes requested). */

--- a/lib/providers/provider.ts
+++ b/lib/providers/provider.ts
@@ -63,6 +63,15 @@ export type PrStatus = {
   }>;
 };
 
+export type IssuePrSummary = {
+  url: string;
+  title?: string;
+  sourceBranch?: string;
+  state: PrState;
+  mergeable?: boolean;
+  isCanonical?: boolean;
+};
+
 /** A review comment on a PR/MR. */
 export type PrReviewComment = {
   id: number;
@@ -97,6 +106,7 @@ export interface IssueProvider {
   reopenIssue(issueId: number): Promise<void>;
   getMergedMRUrl(issueId: number): Promise<string | null>;
   getPrStatus(issueId: number): Promise<PrStatus>;
+  listPrsForIssue(issueId: number): Promise<IssuePrSummary[]>;
   mergePr(issueId: number): Promise<void>;
   getPrDiff(issueId: number): Promise<string | null>;
   /** Get review comments on the PR linked to an issue. */

--- a/lib/services/heartbeat/health-orphan-pr-state.test.ts
+++ b/lib/services/heartbeat/health-orphan-pr-state.test.ts
@@ -1,0 +1,85 @@
+import { describe, it } from "node:test";
+import assert from "node:assert";
+import { tmpdir } from "node:os";
+import { mkdtemp, rm } from "node:fs/promises";
+import { join } from "node:path";
+import { scanOrphanedLabels } from "./health.js";
+import { TestProvider } from "../../testing/test-provider.js";
+import { DEFAULT_WORKFLOW } from "../../workflow/index.js";
+import { PrState } from "../../providers/provider.js";
+import type { Project } from "../../projects/types.js";
+
+function project(): Project {
+  return {
+    slug: "devclaw",
+    name: "devclaw",
+    repo: "/tmp/repo",
+    groupName: "DevClaw",
+    deployUrl: "",
+    baseBranch: "main",
+    deployBranch: "main",
+    channels: [],
+    workers: {
+      developer: { levels: { junior: [{ active: false, issueId: null, sessionKey: null, startTime: null }] } },
+    },
+  };
+}
+
+describe("scanOrphanedLabels PR-state reconciliation", () => {
+  it("moves orphaned developer work with an open PR back to To Review", async () => {
+    const workspaceDir = await mkdtemp(join(tmpdir(), "health-orphan-open-pr-"));
+    try {
+      const provider = new TestProvider();
+      provider.seedIssue({ iid: 42, title: "Open PR", labels: ["Doing"] });
+      provider.setPrStatus(42, { state: PrState.OPEN, url: "https://github.com/test/repo/pull/42" });
+
+      const fixes = await scanOrphanedLabels({
+        workspaceDir,
+        projectSlug: "devclaw",
+        project: project(),
+        role: "developer",
+        autoFix: true,
+        provider,
+        workflow: DEFAULT_WORKFLOW,
+      });
+
+      assert.strictEqual(fixes[0]?.labelReverted, "Doing → To Review");
+      assert.ok((await provider.getIssue(42)).labels.includes("To Review"));
+    } finally {
+      await rm(workspaceDir, { recursive: true, force: true });
+    }
+  });
+
+  it("moves orphaned developer work with ambiguous PRs to To Improve", async () => {
+    const workspaceDir = await mkdtemp(join(tmpdir(), "health-orphan-ambiguous-pr-"));
+    try {
+      const provider = new TestProvider();
+      provider.seedIssue({ iid: 43, title: "Ambiguous PRs", labels: ["Doing"] });
+      provider.setPrStatus(43, {
+        state: PrState.OPEN,
+        url: "https://github.com/test/repo/pull/43",
+        ambiguous: true,
+        reason: "multiple_open_prs",
+        candidates: [
+          { url: "https://github.com/test/repo/pull/41", state: "OPEN" },
+          { url: "https://github.com/test/repo/pull/43", state: "OPEN" },
+        ],
+      });
+
+      const fixes = await scanOrphanedLabels({
+        workspaceDir,
+        projectSlug: "devclaw",
+        project: project(),
+        role: "developer",
+        autoFix: true,
+        provider,
+        workflow: DEFAULT_WORKFLOW,
+      });
+
+      assert.strictEqual(fixes[0]?.labelReverted, "Doing → To Improve");
+      assert.ok((await provider.getIssue(43)).labels.includes("To Improve"));
+    } finally {
+      await rm(workspaceDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/lib/services/heartbeat/health.test.ts
+++ b/lib/services/heartbeat/health.test.ts
@@ -102,7 +102,7 @@ describe("scanOrphanedLabels", () => {
       });
     });
 
-    it("should revert to 'To Improve' when issue has open PR (feedback cycle)", async () => {
+    it("should revert to 'To Review' when issue has an open PR awaiting review", async () => {
       h.provider.seedIssue({ iid: 42, title: "Test issue", labels: ["Doing"] });
       h.provider.setPrStatus(42, { state: PrState.OPEN, url: "https://github.com/test/pr/1" });
 
@@ -118,11 +118,11 @@ describe("scanOrphanedLabels", () => {
 
       assert.strictEqual(fixes.length, 1);
       assert.strictEqual(fixes[0]!.fixed, true);
-      assert.strictEqual(fixes[0]!.labelReverted, "Doing → To Improve");
+      assert.strictEqual(fixes[0]!.labelReverted, "Doing → To Review");
 
-      // Verify issue now has "To Improve" label
+      // Verify issue now has "To Review" label
       const issue = await h.provider.getIssue(42);
-      assert.ok(issue.labels.includes("To Improve"), `Expected "To Improve", got: ${issue.labels}`);
+      assert.ok(issue.labels.includes("To Review"), `Expected "To Review", got: ${issue.labels}`);
     });
 
     it("should revert to 'To Do' when issue has no PR (fresh task)", async () => {
@@ -148,7 +148,7 @@ describe("scanOrphanedLabels", () => {
       assert.ok(issue.labels.includes("To Do"), `Expected "To Do", got: ${issue.labels}`);
     });
 
-    it("should revert to 'To Improve' when PR is already approved but the worker state is stale", async () => {
+    it("should revert to 'To Review' when PR is already approved but the worker state is stale", async () => {
       h.provider.seedIssue({ iid: 42, title: "Test issue", labels: ["Doing"] });
       h.provider.setPrStatus(42, { state: PrState.APPROVED, url: "https://github.com/test/pr/1" });
 
@@ -164,7 +164,7 @@ describe("scanOrphanedLabels", () => {
 
       assert.strictEqual(fixes.length, 1);
       assert.strictEqual(fixes[0]!.fixed, true);
-      assert.strictEqual(fixes[0]!.labelReverted, "Doing → To Improve");
+      assert.strictEqual(fixes[0]!.labelReverted, "Doing → To Review");
     });
 
     it("should revert to 'To Improve' when PR has changes_requested", async () => {
@@ -189,6 +189,34 @@ describe("scanOrphanedLabels", () => {
     it("should revert to 'To Improve' when PR has comments (HAS_COMMENTS)", async () => {
       h.provider.seedIssue({ iid: 42, title: "Test issue", labels: ["Doing"] });
       h.provider.setPrStatus(42, { state: PrState.HAS_COMMENTS, url: "https://github.com/test/pr/1" });
+
+      const fixes = await scanOrphanedLabels({
+        workspaceDir: h.workspaceDir,
+        projectSlug: h.project.slug,
+        project: h.project,
+        role: "developer",
+        autoFix: true,
+        provider: h.provider,
+        workflow: h.workflow,
+      });
+
+      assert.strictEqual(fixes.length, 1);
+      assert.strictEqual(fixes[0]!.fixed, true);
+      assert.strictEqual(fixes[0]!.labelReverted, "Doing → To Improve");
+    });
+
+    it("should revert to 'To Improve' when multiple PRs make the issue ambiguous", async () => {
+      h.provider.seedIssue({ iid: 42, title: "Test issue", labels: ["Doing"] });
+      h.provider.setPrStatus(42, {
+        state: PrState.OPEN,
+        url: "https://github.com/test/pr/2",
+        ambiguous: true,
+        reason: "multiple_open_prs",
+        candidates: [
+          { url: "https://github.com/test/pr/1", state: "OPEN" },
+          { url: "https://github.com/test/pr/2", state: "OPEN" },
+        ],
+      });
 
       const fixes = await scanOrphanedLabels({
         workspaceDir: h.workspaceDir,

--- a/lib/services/heartbeat/health.ts
+++ b/lib/services/heartbeat/health.ts
@@ -45,6 +45,7 @@ import {
   getCurrentStateLabel,
   isOwnedByOrUnclaimed,
   isFeedbackState,
+  hasReviewCheck,
   type WorkflowConfig,
   type Role,
 } from "../../workflow/index.js";
@@ -141,19 +142,32 @@ async function resolveOrphanRevertLabel(
   defaultQueueLabel: string,
   workflow: WorkflowConfig,
 ): Promise<string> {
+  const queueLabels = getQueueLabels(workflow, role);
+  const feedbackLabel = queueLabels.find((l) => isFeedbackState(workflow, l));
+  const reviewQueueLabel = hasReviewCheck(workflow, "reviewer")
+    ? getQueueLabels(workflow, "reviewer")[0] ?? null
+    : null;
+
   try {
     const prStatus = await provider.getPrStatus(issueId);
-    // If a PR exists (open, approved, changes requested, or has comments),
-    // the issue was in a feedback cycle — revert to the feedback queue.
+
+    if (prStatus.ambiguous) {
+      return feedbackLabel ?? defaultQueueLabel;
+    }
+
+    if (prStatus.url && (
+      prStatus.state === PrState.CHANGES_REQUESTED ||
+      prStatus.state === PrState.HAS_COMMENTS ||
+      prStatus.mergeable === false
+    )) {
+      return feedbackLabel ?? defaultQueueLabel;
+    }
+
     if (prStatus.url && (
       prStatus.state === PrState.OPEN ||
-      prStatus.state === PrState.APPROVED ||
-      prStatus.state === PrState.CHANGES_REQUESTED ||
-      prStatus.state === PrState.HAS_COMMENTS
-    )) {
-      const queueLabels = getQueueLabels(workflow, role);
-      const feedbackLabel = queueLabels.find((l) => isFeedbackState(workflow, l));
-      if (feedbackLabel) return feedbackLabel;
+      prStatus.state === PrState.APPROVED
+    ) && reviewQueueLabel) {
+      return reviewQueueLabel;
     }
   } catch {
     // Best-effort — fall back to default queue on API failure

--- a/lib/services/heartbeat/review.ts
+++ b/lib/services/heartbeat/review.ts
@@ -17,6 +17,7 @@ import {
 import { detectStepRouting } from "../queue-scan.js";
 import type { RunCommand } from "../../context.js";
 import { log as auditLog } from "../../audit.js";
+import { summarizePrDrift } from "../../workflow/integrity.js";
 
 /**
  * Scan review-type states and transition issues whose PR check condition is met.
@@ -64,6 +65,18 @@ export async function reviewPass(opts: {
       // from historical comments.
       const isManaged = await provider.issueHasReaction(issue.iid, "eyes");
       if (!isManaged) continue;
+
+      const linkedPrs = await provider.listPrsForIssue(issue.iid);
+      const prDrift = summarizePrDrift(linkedPrs);
+      if (prDrift.hasMultipleActive && prDrift.canonical) {
+        await auditLog(workspaceDir, "review_drift_detected", {
+          project: projectName,
+          issueId: issue.iid,
+          reason: "multiple_active_prs",
+          canonicalPr: prDrift.canonical.url,
+          activePrs: prDrift.active.map((pr) => pr.url),
+        });
+      }
 
       const status = await provider.getPrStatus(issue.iid);
 

--- a/lib/testing/test-provider.ts
+++ b/lib/testing/test-provider.ts
@@ -10,6 +10,7 @@ import type {
   StateLabel,
   IssueComment,
   PrStatus,
+  IssuePrSummary,
 } from "../providers/provider.js";
 import { getStateLabels } from "../workflow/index.js";
 import { DEFAULT_WORKFLOW, type WorkflowConfig } from "../workflow/index.js";
@@ -64,6 +65,8 @@ export class TestProvider implements IssueProvider {
   labels = new Map<string, string>();
   /** PR status overrides per issue. Default: { state: "closed", url: null }. */
   prStatuses = new Map<number, PrStatus>();
+  /** Linked PR summaries per issue. */
+  issuePrs = new Map<number, IssuePrSummary[]>();
   /** Merged MR URLs per issue. */
   mergedMrUrls = new Map<number, string>();
   /** Issue IDs where mergePr should fail (simulates merge conflicts). */
@@ -103,6 +106,30 @@ export class TestProvider implements IssueProvider {
   /** Set PR status for an issue (used by review pass tests). */
   setPrStatus(issueId: number, status: PrStatus): void {
     this.prStatuses.set(issueId, status);
+    if (status.url) {
+      this.issuePrs.set(issueId, [{
+        url: status.url,
+        title: status.title,
+        sourceBranch: status.sourceBranch,
+        state: status.state,
+        mergeable: status.mergeable,
+        isCanonical: true,
+      }]);
+    }
+  }
+
+  setIssuePrs(issueId: number, prs: IssuePrSummary[]): void {
+    this.issuePrs.set(issueId, prs);
+    const canonical = prs.find((pr) => pr.isCanonical) ?? prs[0];
+    if (canonical) {
+      this.prStatuses.set(issueId, {
+        url: canonical.url,
+        title: canonical.title,
+        sourceBranch: canonical.sourceBranch,
+        state: canonical.state,
+        mergeable: canonical.mergeable,
+      });
+    }
   }
 
   /** Get calls filtered by method name. */
@@ -123,6 +150,7 @@ export class TestProvider implements IssueProvider {
     this.comments.clear();
     this.labels.clear();
     this.prStatuses.clear();
+    this.issuePrs.clear();
     this.mergedMrUrls.clear();
     this.mergePrFailures.clear();
     this.prDiffs.clear();
@@ -246,6 +274,10 @@ export class TestProvider implements IssueProvider {
   async getPrStatus(issueId: number): Promise<PrStatus> {
     this.calls.push({ method: "getPrStatus", args: { issueId } });
     return this.prStatuses.get(issueId) ?? { state: "closed", url: null };
+  }
+
+  async listPrsForIssue(issueId: number): Promise<IssuePrSummary[]> {
+    return this.issuePrs.get(issueId) ?? [];
   }
 
   async mergePr(issueId: number): Promise<void> {

--- a/lib/tools/tasks/task-start.ts
+++ b/lib/tools/tasks/task-start.ts
@@ -90,6 +90,16 @@ Examples:
         await provider.transitionLabel(issueId, currentLabel, targetLabel);
       }
 
+      // Clear stale review/test routing labels when resuming from hold states.
+      // These are recomputed later from the canonical workflow path and can otherwise
+      // trap issues in contradictory review/test states.
+      if (currentState.type === StateType.HOLD) {
+        const staleRouting = issue.labels.filter((label) => label.startsWith("review:") || label.startsWith("test:"));
+        if (staleRouting.length > 0) {
+          await provider.removeLabels(issueId, staleRouting);
+        }
+      }
+
       // Apply level hint label if provided
       const targetRole = targetState.role;
       if (levelHint && targetRole) {

--- a/lib/tools/worker/work-finish.test.ts
+++ b/lib/tools/worker/work-finish.test.ts
@@ -72,11 +72,13 @@ describe("work_finish PR validation", () => {
         prHasReaction: () => Promise<boolean>;
         reactToPr: (_issueId: number, _emoji: string) => Promise<void>;
         getPrStatus: (_issueId: number) => Promise<any>;
+        listPrsForIssue: (_issueId: number) => Promise<any[]>;
       };
       let reacted = false;
       provider.prHasReaction = async () => false;
       provider.reactToPr = async () => { reacted = true; };
       provider.getPrStatus = async () => ({ state: PrState.CLOSED, url: null });
+      provider.listPrsForIssue = async () => [{ state: PrState.OPEN, url: "https://github.com/test/repo/pull/105", isCanonical: true }];
 
       const runCommand = async (args: string[]) => {
         if (args[0] === "git") return { stdout: "feature/existing-pr\n", stderr: "", exitCode: 0 };
@@ -106,6 +108,7 @@ describe("work_finish PR validation", () => {
         prHasReaction: () => Promise<boolean>;
         reactToPr: (_issueId: number, _emoji: string) => Promise<void>;
         getPrStatus: (_issueId: number) => Promise<any>;
+        listPrsForIssue: (_issueId: number) => Promise<any[]>;
       };
       let issueLookupCount = 0;
       provider.prHasReaction = async () => true;
@@ -114,6 +117,7 @@ describe("work_finish PR validation", () => {
         issueLookupCount++;
         return { state: PrState.CLOSED, url: null };
       };
+      provider.listPrsForIssue = async () => [{ state: PrState.OPEN, url: "https://github.com/test/repo/pull/105", isCanonical: true }];
 
       const runCommand = async (args: string[]) => {
         if (args[0] === "git") return { stdout: "feature/existing-pr\n", stderr: "", exitCode: 0 };
@@ -199,23 +203,17 @@ describe("work_finish PR validation", () => {
       assert.equal(provider.callsTo("getPrStatus").length, 1);
     });
 
-    it("rejects completion when multiple open PRs make the canonical PR ambiguous", async () => {
+    it("rejects completion when multiple active PRs are linked to the issue", async () => {
       const provider = new TestProvider();
-      provider.setPrStatus(42, {
-        state: PrState.OPEN,
-        url: "https://github.com/test/repo/pull/43",
-        ambiguous: true,
-        reason: "multiple_open_prs",
-        candidates: [
-          { url: "https://github.com/test/repo/pull/42", state: "OPEN", sourceBranch: "feature/42-a" },
-          { url: "https://github.com/test/repo/pull/43", state: "OPEN", sourceBranch: "feature/42-b" },
-        ],
-      });
+      provider.setIssuePrs(42, [
+        { state: PrState.OPEN, url: "https://github.com/test/repo/pull/38", sourceBranch: "feature/42-old", mergeable: false },
+        { state: PrState.OPEN, url: "https://github.com/test/repo/pull/39", sourceBranch: "feature/42-new", mergeable: true, isCanonical: true },
+      ]);
 
-      const runCommand = async () => ({ stdout: "feature/42-b\n", stderr: "", exitCode: 0 });
+      const runCommand = async () => ({ stdout: "feature/42-new\n", stderr: "", exitCode: 0 });
       await assert.rejects(
         () => validatePrExistsForDeveloper(42, tempDir, provider as any, runCommand as any, tempDir, "devclaw"),
-        /multiple PRs are linked to this issue/,
+        /multiple active PRs/,
       );
     });
 
@@ -226,10 +224,12 @@ describe("work_finish PR validation", () => {
         prHasReaction: () => Promise<boolean>;
         reactToPr: (_issueId: number, _emoji: string) => Promise<void>;
         getPrStatus: (_issueId: number) => Promise<any>;
+        listPrsForIssue: (_issueId: number) => Promise<any[]>;
       };
       provider.prHasReaction = async () => true;
       provider.reactToPr = async () => {};
       provider.getPrStatus = async () => ({ state: PrState.CLOSED, url: null });
+      provider.listPrsForIssue = async () => [{ state: PrState.OPEN, url: "https://github.com/test/repo/pull/105", isCanonical: true, mergeable: false }];
 
       const runCommand = async (args: string[]) => {
         if (args[0] === "git") return { stdout: "feature/existing-pr\n", stderr: "", exitCode: 0 };

--- a/lib/tools/worker/work-finish.ts
+++ b/lib/tools/worker/work-finish.ts
@@ -21,6 +21,7 @@ import { getAllRoleIds, isValidResult, getCompletionResults } from "../../roles/
 import { loadWorkflow } from "../../workflow/index.js";
 import { GitHubProvider } from "../../providers/github.js";
 import { PrState, type PrStatus } from "../../providers/provider.js";
+import { summarizePrDrift } from "../../workflow/integrity.js";
 
 /**
  * Get the current git branch name.
@@ -245,6 +246,24 @@ export async function validatePrExistsForDeveloper(
         `Please create a PR first:\n` +
         `  gh pr create --base main --head ${branchName} --title "..." --body "..."\n\n` +
         `Then call work_finish again.`,
+      );
+    }
+
+    const linkedPrs = await provider.listPrsForIssue(issueId);
+    const drift = summarizePrDrift(linkedPrs);
+    if (drift.hasMultipleActive && drift.canonical) {
+      await auditLog(workspaceDir, "work_finish_rejected", {
+        project: projectSlug,
+        issue: issueId,
+        reason: "multiple_active_prs",
+        canonicalPr: drift.canonical.url,
+        activePrs: drift.active.map((pr) => pr.url),
+      });
+      throw new Error(
+        `Cannot complete work_finish(done) while multiple active PRs are linked to issue #${issueId}.\n\n` +
+        `Canonical PR: ${drift.canonical.url}\n` +
+        `Active PRs:\n${drift.active.map((pr) => `  - ${pr.url} (${pr.state}${pr.mergeable === false ? ", conflicting" : ""})`).join("\n")}\n\n` +
+        `Please close or supersede the older PR before marking the issue done.`,
       );
     }
 

--- a/lib/workflow/integrity.test.ts
+++ b/lib/workflow/integrity.test.ts
@@ -1,0 +1,67 @@
+import { describe, it } from "node:test";
+import assert from "node:assert";
+import { PrState, type Issue } from "../providers/provider.js";
+import { DEFAULT_WORKFLOW } from "./index.js";
+import {
+  findSemanticDuplicateIssues,
+  getNonTerminalStateLabels,
+  summarizePrDrift,
+  tokenizeSemanticText,
+} from "./integrity.js";
+
+describe("workflow integrity helpers", () => {
+  it("finds semantically overlapping open issues", () => {
+    const issues: Issue[] = [
+      {
+        iid: 119,
+        title: "Update star catalog docs to note the source from al-Sufi's Book of Fixed Stars",
+        description: "Document the provenance for the star catalog.",
+        labels: ["Planning"],
+        state: "opened",
+        web_url: "https://example.com/issues/119",
+      },
+      {
+        iid: 131,
+        title: "Remove legacy publish reference",
+        description: "Unrelated cleanup",
+        labels: ["Planning"],
+        state: "opened",
+        web_url: "https://example.com/issues/131",
+      },
+    ];
+
+    const duplicates = findSemanticDuplicateIssues({
+      title: "Update star catalog docs to cite al-Sufi's Book of Fixed Stars",
+      description: "Clarify the same provenance in the docs",
+    }, issues);
+
+    assert.equal(duplicates[0]?.issue.iid, 119);
+    assert.ok((duplicates[0]?.score ?? 0) >= 0.45);
+  });
+
+  it("ignores generic stop words while tokenizing", () => {
+    const tokens = tokenizeSemanticText("Update the docs to cite the source from al-Sufi");
+    assert.ok(tokens.includes("alsufi"));
+    assert.ok(!tokens.includes("update"));
+    assert.ok(!tokens.includes("docs"));
+  });
+
+  it("returns all non-terminal workflow labels", () => {
+    const labels = getNonTerminalStateLabels(DEFAULT_WORKFLOW);
+    assert.ok(labels.includes("Planning"));
+    assert.ok(labels.includes("To Review"));
+    assert.ok(!labels.includes("Done"));
+  });
+
+  it("marks the strongest linked PR as canonical and detects duplicate active PRs", () => {
+    const drift = summarizePrDrift([
+      { state: PrState.OPEN, url: "https://example.com/pr/38", mergeable: false },
+      { state: PrState.APPROVED, url: "https://example.com/pr/39", mergeable: true },
+      { state: PrState.CLOSED, url: "https://example.com/pr/40" },
+    ]);
+
+    assert.equal(drift.canonical?.url, "https://example.com/pr/39");
+    assert.equal(drift.hasMultipleActive, true);
+    assert.equal(drift.hasDirtyReviewState, true);
+  });
+});

--- a/lib/workflow/integrity.ts
+++ b/lib/workflow/integrity.ts
@@ -1,0 +1,108 @@
+import { PrState, type Issue, type IssuePrSummary } from "../providers/provider.js";
+import { StateType, type WorkflowConfig } from "./types.js";
+
+const STOP_WORDS = new Set([
+  "a", "an", "and", "are", "be", "by", "cite", "cites", "citing", "clarify", "docs", "doc", "documentation",
+  "for", "from", "in", "into", "is", "note", "the", "to", "update", "with",
+]);
+
+export type DuplicateCandidate = {
+  issue: Issue;
+  score: number;
+  overlappingTokens: string[];
+};
+
+function normalizeToken(token: string): string {
+  let value = token.toLowerCase().replace(/[^a-z0-9]+/g, "");
+  if (value.endsWith("ing") && value.length > 5) value = value.slice(0, -3);
+  else if (value.endsWith("ed") && value.length > 4) value = value.slice(0, -2);
+  else if (value.endsWith("es") && value.length > 4) value = value.slice(0, -2);
+  else if (value.endsWith("s") && value.length > 3) value = value.slice(0, -1);
+  return value;
+}
+
+export function tokenizeSemanticText(text: string): string[] {
+  return [...new Set(
+    text
+      .split(/\s+/)
+      .map(normalizeToken)
+      .filter((token) => token.length >= 3 && !STOP_WORDS.has(token)),
+  )];
+}
+
+export function semanticSimilarity(a: string, b: string): { score: number; overlappingTokens: string[] } {
+  const aTokens = tokenizeSemanticText(a);
+  const bTokens = tokenizeSemanticText(b);
+  if (aTokens.length === 0 || bTokens.length === 0) return { score: 0, overlappingTokens: [] };
+
+  const bSet = new Set(bTokens);
+  const overlap = aTokens.filter((token) => bSet.has(token));
+  const union = new Set([...aTokens, ...bTokens]);
+  return {
+    score: overlap.length / union.size,
+    overlappingTokens: overlap.sort(),
+  };
+}
+
+export function findSemanticDuplicateIssues(
+  proposed: { title: string; description?: string },
+  openIssues: Issue[],
+  opts?: { minScore?: number },
+): DuplicateCandidate[] {
+  const proposedText = [proposed.title, proposed.description ?? ""].join(" ").trim();
+  const minScore = opts?.minScore ?? 0.45;
+
+  return openIssues
+    .map((issue) => {
+      const compared = semanticSimilarity(proposedText, [issue.title, issue.description].join(" "));
+      const exactTitleBoost = issue.title.trim().toLowerCase() === proposed.title.trim().toLowerCase() ? 1 : 0;
+      return {
+        issue,
+        score: Math.max(compared.score, exactTitleBoost),
+        overlappingTokens: compared.overlappingTokens,
+      };
+    })
+    .filter((candidate) => candidate.score >= minScore)
+    .sort((a, b) => b.score - a.score || a.issue.iid - b.issue.iid);
+}
+
+export function getNonTerminalStateLabels(workflow: WorkflowConfig): string[] {
+  return Object.values(workflow.states)
+    .filter((state) => state.type !== StateType.TERMINAL)
+    .map((state) => state.label);
+}
+
+const PR_PRIORITY: Record<string, number> = {
+  [PrState.APPROVED]: 5,
+  [PrState.OPEN]: 4,
+  [PrState.HAS_COMMENTS]: 3,
+  [PrState.CHANGES_REQUESTED]: 2,
+  [PrState.MERGED]: 1,
+  [PrState.CLOSED]: 0,
+};
+
+export function rankIssuePrs(prs: IssuePrSummary[]): IssuePrSummary[] {
+  return [...prs].sort((a, b) => {
+    const byState = (PR_PRIORITY[b.state] ?? -1) - (PR_PRIORITY[a.state] ?? -1);
+    if (byState !== 0) return byState;
+    if ((a.mergeable ?? false) !== (b.mergeable ?? false)) return Number(b.mergeable ?? false) - Number(a.mergeable ?? false);
+    return a.url.localeCompare(b.url);
+  }).map((pr, index) => ({ ...pr, isCanonical: index === 0 }));
+}
+
+export function summarizePrDrift(prs: IssuePrSummary[]): {
+  canonical: IssuePrSummary | null;
+  active: IssuePrSummary[];
+  hasMultipleActive: boolean;
+  hasDirtyReviewState: boolean;
+} {
+  const ranked = rankIssuePrs(prs);
+  const active = ranked.filter((pr) => pr.state !== PrState.CLOSED && pr.state !== PrState.MERGED);
+  const canonical = ranked[0] ?? null;
+  return {
+    canonical,
+    active,
+    hasMultipleActive: active.length > 1,
+    hasDirtyReviewState: active.some((pr) => pr.mergeable === false),
+  };
+}


### PR DESCRIPTION
## Summary
- block semantically duplicate task creation against non-terminal open issues
- add canonical PR drift detection and reject work_finish when multiple active PRs are linked to one issue
- clear stale review/test routing on resume and add regression tests for duplicate PR drift

Addresses issue #31