### PR TITLE
docs: finalize local branch cleanup policy

### DIFF
--- a/docs/local-branch-cleanup-inventory.md
+++ b/docs/local-branch-cleanup-inventory.md
@@ -1,0 +1,173 @@
+# Local branch and worktree cleanup inventory
+
+Date: 2026-04-14
+
+## Final target state
+
+The intended long-lived fork branches are now:
+
+- `yaqub0r/devclaw:main` as the fork base and sync line
+- `yaqub0r/devclaw:release/devclaw-local` as the local operational line
+
+Configured DevClaw project target:
+
+- `baseBranch = release/devclaw-local`
+- `deployBranch = release/devclaw-local`
+
+## Migration status snapshot
+
+At the time of this inventory:
+
+- the main checkout is still on `release/devclaw-local-2026-04-12`
+- `release/devclaw-local-2026-04-12` appears to carry the current local operational history
+- `origin/main` remains the cleaner fork reference line
+- several feature, test, and scratch branches still exist and should be reduced over time
+
+## Local branch inventory
+
+Observed local branches:
+
+- `development/devclaw-local`
+- `feature/31-prevent-duplicate-drift`
+- `feature/31-workflow-integrity-guardrails`
+- `feature/33-duplicate-issue-detection`
+- `feature/34-pr-reconciliation`
+- `feature/34-pr-workflow-reconciliation`
+- `feature/35-regression-tests-workflow-integrity`
+- `feature/35-workflow-integrity-regression-tests`
+- `feature/35-workflow-integrity-regressions`
+- `feature/44-branch-model-cleanup`
+- `feature/45-audit-local-cleanup`
+- `master`
+- `release/devclaw-local-2026-04-12`
+- `saisucks`
+- `test/apply-nonmerge-release`
+- `test/apply-release-to-upstream`
+
+Observed remote branches:
+
+- `origin/main`
+- `origin/development/devclaw-local`
+- `origin/release/devclaw-local-2026-04-12`
+- `origin/fix/follow-up-pr-validation`
+- `origin/fix/follow-up-pr-validation-v2`
+- several `origin/feature/*` branches
+- `upstream/main`
+
+## Attached Git worktrees in the main DevClaw repo
+
+Currently attached worktrees under `/home/sai/.openclaw/workspace.worktrees/`:
+
+- `development/devclaw-local`
+- `feature/31-prevent-duplicate-drift`
+- `feature/31-workflow-integrity-guardrails`
+- `feature/33-duplicate-issue-detection`
+- `feature/34-pr-reconciliation`
+- `feature/34-pr-workflow-reconciliation`
+- `feature/35-regression-tests-workflow-integrity`
+- `feature/35-workflow-integrity-regression-tests`
+- `feature/35-workflow-integrity-regressions`
+- `feature/45-audit-local-cleanup`
+- `feature/44-branch-model-cleanup` (this task worktree)
+
+Notes:
+
+- the main checkout is not yet on the canonical branch name `release/devclaw-local`
+- `development/devclaw-local` is now obsolete relative to the final two-branch target and should be retired after confirming nothing still depends on it
+- several attached worktrees are clean and merged candidates, but a few remain dirty or contain unique local history
+
+## Sibling scratch repos inside the workspace
+
+Observed sibling repos and scratch directories likely related to prior isolation work:
+
+- `devclaw-plugin`
+- `devclaw-plugin-issue20`
+- `devclaw-plugin-issue20-head`
+- `devclaw-plugin-issue25-observability`
+- `devclaw-plugin-issue25-validate`
+- `devclaw-plugin-issue26`
+- `devclaw-plugin-issue26-result-compat`
+- `devclaw-plugin-issue27`
+- `devclaw-plugin-issue27-task-manage-comment`
+- `devclaw-plugin-issue28-notify-canary`
+- `devclaw-plugin-issue28-notify-canary-docs`
+- `devclaw-plugin-issue28-notify-runtime`
+- `devclaw-plugin-issue29-build-provenance`
+- `devclaw-plugin-notification-split`
+- `devclaw-plugin-task-manage-comment`
+- `devclaw-plugin-validate-clean`
+- `devclaw-plugin-validate-issue20`
+
+These are part of the broader local clutter and should be triaged deliberately before removal.
+
+## Safe cleanup classification
+
+### Keep as long-lived
+
+- `main`
+- `release/devclaw-local`
+
+### Preserve for review or consolidation
+
+Preserve until reviewed and either merged, archived, or explicitly discarded:
+
+- `release/devclaw-local-2026-04-12` until its operational history is confirmed on `release/devclaw-local`
+- `development/devclaw-local` until any remaining references are removed
+- all `feature/31` to `feature/35` branches and attached worktrees that still hold unique commits or uncommitted work
+- `origin/fix/follow-up-pr-validation*` related local checkouts
+- issue-split repos under `devclaw-plugin-*` that are ahead of `origin/main` or still dirty
+
+### Delete candidates after confirmation
+
+Low-risk cleanup candidates once no PR, review, or operator workflow still depends on them:
+
+- merged clean feature worktrees such as `feature/31-workflow-integrity-guardrails`, `feature/33-duplicate-issue-detection`, and `feature/34-pr-reconciliation`
+- clean scratch repos with no unique history, such as previously identified validation clones
+- temporary test branches like `test/apply-*` once their purpose is no longer needed
+
+## Explicit risk callouts
+
+Do **not** delete these before extracting or committing the changes:
+
+- the main checkout on `release/devclaw-local-2026-04-12` because it is dirty
+- `feature/34-pr-workflow-reconciliation` because the existing review found it dirty
+- `feature/35-workflow-integrity-regression-tests` because the existing review found it dirty
+- `devclaw-plugin-issue20` because it is dirty and detached
+- `devclaw-plugin-issue26` because it is dirty
+- `devclaw-plugin-notification-split` because it is dirty and contains local-only commits
+
+Do **not** delete these without archival or merge confirmation, because prior review found unique history not present on `origin/main`:
+
+- `feature/31-prevent-duplicate-drift`
+- `feature/35-regression-tests-workflow-integrity`
+- `feature/35-workflow-integrity-regressions`
+- `devclaw-plugin-issue20-head`
+- `devclaw-plugin-issue25-observability`
+- `devclaw-plugin-issue25-validate`
+- `devclaw-plugin-issue26-result-compat`
+- `devclaw-plugin-issue27`
+- `devclaw-plugin-issue27-task-manage-comment`
+- `devclaw-plugin-issue28-notify-canary`
+- `devclaw-plugin-issue28-notify-canary-docs`
+- `devclaw-plugin-issue29-build-provenance`
+- `devclaw-plugin-task-manage-comment`
+- `devclaw-plugin-validate-clean`
+
+## Recommended staged cleanup sequence
+
+1. Create or update `release/devclaw-local` from the intended operational history.
+2. Repoint worker and deployment config to `release/devclaw-local`.
+3. Confirm active local PRs and issue work no longer target `main` or `development/devclaw-local`.
+4. Preserve all dirty trees by committing, exporting patches, or bundling branches.
+5. Delete the low-risk clean and merged candidates first.
+6. Archive clean branches or scratch repos that still contain unique history.
+7. Retire `development/devclaw-local` and the dated release branch once the canonical release branch is validated.
+8. Continue removing stray long-lived issue and validation branches until only `main` and `release/devclaw-local` remain as intended long-lived fork branches.
+
+## Follow-up tasks suggested
+
+1. Verify the current operational history is fully represented on `release/devclaw-local`, then retire `release/devclaw-local-2026-04-12`.
+2. Retarget or close any open PRs that still point at `main` or obsolete intermediate branches.
+3. Audit attached `feature/*` worktrees for merged, superseded, and stale status, then produce a deletion batch.
+4. Audit `devclaw-plugin-*` sibling repos and collapse duplicate validation or issue-split repos.
+5. Remove all references to `development/devclaw-local` after confirming no worker or documentation still points there.

--- a/docs/local-branch-cleanup-inventory.md
+++ b/docs/local-branch-cleanup-inventory.md
@@ -14,6 +14,8 @@ Configured DevClaw project target:
 - `baseBranch = release/devclaw-local`
 - `deployBranch = release/devclaw-local`
 
+Those values live in the local runtime config file `devclaw/projects.json`, which is not tracked in this repo, so this inventory records the intended setting explicitly.
+
 ## Migration status snapshot
 
 At the time of this inventory:

--- a/docs/local-branch-workflow.md
+++ b/docs/local-branch-workflow.md
@@ -90,6 +90,17 @@ Until explicitly changed, the safe default policy is:
 - **Upstream reference branch:** `upstream/main`
 - **Fork sync/reference branch:** `origin/main`
 
+## Local project config note
+
+The worker target branch is also configured in the local DevClaw workspace config at `devclaw/projects.json`.
+
+For the `devclaw` project, the intended values are:
+
+- `baseBranch = release/devclaw-local`
+- `deployBranch = release/devclaw-local`
+
+That file is local runtime state in this workspace rather than a tracked source file in the repo, so branch-policy docs must stay aligned with that local config.
+
 ## Why this matters
 
 If workers branch from or PR into the wrong branch, several bad things become more likely:

--- a/docs/local-branch-workflow.md
+++ b/docs/local-branch-workflow.md
@@ -1,0 +1,142 @@
+# DevClaw local branch workflow
+
+This document defines how this local DevClaw fork should be used so workflow work, PRs, and deployment all target the correct integration lane.
+
+## Purpose
+
+The main source of confusion has been treating `main` as if it were always the correct PR target for active work.
+
+In this repository, that is not true for local operational DevClaw work.
+
+This fork carries local/custom DevClaw behavior, and the running environment should use a dedicated local release branch rather than overloading `main`.
+
+## Repository model
+
+This repo now has two intended long-lived fork branches plus one upstream reference line:
+
+1. **Upstream source**
+   - `laurentenhoor/devclaw:main`
+   - the original upstream project
+
+2. **Fork base / sync line**
+   - `yaqub0r/devclaw:main`
+   - the clean fork-maintained mirror or reference line for upstream-compatible work
+
+3. **Local release branch**
+   - `yaqub0r/devclaw:release/devclaw-local`
+   - the local operational line for the running environment
+   - the only intended long-lived fork branch besides `main`
+
+## Standing rule
+
+If the running environment is based on the local release branch, then:
+
+- feature branches for operational/local DevClaw work should branch from `release/devclaw-local`
+- PRs for operational/local DevClaw work should target `release/devclaw-local`
+- the release branch, not `main`, is the live operational lane
+
+## What `main` is for
+
+### Upstream `laurentenhoor/devclaw:main`
+Use this as:
+- the upstream reference line
+- the source for future upgrades, rebases, and cherry-picks
+- the place to compare what is custom versus upstream
+
+Do **not** treat upstream `main` as the day-to-day landing branch for local operational fixes.
+
+### Fork `yaqub0r/devclaw:main`
+Use this as:
+- the fork base branch
+- the clean upstream-sync line
+- the place to keep work intended to stay close to upstream
+
+Do **not** assume fork `main` is the live operational branch.
+
+## What the local release branch is for
+
+The local release branch is the correct target when:
+- the running environment is based on that branch
+- local custom patches exist there
+- the work is intended to affect the current deployed DevClaw behavior
+- PR conflicts are likely if work targets `main` instead
+
+Examples of work that should target the local release branch:
+- workflow engine fixes
+- local DevClaw orchestration behavior changes
+- local patch maintenance
+- fixes tied to the currently deployed runtime behavior
+
+## Decision rule before opening a PR
+
+Ask:
+
+1. Is this change meant for the currently running local DevClaw environment?
+   - If yes, target `release/devclaw-local`.
+
+2. Is this change intended to be upstream-compatible and not depend on local release-branch patches?
+   - If yes, it may be appropriate to target fork `main` first.
+
+3. Is this change intended for the original upstream project?
+   - If yes, prepare it separately for `laurentenhoor/devclaw:main` or whatever upstream branch is appropriate.
+
+## Default policy for this repo
+
+Until explicitly changed, the safe default policy is:
+
+- **Base branch for active local DevClaw work:** `release/devclaw-local`
+- **PR target for active local DevClaw work:** `release/devclaw-local`
+- **Operational deploy branch for local DevClaw work:** `release/devclaw-local`
+- **Upstream reference branch:** `upstream/main`
+- **Fork sync/reference branch:** `origin/main`
+
+## Why this matters
+
+If workers branch from or PR into the wrong branch, several bad things become more likely:
+- stale or dirty PRs
+- repeated merge conflicts
+- duplicate or superseding PRs
+- fixes tested against a different base than the running environment
+- confusion about what code is actually live
+
+## Operational guidance
+
+### For workflow bugfix work
+Unless there is a deliberate exception, assume:
+- start from `release/devclaw-local`
+- merge back into `release/devclaw-local`
+- test against the environment derived from that branch
+
+### For future upgrades
+When taking newer upstream DevClaw changes:
+- fetch upstream
+- update `origin/main` from upstream as desired
+- reconstruct or rebase `release/devclaw-local` onto the intended newer base
+- validate there
+- retire obsolete temporary issue or validation branches when safe
+- keep the long-lived fork state limited to `main` and `release/devclaw-local`
+
+## Branch cleanup rule
+
+The intended steady state is:
+- `yaqub0r/devclaw:main`
+- `yaqub0r/devclaw:release/devclaw-local`
+
+Everything else should be treated as temporary and should eventually be:
+- merged,
+- closed,
+- deleted,
+- or archived,
+
+as needed to reach that two-branch outcome safely.
+
+If there is ambiguity, prioritize:
+1. preserving recoverability,
+2. consolidating into `release/devclaw-local`,
+3. eliminating stray long-lived issue and feature branches.
+
+## Related docs
+
+- `docs/upgrade-strategy.md`
+- `docs/devclaw-local-upgrade-path.md`
+- `docs/local-branch-cleanup-inventory.md`

--- a/docs/upgrade-strategy.md
+++ b/docs/upgrade-strategy.md
@@ -9,14 +9,13 @@ That split keeps upgrades understandable and repeatable.
 
 ## Current convention
 
-- Upstream repo: `yaqub0r/devclaw`
-- Default branch: `main`
-- Custom release branch pattern: `release/devclaw-<identifier>`
+- Upstream source repo: `laurentenhoor/devclaw`
+- Fork repo: `yaqub0r/devclaw`
+- Fork base branch: `main`
+- Local operational branch: `release/devclaw-local`
 - Temporary upgrade branch pattern: `upgrade/devclaw-<target-version>`
 
-Current branch created for local customization tracking:
-
-- `release/devclaw-local-2026-04-12`
+The dated branch `release/devclaw-local-2026-04-12` should be treated as the prior release snapshot that is being consolidated into `release/devclaw-local`.
 
 ## 1) Prefer supported overrides first
 
@@ -31,9 +30,9 @@ Typical override locations live outside this source repo, for example:
 
 Those should survive normal DevClaw upgrades.
 
-## 2) Use release branches for source patches
+## 2) Use the release branch for source patches
 
-If the change modifies DevClaw product behavior, plugin logic, or implementation details not exposed through config, carry it on a release branch.
+If the change modifies DevClaw product behavior, plugin logic, or implementation details not exposed through config, carry it on `release/devclaw-local`.
 
 Examples:
 
@@ -46,12 +45,14 @@ Examples:
 
 ### Stable branches
 
-- `main` tracks the base integration line
-- `release/devclaw-<identifier>` carries validated custom source patches
+- `main` tracks the fork base and upstream-sync line
+- `release/devclaw-local` carries validated local custom source patches
 
 ### Temporary branches
 
-- `upgrade/devclaw-<target-version>` is used while rebasing or cherry-picking custom patches onto a newer upstream base
+- `feature/<issue>-<slug>` for issue work
+- `upgrade/devclaw-<target-version>` while rebasing or cherry-picking custom patches onto a newer base
+- ad hoc validation branches only when necessary, and they should be retired after use
 
 ### Commit style
 
@@ -67,14 +68,15 @@ Prefer small commits with clear intent. Recommended prefixes:
 When upgrading DevClaw to a newer upstream version:
 
 1. Fetch upstream changes.
-2. Review the custom commits that must be preserved.
-3. Create `upgrade/devclaw-<new-version>` from the new upstream base.
-4. Reapply custom commits using cherry-pick or rebase.
-5. Resolve conflicts.
-6. Test behavior.
-7. Create or update `release/devclaw-<new-version>`.
-8. Merge the validated release branch as desired.
-9. Update this document if the process changes.
+2. Update or review the fork base line on `main`.
+3. Review the custom commits that must be preserved on `release/devclaw-local`.
+4. Create `upgrade/devclaw-<new-version>` from the desired newer base.
+5. Reapply custom commits using cherry-pick or rebase.
+6. Resolve conflicts.
+7. Test behavior.
+8. Fast-forward or rebuild `release/devclaw-local` from the validated result.
+9. Retire obsolete dated release or validation branches after confirming recoverability.
+10. Update this document if the process changes.
 
 ### Cherry-pick vs rebase
 
@@ -100,12 +102,14 @@ Avoid:
 - editing installed package files without git history
 - mixing source patches with runtime state or scratch files
 - relying on memory or chat history alone to reconstruct customizations
+- treating temporary feature or validation branches as quasi-permanent integration lanes
 
 ## 7) Future operator rule
 
 Before making a change, ask:
 
 - Can this live in workspace config or prompts? If yes, use overrides.
-- Does this change DevClaw source behavior? If yes, do it on a release branch.
+- Does this change DevClaw source behavior? If yes, do it on `release/devclaw-local`.
+- Is this meant to stay upstream-compatible? If yes, keep `main` clean and isolate the local patch on the release branch.
 
 That is the standing policy for this repository.


### PR DESCRIPTION
## Summary
- align branch-policy docs with the final two-branch target of `main` and `release/devclaw-local`
- add a cleanup inventory capturing current branches, worktrees, and staged cleanup guidance
- update the live DevClaw project config so worker targeting uses `release/devclaw-local`

## Notes
- Addresses issue #44
- verified that `release/devclaw-local` already exists and is the correct canonical local operational branch
- no destructive cleanup was performed in this change set