### PR TITLE
test: cover PR ownership split regressions

### DIFF
--- a/lib/services/heartbeat/review.test.ts
+++ b/lib/services/heartbeat/review.test.ts
@@ -8,6 +8,33 @@ import { PrState } from '../../providers/provider.js';
 const runCommand = async () => ({ stdout: '', stderr: '', exitCode: 0, code: 0, signal: null, killed: false, termination: 'exit' } as any);
 
 describe('reviewPass ambiguity reconciliation', () => {
+  it('treats an already merged external PR as canonical and advances without re-merging', async () => {
+    const provider = new TestProvider();
+    provider.seedIssue({ iid: 130, title: 'Externally merged PR', labels: ['To Review', 'review:human'] });
+    provider.setPrStatus(130, {
+      state: PrState.MERGED,
+      url: 'https://example.com/pr/130',
+      title: 'docs: clarify provenance',
+      sourceBranch: 'feature/130-docs-provenance',
+    });
+
+    const transitions = await reviewPass({
+      workspaceDir: '/tmp',
+      projectName: 'devclaw',
+      workflow: DEFAULT_WORKFLOW,
+      provider,
+      repoPath: '/tmp',
+      runCommand,
+    });
+
+    assert.strictEqual(transitions, 1);
+    assert.strictEqual(provider.callsTo('mergePr').length, 0, 'should not try to merge an already merged PR');
+
+    const issue = await provider.getIssue(130);
+    assert.ok(issue.labels.includes('To Test'));
+    assert.ok(!issue.labels.includes('To Review'));
+  });
+
   it('surfaces ambiguous multiple open PRs instead of silently transitioning', async () => {
     const provider = new TestProvider();
     provider.seedIssue({ iid: 131, title: 'Ambiguous review', labels: ['To Review', 'review:human'] });

--- a/lib/tools/worker/work-finish.test.ts
+++ b/lib/tools/worker/work-finish.test.ts
@@ -138,6 +138,43 @@ describe("work_finish PR validation", () => {
       assert.equal(issueLookupCount, 0);
     });
 
+    it("accepts a branch-matched PR that is already merged externally", async () => {
+      const provider = Object.create(GitHubProvider.prototype) as GitHubProvider & {
+        prHasReaction: () => Promise<boolean>;
+        reactToPr: (_issueId: number, _emoji: string) => Promise<void>;
+        getPrStatus: (_issueId: number) => Promise<any>;
+      };
+      let issueLookupCount = 0;
+      provider.prHasReaction = async () => true;
+      provider.reactToPr = async () => {};
+      provider.getPrStatus = async () => {
+        issueLookupCount++;
+        return { state: PrState.CLOSED, url: null };
+      };
+
+      const runCommand = async (args: string[]) => {
+        if (args[0] === "git") return { stdout: "feature/existing-pr\n", stderr: "", exitCode: 0 };
+        if (args[0] === "gh" && args[1] === "pr" && args[2] === "list") {
+          return {
+            stdout: JSON.stringify([{
+              url: "https://github.com/test/repo/pull/105",
+              title: "existing pr",
+              state: "MERGED",
+              headRefName: "feature/existing-pr",
+              reviewDecision: "APPROVED",
+              mergeable: null,
+            }]),
+            stderr: "",
+            exitCode: 0,
+          };
+        }
+        throw new Error(`unexpected command: ${args.join(" ")}`);
+      };
+
+      await validatePrExistsForDeveloper(108, tempDir, provider, runCommand as any, tempDir, "devclaw");
+      assert.equal(issueLookupCount, 0, 'merged branch lookup should still be canonical without falling back to issue scan');
+    });
+
     it("validates explicit URLs for non-GitHub providers against the linked PR", async () => {
       const provider = new TestProvider();
       provider.setPrStatus(42, {


### PR DESCRIPTION
## Summary
- add a review-pass regression proving a human-merged PR is treated as canonical and advances without a duplicate merge attempt
- add a work_finish regression proving branch-based PR lookup still accepts a PR already merged externally
- validate the ownership-split path with focused regression coverage

Addresses issue #31.