### PR TITLE
fix: normalize merged PR status in github provider

### DIFF
--- a/lib/providers/github.ts
+++ b/lib/providers/github.ts
@@ -337,6 +337,11 @@ export class GitHubProvider implements IssueProvider {
 
       return { ...canonical, state };
     }
+    // Merged PRs must always report MERGED, even if GitHub still retains an
+    // APPROVED reviewDecision after merge. Returning APPROVED here makes the
+    // heartbeat try to merge an already-merged PR again, which can bounce the
+    // issue into merge-failed / re-dispatch flows during normal post-merge
+    // cleanup.
     type MergedPr = { title: string; body: string; headRefName: string; url: string; reviewDecision: string | null; mergedAt?: string | null; number?: number };
     const merged = await this.findPrsForIssue<MergedPr>(issueId, "merged", "title,body,headRefName,url,reviewDecision,mergedAt,number");
     const allPrs = await this.findPrsViaTimeline(issueId, "all");
@@ -351,8 +356,7 @@ export class GitHubProvider implements IssueProvider {
       closed,
     });
     if (terminal.ambiguous || terminal.state !== PrState.MERGED) return terminal;
-    const mergedPr = merged.find((pr) => pr.url === terminal.url);
-    return { ...terminal, state: mergedPr?.reviewDecision === "APPROVED" ? PrState.APPROVED : PrState.MERGED };
+    return { ...terminal, state: PrState.MERGED };
   }
 
   /**

--- a/lib/providers/provider-pr-status.test.ts
+++ b/lib/providers/provider-pr-status.test.ts
@@ -142,6 +142,35 @@ describe("GitHubProvider.getPrStatus — closed PR handling", () => {
     assert.strictEqual(status.url, mergedPrUrl);
   });
 
+  it("returns MERGED for merged PRs even when reviewDecision stays APPROVED", async () => {
+    const provider = new GitHubProvider({ repoPath: "/fake", runCommand: mockRunCommand });
+
+    const mergedPrUrl = "https://github.com/owner/repo/pull/6";
+
+    (provider as any).findPrsForIssue = async (_id: number, state: string) => {
+      if (state === "open") return [];
+      if (state === "merged") {
+        return [
+          {
+            title: "feat: merged after approval",
+            body: "",
+            headRefName: "feature/6-merged-approved",
+            url: mergedPrUrl,
+            reviewDecision: "APPROVED",
+          },
+        ];
+      }
+      return [];
+    };
+    (provider as any).findPrsViaTimeline = async () => null;
+
+    const status = await provider.getPrStatus(42);
+
+    assert.strictEqual(status.state, PrState.MERGED, "merged PRs must not be downgraded to APPROVED");
+    assert.strictEqual(status.url, mergedPrUrl);
+    assert.strictEqual(status.sourceBranch, "feature/6-merged-approved");
+  });
+
   it("ignores non-CLOSED states in timeline when returning closed PR", async () => {
     const provider = new GitHubProvider({ repoPath: "/fake", runCommand: mockRunCommand });
 

--- a/lib/services/pipeline.e2e.test.ts
+++ b/lib/services/pipeline.e2e.test.ts
@@ -596,6 +596,34 @@ describe("E2E pipeline", () => {
       assert.ok(issue.labels.includes("To Test"), `Labels: ${issue.labels}`);
     });
 
+    it("should transition merged PRs without re-merging them", async () => {
+      h.provider.seedIssue({ iid: 79, title: "Merged externally", labels: ["To Review", "review:human"] });
+      h.provider.setPrStatus(79, {
+        state: "merged",
+        url: "https://example.com/pr/79",
+        title: "feat: merged externally",
+        sourceBranch: "feature/79-merged-externally",
+      });
+
+      const transitions = await reviewPass({
+        workspaceDir: h.workspaceDir,
+        projectName: h.project.name,
+        workflow: DEFAULT_WORKFLOW,
+        provider: h.provider,
+        repoPath: "/tmp/test-repo",
+        runCommand: h.runCommand,
+      });
+
+      assert.strictEqual(transitions, 1, "Merged PR should still advance the workflow");
+
+      const issue = await h.provider.getIssue(79);
+      assert.ok(issue.labels.includes("To Test"), `Labels: ${issue.labels}`);
+      assert.ok(!issue.labels.includes("To Review"), "Should not have To Review");
+
+      const mergeCalls = h.provider.callsTo("mergePr");
+      assert.strictEqual(mergeCalls.length, 0, "Should not attempt to merge an already-merged PR");
+    });
+
     it("should transition To Review → To Improve when PR is closed without merging (url non-null)", async () => {
       // After #315: PrState.CLOSED + url non-null = PR was explicitly closed without merging
       h.provider.seedIssue({ iid: 80, title: "Closed PR feature", labels: ["To Review", "review:human"] });


### PR DESCRIPTION
## Summary
- treat GitHub merged PRs as MERGED even when reviewDecision remains APPROVED
- prevent heartbeat merge retries against already-merged PRs
- add regression coverage for merged-after-approval provider status and review-pass behavior

Addresses issue #54

## Validation
- npx tsx --test lib/providers/provider-pr-status.test.ts
- npx tsx /tmp/issue54-reviewpass-check.ts
- attempted broader heartbeat/pipeline test run, but the existing test harness in this worktree fails on an unrelated defaults-path lookup in lib/setup/templates.ts
