### PR TITLE
feat: add research dispatch observability

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -98,9 +98,22 @@ Plugin dispatch (heartbeat → dispatchTask):
   4. Update projects.json, write audit log
 ```
 
-The orchestrator's only job is to advance issues to the queue via `task_start`. The heartbeat handles everything else — level assignment, session creation, task dispatch, state update, audit logging — as deterministic plugin code.
+The orchestrator's only job is to advance issues to the queue via `task_start`. The heartbeat handles everything else, level assignment, session creation, task dispatch, state update, audit logging, as deterministic plugin code.
 
 **Why this matters:** Previously the plugin returned instructions like `{ sessionAction: "spawn", model: "sonnet" }` and the agent had to correctly call `sessions_spawn` with the right params. This was the fragile handoff point where agents would forget `cleanup: "keep"`, use wrong models, or corrupt session state. Moving dispatch into the plugin eliminates that entire class of errors.
+
+### Research dispatch observability
+
+Research work now persists a per-issue dispatch status record in `devclaw/dispatch-status.json`. For architect research issues, DevClaw tracks four separate facts that used to be conflated:
+
+1. the issue label moved into `Researching`
+2. the gateway accepted `sessions.patch`
+3. the gateway accepted the `agent` delivery request
+4. the worker produced confirmed tracker-visible output, either a comment or `work_finish`
+
+This lets operator-facing tools distinguish states like `delivery_failed`, `session_alive_waiting_for_output`, `output_confirmed`, and `completed`.
+
+A live gateway session is not treated as equivalent to visible worker progress. The gateway only proves that a session exists. Confirmed progress is recorded only after `task_comment` or `work_finish` succeeds, because those are the first durable signals the operator can actually see in the tracker.
 
 **Session persistence:** Sessions created via `sessions.patch` persist indefinitely (no auto-cleanup). The plugin manages lifecycle explicitly through the `health` tool.
 

--- a/lib/dispatch/index.ts
+++ b/lib/dispatch/index.ts
@@ -26,6 +26,7 @@ import { slotName } from "../names.js";
 import { buildTaskMessage, buildConflictFixMessage, buildAnnouncement, formatSessionLabel } from "./message-builder.js";
 import { ensureSessionFireAndForget, sendToAgent, shouldClearSession } from "./session.js";
 import { acknowledgeComments, EYES_EMOJI } from "./acknowledge.js";
+import { upsertDispatchStatus } from "../services/dispatch-status.js";
 
 export type DispatchOpts = {
   workspaceDir: string;
@@ -184,6 +185,7 @@ export async function dispatchTask(
 
   // ── Commitment point — transition label (issue leaves queue) ────────
   await provider.transitionLabel(issueId, fromLabel, toLabel);
+  const labelMovedAt = new Date().toISOString();
 
   // Mark issue + PR as managed and all consumed comments as seen (fire-and-forget)
   provider.reactToIssue(issueId, EYES_EMOJI).catch(() => {});
@@ -283,16 +285,36 @@ export async function dispatchTask(
   // Step 3: Ensure session exists (fire-and-forget — don't wait for gateway)
   // Session key is deterministic, so we can proceed immediately
   const sessionLabel = formatSessionLabel(project.name, role, level, botName);
-  ensureSessionFireAndForget(sessionKey, model, workspaceDir, rc, timeouts.sessionPatchMs, sessionLabel);
+  await upsertDispatchStatus(workspaceDir, { projectSlug: project.slug, issueId, role }, {
+    projectName: project.name,
+    level,
+    sessionKey,
+    sessionAction,
+    labelMovedAt,
+    workerName: botName,
+  });
+  ensureSessionFireAndForget(sessionKey, model, workspaceDir, rc, {
+    timeoutMs: timeouts.sessionPatchMs,
+    label: sessionLabel,
+    projectSlug: project.slug,
+    projectName: project.name,
+    issueId,
+    role,
+    provider,
+    postVisibleFailureMarker: role === "architect" && fromLabel === "To Research",
+    fromLabel,
+  });
 
   // Step 4: Send task to agent (fire-and-forget)
   // Model is set on the session via sessions.patch (step 3), not on the agent RPC —
   // the gateway's agent endpoint rejects unknown properties like 'model'.
   sendToAgent(sessionKey, taskMessage, {
-    agentId, projectName: project.name, issueId, role, level, slotIndex, fromLabel,
+    agentId, projectName: project.name, projectSlug: project.slug, issueId, role, level, slotIndex, fromLabel,
     orchestratorSessionKey: opts.sessionKey, workspaceDir,
     dispatchTimeoutMs: timeouts.dispatchMs,
     extraSystemPrompt: roleInstructions.trim() || undefined,
+    provider,
+    postVisibleFailureMarker: role === "architect" && fromLabel === "To Research",
     runCommand: rc,
   });
 

--- a/lib/dispatch/session.ts
+++ b/lib/dispatch/session.ts
@@ -2,8 +2,10 @@
  * session.ts — Session management helpers for dispatch.
  */
 import type { RunCommand } from "../context.js";
+import type { IssueProvider } from "../providers/provider.js";
 import { log as auditLog } from "../audit.js";
 import { fetchGatewaySessions } from "../services/gateway-sessions.js";
+import { getDispatchStatus, upsertDispatchStatus } from "../services/dispatch-status.js";
 
 // ---------------------------------------------------------------------------
 // Context budget management
@@ -67,24 +69,84 @@ export async function shouldClearSession(
  * Session key is deterministic, so we don't need to wait for confirmation.
  * If this fails, health check will catch orphaned state later.
  */
-export function ensureSessionFireAndForget(sessionKey: string, model: string, workspaceDir: string, runCommand: RunCommand, timeoutMs = 30_000, label?: string): void {
+export function ensureSessionFireAndForget(
+  sessionKey: string,
+  model: string,
+  workspaceDir: string,
+  runCommand: RunCommand,
+  opts: {
+    timeoutMs?: number;
+    label?: string;
+    projectSlug: string;
+    projectName: string;
+    issueId: number;
+    role: string;
+    provider?: IssueProvider;
+    postVisibleFailureMarker?: boolean;
+    fromLabel?: string;
+  },
+): void {
   const rc = runCommand;
   const params: Record<string, unknown> = { key: sessionKey, model };
-  if (label) params.label = label;
+  if (opts.label) params.label = opts.label;
+  upsertDispatchStatus(workspaceDir, { projectSlug: opts.projectSlug, issueId: opts.issueId, role: opts.role }, {
+    projectName: opts.projectName,
+    sessionKey,
+    sessionPatchStartedAt: new Date().toISOString(),
+  }).catch(() => {});
   rc(
     ["openclaw", "gateway", "call", "sessions.patch", "--params", JSON.stringify(params)],
-    { timeoutMs },
-  ).catch((err) => {
+    { timeoutMs: opts.timeoutMs ?? 30_000 },
+  ).then(() => {
+    return upsertDispatchStatus(workspaceDir, { projectSlug: opts.projectSlug, issueId: opts.issueId, role: opts.role }, {
+      projectName: opts.projectName,
+      sessionKey,
+      sessionPatchSucceededAt: new Date().toISOString(),
+      sessionPatchFailedAt: undefined,
+      sessionPatchError: undefined,
+    });
+  }).catch(async (err) => {
+    const error = (err as Error).message ?? String(err);
+    upsertDispatchStatus(workspaceDir, { projectSlug: opts.projectSlug, issueId: opts.issueId, role: opts.role }, {
+      projectName: opts.projectName,
+      sessionKey,
+      sessionPatchFailedAt: new Date().toISOString(),
+      sessionPatchError: error,
+    }).catch(() => {});
+    if (opts.provider && opts.postVisibleFailureMarker) {
+      const status = await getDispatchStatus(workspaceDir, { projectSlug: opts.projectSlug, issueId: opts.issueId, role: opts.role });
+      if (!status?.failureCommentId) {
+        opts.provider.addComment(opts.issueId, `⚠️ Research session preparation failed before the architect could respond.\n\n- Session: \`${sessionKey}\`\n- Error: \`${error}\`\n\nYou can retry by moving the issue back to \`${opts.fromLabel ?? "To Research"}\` and redispatching.`).then((commentId) => {
+          upsertDispatchStatus(workspaceDir, { projectSlug: opts.projectSlug, issueId: opts.issueId, role: opts.role }, { failureCommentId: commentId }).catch(() => {});
+        }).catch(() => {});
+      }
+    }
     auditLog(workspaceDir, "dispatch_warning", {
       step: "ensureSession", sessionKey,
-      error: (err as Error).message ?? String(err),
+      error,
     }).catch(() => {});
   });
 }
 
 export function sendToAgent(
   sessionKey: string, taskMessage: string,
-  opts: { agentId?: string; projectName: string; issueId: number; role: string; level?: string; slotIndex?: number; fromLabel?: string; orchestratorSessionKey?: string; workspaceDir: string; dispatchTimeoutMs?: number; extraSystemPrompt?: string; runCommand: RunCommand },
+  opts: {
+    agentId?: string;
+    projectName: string;
+    projectSlug: string;
+    issueId: number;
+    role: string;
+    level?: string;
+    slotIndex?: number;
+    fromLabel?: string;
+    orchestratorSessionKey?: string;
+    workspaceDir: string;
+    dispatchTimeoutMs?: number;
+    extraSystemPrompt?: string;
+    provider?: IssueProvider;
+    postVisibleFailureMarker?: boolean;
+    runCommand: RunCommand;
+  },
 ): void {
   const rc = opts.runCommand;
   const gatewayParams = JSON.stringify({
@@ -97,15 +159,46 @@ export function sendToAgent(
     ...(opts.orchestratorSessionKey ? { spawnedBy: opts.orchestratorSessionKey } : {}),
     ...(opts.extraSystemPrompt ? { extraSystemPrompt: opts.extraSystemPrompt } : {}),
   });
+  upsertDispatchStatus(opts.workspaceDir, { projectSlug: opts.projectSlug, issueId: opts.issueId, role: opts.role }, {
+    projectName: opts.projectName,
+    level: opts.level,
+    sessionKey,
+    agentDispatchStartedAt: new Date().toISOString(),
+  }).catch(() => {});
   // Fire-and-forget: long-running agent turn, don't await
   rc(
     ["openclaw", "gateway", "call", "agent", "--params", gatewayParams, "--expect-final", "--json"],
     { timeoutMs: opts.dispatchTimeoutMs ?? 600_000 },
-  ).catch((err) => {
+  ).then(() => {
+    return upsertDispatchStatus(opts.workspaceDir, { projectSlug: opts.projectSlug, issueId: opts.issueId, role: opts.role }, {
+      projectName: opts.projectName,
+      level: opts.level,
+      sessionKey,
+      agentDispatchAcceptedAt: new Date().toISOString(),
+      agentDispatchFailedAt: undefined,
+      agentDispatchError: undefined,
+    });
+  }).catch((err) => {
+    const error = (err as Error).message ?? String(err);
+    upsertDispatchStatus(opts.workspaceDir, { projectSlug: opts.projectSlug, issueId: opts.issueId, role: opts.role }, {
+      projectName: opts.projectName,
+      level: opts.level,
+      sessionKey,
+      agentDispatchFailedAt: new Date().toISOString(),
+      agentDispatchError: error,
+    }).catch(() => {});
+    if (opts.provider && opts.postVisibleFailureMarker) {
+      getDispatchStatus(opts.workspaceDir, { projectSlug: opts.projectSlug, issueId: opts.issueId, role: opts.role }).then((status) => {
+        if (status?.failureCommentId) return;
+        opts.provider!.addComment(opts.issueId, `⚠️ Research dispatch failed before the architect could respond.\n\n- Session: \`${sessionKey}\`\n- Error: \`${error}\`\n\nYou can retry by moving the issue back to \`${opts.fromLabel ?? "To Research"}\` and redispatching.`).then((commentId) => {
+          upsertDispatchStatus(opts.workspaceDir, { projectSlug: opts.projectSlug, issueId: opts.issueId, role: opts.role }, { failureCommentId: commentId }).catch(() => {});
+        }).catch(() => {});
+      }).catch(() => {});
+    }
     auditLog(opts.workspaceDir, "dispatch_warning", {
       step: "sendToAgent", sessionKey,
       issue: opts.issueId, role: opts.role,
-      error: (err as Error).message ?? String(err),
+      error,
     }).catch(() => {});
   });
 }

--- a/lib/services/dispatch-status.test.ts
+++ b/lib/services/dispatch-status.test.ts
@@ -1,0 +1,71 @@
+/**
+ * Tests for dispatch status persistence and failure tracking.
+ */
+import { describe, it } from "node:test";
+import assert from "node:assert";
+import { createTestHarness } from "../testing/index.js";
+import { ensureSessionFireAndForget, sendToAgent } from "../dispatch/session.js";
+import { getDispatchStatus, upsertDispatchStatus } from "./dispatch-status.js";
+
+describe("dispatch status", () => {
+  it("records label moved but sessions.patch failed", async () => {
+    const h = await createTestHarness();
+    try {
+      const runCommand = async () => { throw new Error("sessions.patch failed"); };
+      await upsertDispatchStatus(h.workspaceDir, { projectSlug: h.project.slug, issueId: 62, role: "architect" }, {
+        projectName: h.project.name,
+        level: "senior",
+        sessionKey: "s1",
+        sessionAction: "spawn",
+        labelMovedAt: new Date().toISOString(),
+      });
+
+      ensureSessionFireAndForget("s1", "m1", h.workspaceDir, runCommand as any, {
+        projectSlug: h.project.slug,
+        projectName: h.project.name,
+        issueId: 62,
+        role: "architect",
+      });
+      await new Promise((r) => setTimeout(r, 25));
+
+      const status = await getDispatchStatus(h.workspaceDir, { projectSlug: h.project.slug, issueId: 62, role: "architect" });
+      assert.ok(status?.sessionPatchStartedAt);
+      assert.ok(status?.sessionPatchFailedAt);
+      assert.match(status?.sessionPatchError ?? "", /sessions.patch failed/);
+    } finally {
+      await h.cleanup();
+    }
+  });
+
+  it("records label moved but agent delivery failed", async () => {
+    const h = await createTestHarness();
+    try {
+      const runCommand = async () => { throw new Error("gateway agent failed"); };
+      await upsertDispatchStatus(h.workspaceDir, { projectSlug: h.project.slug, issueId: 63, role: "architect" }, {
+        projectName: h.project.name,
+        level: "senior",
+        sessionKey: "s2",
+        sessionAction: "spawn",
+        labelMovedAt: new Date().toISOString(),
+      });
+
+      sendToAgent("s2", "task", {
+        projectSlug: h.project.slug,
+        projectName: h.project.name,
+        issueId: 63,
+        role: "architect",
+        level: "senior",
+        workspaceDir: h.workspaceDir,
+        runCommand: runCommand as any,
+      });
+      await new Promise((r) => setTimeout(r, 25));
+
+      const status = await getDispatchStatus(h.workspaceDir, { projectSlug: h.project.slug, issueId: 63, role: "architect" });
+      assert.ok(status?.agentDispatchStartedAt);
+      assert.ok(status?.agentDispatchFailedAt);
+      assert.match(status?.agentDispatchError ?? "", /gateway agent failed/);
+    } finally {
+      await h.cleanup();
+    }
+  });
+});

--- a/lib/services/dispatch-status.ts
+++ b/lib/services/dispatch-status.ts
@@ -1,0 +1,162 @@
+/**
+ * dispatch-status.ts — durable per-issue worker delivery and output observability.
+ */
+import fs from "node:fs/promises";
+import path from "node:path";
+import { DATA_DIR } from "../setup/migrate-layout.js";
+
+const LOCK_STALE_MS = 30_000;
+const LOCK_RETRY_MS = 50;
+const LOCK_TIMEOUT_MS = 10_000;
+
+export type DispatchStatus = {
+  projectSlug: string;
+  projectName?: string;
+  issueId: number;
+  role: string;
+  level: string;
+  sessionKey: string;
+  sessionAction: "spawn" | "send";
+  labelMovedAt: string;
+  workerName?: string;
+  progressCommentId?: number;
+  failureCommentId?: number;
+  sessionPatchStartedAt?: string;
+  sessionPatchSucceededAt?: string;
+  sessionPatchFailedAt?: string;
+  sessionPatchError?: string;
+  agentDispatchStartedAt?: string;
+  agentDispatchAcceptedAt?: string;
+  agentDispatchFailedAt?: string;
+  agentDispatchError?: string;
+  firstWorkerOutputAt?: string;
+  firstWorkerOutputKind?: "comment" | "completion";
+  lastWorkerOutputAt?: string;
+  lastWorkerOutputKind?: "comment" | "completion";
+  lastCommentPostedAt?: string;
+  lastCommentPostFailedAt?: string;
+  lastCommentPostError?: string;
+  completionOutputConfirmedAt?: string;
+  completedAt?: string;
+  completionResult?: string;
+  updatedAt: string;
+};
+
+type DispatchStatusStore = Record<string, DispatchStatus>;
+
+function storePath(workspaceDir: string): string {
+  return path.join(workspaceDir, DATA_DIR, "dispatch-status.json");
+}
+
+function lockPath(workspaceDir: string): string {
+  return storePath(workspaceDir) + ".lock";
+}
+
+function recordKey(projectSlug: string, issueId: number, role: string): string {
+  return `${projectSlug}:${issueId}:${role}`;
+}
+
+async function acquireLock(workspaceDir: string): Promise<void> {
+  const lock = lockPath(workspaceDir);
+  const deadline = Date.now() + LOCK_TIMEOUT_MS;
+
+  while (Date.now() < deadline) {
+    try {
+      await fs.mkdir(path.dirname(lock), { recursive: true });
+      await fs.writeFile(lock, String(Date.now()), { flag: "wx" });
+      return;
+    } catch (err: any) {
+      if (err.code !== "EEXIST") throw err;
+      try {
+        const content = await fs.readFile(lock, "utf-8");
+        if (Date.now() - Number(content) > LOCK_STALE_MS) {
+          try { await fs.unlink(lock); } catch {}
+          continue;
+        }
+      } catch {}
+      await new Promise((resolve) => setTimeout(resolve, LOCK_RETRY_MS));
+    }
+  }
+
+  try { await fs.unlink(lock); } catch {}
+  await fs.writeFile(lock, String(Date.now()), { flag: "wx" });
+}
+
+async function releaseLock(workspaceDir: string): Promise<void> {
+  try { await fs.unlink(lockPath(workspaceDir)); } catch {}
+}
+
+async function readStore(workspaceDir: string): Promise<DispatchStatusStore> {
+  try {
+    const raw = await fs.readFile(storePath(workspaceDir), "utf-8");
+    return JSON.parse(raw) as DispatchStatusStore;
+  } catch {
+    return {};
+  }
+}
+
+async function writeStore(workspaceDir: string, data: DispatchStatusStore): Promise<void> {
+  const filePath = storePath(workspaceDir);
+  const tmpPath = `${filePath}.tmp`;
+  await fs.mkdir(path.dirname(filePath), { recursive: true });
+  await fs.writeFile(tmpPath, JSON.stringify(data, null, 2) + "\n", "utf-8");
+  await fs.rename(tmpPath, filePath);
+}
+
+export async function upsertDispatchStatus(
+  workspaceDir: string,
+  identity: { projectSlug: string; issueId: number; role: string },
+  patch: Partial<DispatchStatus>,
+): Promise<DispatchStatus> {
+  await acquireLock(workspaceDir);
+  try {
+    const data = await readStore(workspaceDir);
+    const key = recordKey(identity.projectSlug, identity.issueId, identity.role);
+    const existing = data[key];
+    const next = {
+      ...existing,
+      ...patch,
+      projectSlug: identity.projectSlug,
+      issueId: identity.issueId,
+      role: identity.role,
+      updatedAt: new Date().toISOString(),
+    } as DispatchStatus;
+    data[key] = next;
+    await writeStore(workspaceDir, data);
+    return next;
+  } finally {
+    await releaseLock(workspaceDir);
+  }
+}
+
+export async function getDispatchStatus(
+  workspaceDir: string,
+  identity: { projectSlug: string; issueId: number; role: string },
+): Promise<DispatchStatus | null> {
+  const data = await readStore(workspaceDir);
+  return data[recordKey(identity.projectSlug, identity.issueId, identity.role)] ?? null;
+}
+
+export async function findDispatchStatusBySession(
+  workspaceDir: string,
+  projectSlug: string,
+  issueId: number,
+  sessionKey: string,
+): Promise<DispatchStatus | null> {
+  const data = await readStore(workspaceDir);
+  return Object.values(data).find((entry) =>
+    entry.projectSlug === projectSlug &&
+    entry.issueId === issueId &&
+    entry.sessionKey === sessionKey,
+  ) ?? null;
+}
+
+export function summarizeDispatchStatus(status: DispatchStatus | null, sessionAlive?: boolean | null): string {
+  if (!status) return "unknown";
+  if (status.completedAt) return "completed";
+  if (status.agentDispatchFailedAt || status.sessionPatchFailedAt || status.lastCommentPostFailedAt) return "delivery_failed";
+  if (status.firstWorkerOutputAt || status.completionOutputConfirmedAt) return "output_confirmed";
+  if (sessionAlive) return "session_alive_waiting_for_output";
+  if (status.agentDispatchAcceptedAt || status.sessionPatchSucceededAt) return "dispatched_waiting_for_output";
+  return "dispatching";
+}

--- a/lib/services/heartbeat/health.ts
+++ b/lib/services/heartbeat/health.ts
@@ -51,6 +51,7 @@ import {
 import { isSessionAlive, type SessionLookup } from "../gateway-sessions.js";
 import { sendToAgent } from "../../dispatch/session.js";
 import type { RunCommand } from "../../context.js";
+import { getDispatchStatus } from "../dispatch-status.js";
 
 // Re-export for consumers that import from health.ts
 export { fetchGatewaySessions, isSessionAlive, type GatewaySession, type SessionLookup } from "../gateway-sessions.js";
@@ -80,6 +81,7 @@ export type HealthIssue = {
     | "orphaned_label"       // Case 7: active label but no worker tracking it
     | "context_overflow"     // Case 1c: active worker but session hit context limit (abortedLastRun)
     | "session_stalled"     // Active worker but session inactive for >stallTimeoutMinutes
+    | "research_waiting_for_output"
     | "stateless_issue";     // Case 8: open managed issue with no state label (#473)
   severity: "critical" | "warning";
   project: string;
@@ -459,6 +461,7 @@ export async function checkWorkerHealth(opts: {
               sendToAgent(sessionKey, NUDGE_MESSAGE, {
                 agentId: opts.agentId,
                 projectName: project.name,
+                projectSlug,
                 issueId: issueIdNum!,
                 role,
                 level,
@@ -485,6 +488,53 @@ export async function checkWorkerHealth(opts: {
           }).catch(() => {});
           fixes.push(fix);
           continue;
+        }
+      }
+
+      if (role === "architect" && slot.active && issueIdNum && sessionKey && sessions && isSessionAlive(sessionKey, sessions)) {
+        const dispatchStatus = await getDispatchStatus(workspaceDir, { projectSlug, issueId: issueIdNum, role });
+        const labelMovedAtMs = dispatchStatus?.labelMovedAt ? new Date(dispatchStatus.labelMovedAt).getTime() : workerStartTime;
+        if (labelMovedAtMs && !dispatchStatus?.firstWorkerOutputAt && !dispatchStatus?.completionOutputConfirmedAt && (Date.now() - labelMovedAtMs) > GRACE_PERIOD_MS) {
+          const fix: HealthFix = {
+            issue: {
+              type: "research_waiting_for_output",
+              severity: "warning",
+              project: project.name,
+              projectSlug,
+              role,
+              level,
+              sessionKey,
+              issueId: slot.issueId,
+              slotIndex,
+              message: `ARCHITECT ${level}[${slotIndex}] session is alive but research issue #${issueIdNum} has no confirmed output after grace window`,
+            },
+            fixed: false,
+          };
+          if (autoFix) {
+            sendToAgent(sessionKey, NUDGE_MESSAGE, {
+              agentId: opts.agentId,
+              projectName: project.name,
+              projectSlug,
+              issueId: issueIdNum,
+              role,
+              level,
+              slotIndex,
+              workspaceDir,
+              runCommand: opts.runCommand,
+            });
+            fix.nudgeSent = true;
+            fix.fixed = true;
+          }
+          await auditLog(workspaceDir, "research_waiting_for_output", {
+            project: project.name,
+            projectSlug,
+            role,
+            level,
+            sessionKey,
+            issueId: slot.issueId,
+            slotIndex,
+          }).catch(() => {});
+          fixes.push(fix);
         }
       }
 

--- a/lib/tools/tasks/research-task.ts
+++ b/lib/tools/tasks/research-task.ts
@@ -25,6 +25,7 @@ import { getActiveLabel, loadWorkflow } from "../../workflow/index.js";
 import { selectLevel } from "../../roles/model-selector.js";
 import { resolveModel } from "../../roles/index.js";
 import { findDuplicateCandidates, buildDuplicateConfirmationMessage } from "../../services/issue-dedup.js";
+import { getDispatchStatus, summarizeDispatchStatus, upsertDispatchStatus } from "../../services/dispatch-status.js";
 
 /** Queue label for research tasks. */
 const TO_RESEARCH_LABEL = "To Research";
@@ -219,6 +220,16 @@ Example:
         runCommand: ctx.runCommand,
       });
 
+      const progressCommentId = await provider.addComment(
+        issue.iid,
+        `📡 Research dispatch started.\n\n- Architect: **${level}**\n- Session: \`${dr.sessionKey}\`\n- Delivery: session prepared, awaiting architect output.`,
+      );
+      provider.reactToIssueComment(issue.iid, progressCommentId, "eyes").catch(() => {});
+      await upsertDispatchStatus(workspaceDir, { projectSlug: project.slug, issueId: issue.iid, role }, {
+        progressCommentId,
+      }).catch(() => {});
+      const dispatchStatus = await getDispatchStatus(workspaceDir, { projectSlug: project.slug, issueId: issue.iid, role });
+
       return jsonResult({
         success: true,
         issue: { id: issue.iid, title: issue.title, url: issue.web_url, label: toLabel },
@@ -227,7 +238,8 @@ Example:
           level: dr.level,
           model: dr.model,
           sessionAction: dr.sessionAction,
-          status: "in_progress",
+          status: summarizeDispatchStatus(dispatchStatus),
+          dispatch: dispatchStatus,
         },
         project: project.name,
         duplicateCheck: {

--- a/lib/tools/tasks/task-comment.test.ts
+++ b/lib/tools/tasks/task-comment.test.ts
@@ -1,0 +1,77 @@
+/**
+ * Tests for task_comment dispatch-status output tracking.
+ */
+import { describe, it } from "node:test";
+import assert from "node:assert";
+import { createTestHarness } from "../../testing/index.js";
+import { createTaskCommentTool } from "./task-comment.js";
+import { upsertDispatchStatus, getDispatchStatus } from "../../services/dispatch-status.js";
+
+describe("task_comment dispatch status", () => {
+  it("records worker output when a session-backed worker comment succeeds", async () => {
+    const h = await createTestHarness();
+    try {
+      h.provider.seedIssue({ iid: 64, title: "Research issue", labels: ["Researching"] });
+      await upsertDispatchStatus(h.workspaceDir, { projectSlug: h.project.slug, issueId: 64, role: "architect" }, {
+        projectName: h.project.name,
+        level: "senior",
+        sessionKey: "sess-64",
+        sessionAction: "spawn",
+        labelMovedAt: new Date().toISOString(),
+      });
+
+      const tool = createTaskCommentTool({ runCommand: h.runCommand } as any)({
+        workspaceDir: h.workspaceDir,
+        sessionKey: "sess-64",
+        agentId: "devclaw",
+      });
+      await tool.execute("1", {
+        channelId: h.channelId,
+        issueId: 64,
+        body: "Findings posted",
+        authorRole: "architect",
+      });
+
+      const status = await getDispatchStatus(h.workspaceDir, { projectSlug: h.project.slug, issueId: 64, role: "architect" });
+      assert.ok(status?.firstWorkerOutputAt);
+      assert.strictEqual(status?.firstWorkerOutputKind, "comment");
+      assert.ok(status?.lastWorkerOutputAt);
+    } finally {
+      await h.cleanup();
+    }
+  });
+
+  it("records comment-post failures before rethrowing", async () => {
+    const h = await createTestHarness();
+    try {
+      h.provider.seedIssue({ iid: 65, title: "Research issue", labels: ["Researching"] });
+      await upsertDispatchStatus(h.workspaceDir, { projectSlug: h.project.slug, issueId: 65, role: "architect" }, {
+        projectName: h.project.name,
+        level: "senior",
+        sessionKey: "sess-65",
+        sessionAction: "spawn",
+        labelMovedAt: new Date().toISOString(),
+      });
+      h.provider.addComment = async () => { throw new Error("tracker write failed"); };
+
+      const tool = createTaskCommentTool({ runCommand: h.runCommand } as any)({
+        workspaceDir: h.workspaceDir,
+        sessionKey: "sess-65",
+        agentId: "devclaw",
+      });
+
+      await assert.rejects(() => tool.execute("1", {
+        channelId: h.channelId,
+        issueId: 65,
+        body: "Findings posted",
+        authorRole: "architect",
+      }), /tracker write failed/);
+
+      const status = await getDispatchStatus(h.workspaceDir, { projectSlug: h.project.slug, issueId: 65, role: "architect" });
+      assert.ok(status?.lastCommentPostFailedAt);
+      assert.match(status?.lastCommentPostError ?? "", /tracker write failed/);
+    } finally {
+      await h.cleanup();
+    }
+  });
+});

--- a/lib/tools/tasks/task-comment.ts
+++ b/lib/tools/tasks/task-comment.ts
@@ -12,6 +12,7 @@ import type { ToolContext } from "../../types.js";
 import { log as auditLog } from "../../audit.js";
 import { requireWorkspaceDir, resolveChannelId, resolveProject, resolveProvider, autoAssignOwnerLabel, applyNotifyLabel } from "../helpers.js";
 import { getAllRoleIds, getFallbackEmoji } from "../../roles/index.js";
+import { findDispatchStatusBySession, upsertDispatchStatus } from "../../services/dispatch-status.js";
 
 /** Valid author roles for attribution — all registry roles + orchestrator */
 const AUTHOR_ROLES = [...getAllRoleIds(), "orchestrator"];
@@ -77,7 +78,32 @@ Examples:
         ? `${getRoleEmoji(authorRole)} **${authorRole.toUpperCase()}**: ${body}`
         : body;
 
-      const commentId = await provider.addComment(issueId, commentBody);
+      let commentId: number;
+      try {
+        commentId = await provider.addComment(issueId, commentBody);
+      } catch (err) {
+        if (toolCtx.sessionKey && authorRole && authorRole !== "orchestrator") {
+          await upsertDispatchStatus(workspaceDir, { projectSlug: project.slug, issueId, role: authorRole }, {
+            lastCommentPostFailedAt: new Date().toISOString(),
+            lastCommentPostError: (err as Error).message ?? String(err),
+          }).catch(() => {});
+        }
+        throw err;
+      }
+
+      if (toolCtx.sessionKey && authorRole && authorRole !== "orchestrator") {
+        const status = await findDispatchStatusBySession(workspaceDir, project.slug, issueId, toolCtx.sessionKey);
+        if (status) {
+          const now = new Date().toISOString();
+          await upsertDispatchStatus(workspaceDir, { projectSlug: project.slug, issueId, role: status.role }, {
+            firstWorkerOutputAt: status.firstWorkerOutputAt ?? now,
+            firstWorkerOutputKind: status.firstWorkerOutputKind ?? "comment",
+            lastWorkerOutputAt: now,
+            lastWorkerOutputKind: "comment",
+            lastCommentPostedAt: now,
+          }).catch(() => {});
+        }
+      }
 
       // Mark as system-managed (best-effort).
       provider.reactToIssueComment(issueId, commentId, "eyes").catch(() => {});

--- a/lib/tools/tasks/tasks-status.ts
+++ b/lib/tools/tasks/tasks-status.ts
@@ -11,8 +11,11 @@ import { log as auditLog } from "../../audit.js";
 import { getStateLabelsByType } from "../../services/queue.js";
 import { requireWorkspaceDir, resolveChannelId, resolveProject, resolveProvider } from "../helpers.js";
 import { loadConfig } from "../../config/index.js";
+import { fetchGatewaySessions, isSessionAlive } from "../../services/gateway-sessions.js";
+import { getDispatchStatus, summarizeDispatchStatus } from "../../services/dispatch-status.js";
 
 type IssueSummary = { id: number; title: string; url: string };
+type ResearchStatusSummary = IssueSummary & { researchStatus: string; sessionKey?: string; workerName?: string };
 
 export function createTasksStatusTool(ctx: PluginContext) {
   return (toolCtx: ToolContext) => ({
@@ -72,6 +75,19 @@ export function createTasksStatusTool(ctx: PluginContext) {
         };
       }
 
+      const gatewaySessions = await fetchGatewaySessions(undefined, ctx.runCommand);
+      const researching = active["Researching"]?.issues ?? [];
+      const research = await Promise.all(researching.map(async (item): Promise<ResearchStatusSummary> => {
+        const status = await getDispatchStatus(workspaceDir, { projectSlug: project.slug, issueId: item.id, role: "architect" });
+        const sessionAlive = status?.sessionKey ? isSessionAlive(status.sessionKey, gatewaySessions) : false;
+        return {
+          ...item,
+          researchStatus: summarizeDispatchStatus(status, sessionAlive),
+          sessionKey: status?.sessionKey,
+          workerName: status?.workerName,
+        };
+      }));
+
       // Totals
       const totalHold = Object.values(hold).reduce((s, c) => s + c.count, 0);
       const totalActive = Object.values(active).reduce((s, c) => s + c.count, 0);
@@ -99,6 +115,7 @@ export function createTasksStatusTool(ctx: PluginContext) {
         hold,
         active,
         queue,
+        research,
       });
     },
   });

--- a/lib/tools/worker/work-finish.ts
+++ b/lib/tools/worker/work-finish.ts
@@ -21,6 +21,7 @@ import { getAllRoleIds, isValidResult, getCompletionResults } from "../../roles/
 import { loadWorkflow } from "../../workflow/index.js";
 import { GitHubProvider } from "../../providers/github.js";
 import { PrState, type PrStatus } from "../../providers/provider.js";
+import { upsertDispatchStatus } from "../../services/dispatch-status.js";
 
 /**
  * Get the current git branch name.
@@ -409,6 +410,17 @@ export function createWorkFinishTool(ctx: PluginContext) {
         createdTasks,
         runCommand: ctx.runCommand,
       });
+
+      const completionConfirmedAt = new Date().toISOString();
+      await upsertDispatchStatus(workspaceDir, { projectSlug: project.slug, issueId, role }, {
+        completionOutputConfirmedAt: completionConfirmedAt,
+        firstWorkerOutputAt: completionConfirmedAt,
+        firstWorkerOutputKind: "completion",
+        lastWorkerOutputAt: completionConfirmedAt,
+        lastWorkerOutputKind: "completion",
+        completedAt: completionConfirmedAt,
+        completionResult: result,
+      }).catch(() => {});
 
       await auditLog(workspaceDir, "work_finish", {
         project: project.name, issue: issueId, role, result,


### PR DESCRIPTION
## Summary
- persist per-issue dispatch status for research delivery and output confirmation
- surface research delivery/output state in research_task, tasks_status, and heartbeat recovery
- record worker comment/completion output and document the observability model

Addresses issue #62

## Verification
- `npm run check` *(fails in this branch because the current openclaw/plugin-sdk package in node_modules does not export jsonResult; this is a pre-existing workspace/toolchain mismatch)*
- `npx tsx --test lib/services/dispatch-status.test.ts lib/tools/tasks/task-comment.test.ts` *(blocked by the same plugin-sdk export mismatch during module load)*