### PR TITLE
fix: normalize canonical PR workflow cleanup

### DIFF
--- a/lib/providers/github.ts
+++ b/lib/providers/github.ts
@@ -18,7 +18,6 @@ import {
   getLabelColors,
   type WorkflowConfig,
 } from "../workflow/index.js";
-import { reconcileCanonicalPr } from "./pr-reconciliation.js";
 
 type GhIssue = {
   number: number;
@@ -28,6 +27,48 @@ type GhIssue = {
   state: string;
   url: string;
 };
+
+type LinkedPr = {
+  number: number;
+  title: string;
+  body: string;
+  headRefName: string;
+  url: string;
+  mergedAt: string | null;
+  reviewDecision: string | null;
+  state: string;
+  mergeable: string | null;
+};
+
+function byNewestMergedAt(a: LinkedPr, b: LinkedPr): number {
+  return new Date(b.mergedAt ?? 0).getTime() - new Date(a.mergedAt ?? 0).getTime();
+}
+
+function pickCanonicalPr(prs: LinkedPr[], preferredBranch?: string): LinkedPr | null {
+  if (prs.length === 0) return null;
+
+  const branchMatches = preferredBranch
+    ? prs.filter((pr) => pr.headRefName === preferredBranch)
+    : [];
+  const openBranchMatch = branchMatches.find((pr) => pr.state === "OPEN");
+  if (openBranchMatch) return openBranchMatch;
+
+  const open = prs.filter((pr) => pr.state === "OPEN");
+  if (open.length > 0) return open[0]!;
+
+  const mergedBranchMatch = [...branchMatches]
+    .filter((pr) => pr.state === "MERGED")
+    .sort(byNewestMergedAt)[0];
+  if (mergedBranchMatch) return mergedBranchMatch;
+
+  const merged = prs.filter((pr) => pr.state === "MERGED").sort(byNewestMergedAt);
+  if (merged.length > 0) return merged[0]!;
+
+  const closedBranchMatch = branchMatches.find((pr) => pr.state === "CLOSED");
+  if (closedBranchMatch) return closedBranchMatch;
+
+  return prs.find((pr) => pr.state === "CLOSED") ?? prs[0] ?? null;
+}
 
 function toIssue(gh: GhIssue): Issue {
   return {
@@ -84,7 +125,7 @@ export class GitHubProvider implements IssueProvider {
   private async findPrsViaTimeline(
     issueId: number,
     state: "open" | "merged" | "all",
-  ): Promise<Array<{ number: number; title: string; body: string; headRefName: string; url: string; mergedAt: string | null; reviewDecision: string | null; state: string; mergeable: string | null }> | null> {
+  ): Promise<LinkedPr[] | null> {
     const repo = await this.getRepoInfo();
     if (!repo) return null;
 
@@ -113,7 +154,7 @@ export class GitHubProvider implements IssueProvider {
 
       // Extract PR data from both event types
       const seen = new Set<number>();
-      const prs: Array<{ number: number; title: string; body: string; headRefName: string; url: string; mergedAt: string | null; reviewDecision: string | null; state: string; mergeable: string | null }> = [];
+      const prs: LinkedPr[] = [];
 
       for (const node of nodes) {
         const pr = node.subject ?? node.source;
@@ -289,32 +330,23 @@ export class GitHubProvider implements IssueProvider {
   async reopenIssue(issueId: number): Promise<void> { await this.gh(["issue", "reopen", String(issueId)]); }
 
   async getMergedMRUrl(issueId: number): Promise<string | null> {
+    const prs = await this.findPrsViaTimeline(issueId, "all");
+    const canonical = pickCanonicalPr(prs?.filter((pr) => pr.state === "MERGED") ?? []);
+    if (canonical) return canonical.url;
+
     type MergedPr = { title: string; body: string; headRefName: string; url: string; mergedAt: string };
-    const prs = await this.findPrsForIssue<MergedPr>(issueId, "merged", "title,body,headRefName,url,mergedAt");
-    if (prs.length === 0) return null;
-    prs.sort((a, b) => new Date(b.mergedAt).getTime() - new Date(a.mergedAt).getTime());
-    return prs[0].url;
+    const fallback = await this.findPrsForIssue<MergedPr>(issueId, "merged", "title,body,headRefName,url,mergedAt");
+    if (fallback.length === 0) return null;
+    fallback.sort((a, b) => new Date(b.mergedAt).getTime() - new Date(a.mergedAt).getTime());
+    return fallback[0]!.url;
   }
 
   async getPrStatus(issueId: number): Promise<PrStatus> {
-    // Check open PRs first — include mergeable for conflict detection
-    type OpenPr = { title: string; body: string; headRefName: string; url: string; number: number; reviewDecision: string; mergeable: string };
-    const open = await this.findPrsForIssue<OpenPr>(issueId, "open", "title,body,headRefName,url,number,reviewDecision,mergeable");
-    const canonical = reconcileCanonicalPr({
-      open: open.map((pr) => ({
-        url: pr.url,
-        title: pr.title,
-        sourceBranch: pr.headRefName,
-        state: "OPEN",
-        mergeable: pr.mergeable === "CONFLICTING" ? false : pr.mergeable === "MERGEABLE" ? true : undefined,
-        number: pr.number,
-      })),
-      merged: [],
-      closed: [],
-    });
-    if (canonical.ambiguous) return canonical;
-    if (open.length === 1) {
-      const pr = open[0];
+    const allPrs = await this.findPrsViaTimeline(issueId, "all");
+    const canonical = pickCanonicalPr(allPrs ?? []);
+
+    if (canonical?.state === "OPEN") {
+      const pr = canonical;
       let state: PrState;
       if (pr.reviewDecision === "APPROVED") {
         state = PrState.APPROVED;
@@ -335,28 +367,54 @@ export class GitHubProvider implements IssueProvider {
         }
       }
 
-      return { ...canonical, state };
+      const mergeable = pr.mergeable === "CONFLICTING" ? false
+        : pr.mergeable === "MERGEABLE" ? true
+        : undefined;
+
+      return { state, url: pr.url, title: pr.title, sourceBranch: pr.headRefName, mergeable };
     }
-    // Merged PRs must always report MERGED, even if GitHub still retains an
-    // APPROVED reviewDecision after merge. Returning APPROVED here makes the
-    // heartbeat try to merge an already-merged PR again, which can bounce the
-    // issue into merge-failed / re-dispatch flows during normal post-merge
-    // cleanup.
-    type MergedPr = { title: string; body: string; headRefName: string; url: string; reviewDecision: string | null; mergedAt?: string | null; number?: number };
-    const merged = await this.findPrsForIssue<MergedPr>(issueId, "merged", "title,body,headRefName,url,reviewDecision,mergedAt,number");
-    const allPrs = await this.findPrsViaTimeline(issueId, "all");
-    const closed = (allPrs ?? []).filter((pr) => pr.state === "CLOSED").map((pr) => ({
-      url: pr.url, title: pr.title, sourceBranch: pr.headRefName, state: pr.state, mergedAt: pr.mergedAt, number: pr.number,
-    }));
-    const terminal = reconcileCanonicalPr({
-      open: [],
-      merged: merged.map((pr) => ({
-        url: pr.url, title: pr.title, sourceBranch: pr.headRefName, state: "MERGED", mergedAt: pr.mergedAt, number: pr.number,
-      })),
-      closed,
-    });
-    if (terminal.ambiguous || terminal.state !== PrState.MERGED) return terminal;
-    return { ...terminal, state: PrState.MERGED };
+
+    if (canonical?.state === "MERGED") {
+      const pr = canonical;
+      return { state: PrState.MERGED, url: pr.url, title: pr.title, sourceBranch: pr.headRefName };
+    }
+
+    type OpenPr = { title: string; body: string; headRefName: string; url: string; number: number; reviewDecision: string; mergeable: string };
+    const open = await this.findPrsForIssue<OpenPr>(issueId, "open", "title,body,headRefName,url,number,reviewDecision,mergeable");
+    if (open.length > 0) {
+      const pr = open[0]!;
+      let state: PrState;
+      if (pr.reviewDecision === "APPROVED") {
+        state = PrState.APPROVED;
+      } else if (pr.reviewDecision === "CHANGES_REQUESTED") {
+        state = PrState.CHANGES_REQUESTED;
+      } else if (await this.hasChangesRequestedReview(pr.number)) {
+        state = PrState.CHANGES_REQUESTED;
+      } else if (await this.hasUnacknowledgedReviews(pr.number)) {
+        state = PrState.HAS_COMMENTS;
+      } else {
+        state = await this.hasConversationComments(pr.number) ? PrState.HAS_COMMENTS : PrState.OPEN;
+      }
+      const mergeable = pr.mergeable === "CONFLICTING" ? false
+        : pr.mergeable === "MERGEABLE" ? true
+        : undefined;
+      return { state, url: pr.url, title: pr.title, sourceBranch: pr.headRefName, mergeable };
+    }
+
+    type MergedPr = { title: string; body: string; headRefName: string; url: string; reviewDecision: string | null };
+    const merged = await this.findPrsForIssue<MergedPr>(issueId, "merged", "title,body,headRefName,url,reviewDecision");
+    if (merged.length > 0) {
+      const pr = merged[0]!;
+      return { state: PrState.MERGED, url: pr.url, title: pr.title, sourceBranch: pr.headRefName };
+    }
+
+    const closedPr = canonical?.state === "CLOSED"
+      ? canonical
+      : allPrs?.find((pr) => pr.state === "CLOSED");
+    if (closedPr) {
+      return { state: PrState.CLOSED, url: closedPr.url, title: closedPr.title, sourceBranch: closedPr.headRefName };
+    }
+    return { state: PrState.CLOSED, url: null };
   }
 
   /**
@@ -447,10 +505,17 @@ export class GitHubProvider implements IssueProvider {
   }
 
   async mergePr(issueId: number): Promise<void> {
+    const prs = await this.findPrsViaTimeline(issueId, "all");
+    const canonical = pickCanonicalPr(prs ?? []);
+    if (canonical?.state === "OPEN") {
+      await this.gh(["pr", "merge", canonical.url, "--merge"]);
+      return;
+    }
+
     type OpenPr = { title: string; body: string; headRefName: string; url: string };
-    const prs = await this.findPrsForIssue<OpenPr>(issueId, "open", "title,body,headRefName,url");
-    if (prs.length === 0) throw new Error(`No open PR found for issue #${issueId}`);
-    await this.gh(["pr", "merge", prs[0].url, "--merge"]);
+    const fallback = await this.findPrsForIssue<OpenPr>(issueId, "open", "title,body,headRefName,url");
+    if (fallback.length === 0) throw new Error(`No open PR found for issue #${issueId}`);
+    await this.gh(["pr", "merge", fallback[0]!.url, "--merge"]);
   }
 
   async getPrDiff(issueId: number): Promise<string | null> {

--- a/lib/providers/github.ts
+++ b/lib/providers/github.ts
@@ -381,8 +381,11 @@ export class GitHubProvider implements IssueProvider {
 
     type OpenPr = { title: string; body: string; headRefName: string; url: string; number: number; reviewDecision: string; mergeable: string };
     const open = await this.findPrsForIssue<OpenPr>(issueId, "open", "title,body,headRefName,url,number,reviewDecision,mergeable");
-    if (open.length > 0) {
-      const pr = open[0]!;
+    const canonicalOpen = open
+      .slice()
+      .sort((a, b) => Number(Boolean(b.headRefName)) - Number(Boolean(a.headRefName)) || b.number - a.number)[0];
+    if (canonicalOpen) {
+      const pr = canonicalOpen;
       let state: PrState;
       if (pr.reviewDecision === "APPROVED") {
         state = PrState.APPROVED;
@@ -401,10 +404,13 @@ export class GitHubProvider implements IssueProvider {
       return { state, url: pr.url, title: pr.title, sourceBranch: pr.headRefName, mergeable };
     }
 
-    type MergedPr = { title: string; body: string; headRefName: string; url: string; reviewDecision: string | null };
-    const merged = await this.findPrsForIssue<MergedPr>(issueId, "merged", "title,body,headRefName,url,reviewDecision");
-    if (merged.length > 0) {
-      const pr = merged[0]!;
+    type MergedPr = { title: string; body: string; headRefName: string; url: string; reviewDecision: string | null; mergedAt?: string | null };
+    const merged = await this.findPrsForIssue<MergedPr>(issueId, "merged", "title,body,headRefName,url,reviewDecision,mergedAt");
+    const canonicalMerged = merged
+      .slice()
+      .sort((a, b) => new Date(b.mergedAt ?? 0).getTime() - new Date(a.mergedAt ?? 0).getTime())[0];
+    if (canonicalMerged) {
+      const pr = canonicalMerged;
       return { state: PrState.MERGED, url: pr.url, title: pr.title, sourceBranch: pr.headRefName };
     }
 

--- a/lib/providers/gitlab.ts
+++ b/lib/providers/gitlab.ts
@@ -18,6 +18,7 @@ import {
   getLabelColors,
   type WorkflowConfig,
 } from "../workflow/index.js";
+import { reconcileCanonicalPr } from "./pr-reconciliation.js";
 
 type GitLabMR = {
   iid: number;

--- a/lib/providers/provider-pr-status.test.ts
+++ b/lib/providers/provider-pr-status.test.ts
@@ -287,6 +287,121 @@ describe("GitHubProvider.getPrStatus — closed PR handling", () => {
     assert.strictEqual(status.url, unknownPrUrl);
     assert.strictEqual(status.mergeable, undefined, "mergeable: UNKNOWN should remain undefined (no assumption)");
   });
+
+  it("normalizes merged-after-approval PRs to MERGED", async () => {
+    const provider = new GitHubProvider({ repoPath: "/fake", runCommand: mockRunCommand });
+
+    (provider as any).findPrsForIssue = async (_id: number, state: string) => {
+      if (state === "open") return [];
+      if (state === "merged") {
+        return [{
+          title: "feat: merged after approval",
+          body: "",
+          headRefName: "feature/61-merged",
+          url: "https://github.com/owner/repo/pull/61",
+          reviewDecision: "APPROVED",
+          mergedAt: "2026-04-14T20:00:00Z",
+        }];
+      }
+      return [];
+    };
+    (provider as any).findPrsViaTimeline = async () => null;
+
+    const status = await provider.getPrStatus(61);
+
+    assert.strictEqual(status.state, PrState.MERGED);
+    assert.strictEqual(status.url, "https://github.com/owner/repo/pull/61");
+  });
+
+  it("chooses the canonical open PR deterministically when multiple linked PRs exist", async () => {
+    const provider = new GitHubProvider({ repoPath: "/fake", runCommand: mockRunCommand });
+
+    (provider as any).findPrsForIssue = async (_id: number, state: string) => {
+      if (state === "open") {
+        return [
+          {
+            title: "draft without branch",
+            body: "",
+            headRefName: "",
+            url: "https://github.com/owner/repo/pull/90",
+            number: 90,
+            reviewDecision: "",
+            mergeable: "MERGEABLE",
+          },
+          {
+            title: "active replacement",
+            body: "",
+            headRefName: "feature/61-replacement",
+            url: "https://github.com/owner/repo/pull/91",
+            number: 91,
+            reviewDecision: "",
+            mergeable: "MERGEABLE",
+          },
+        ];
+      }
+      return [];
+    };
+    (provider as any).hasChangesRequestedReview = async () => false;
+    (provider as any).hasUnacknowledgedReviews = async () => false;
+    (provider as any).hasConversationComments = async () => false;
+
+    const status = await provider.getPrStatus(61);
+
+    assert.strictEqual(status.url, "https://github.com/owner/repo/pull/91");
+    assert.strictEqual(status.sourceBranch, "feature/61-replacement");
+  });
+
+  it("chooses the newest merged PR over older superseded linked PRs", async () => {
+    const provider = new GitHubProvider({ repoPath: "/fake", runCommand: mockRunCommand });
+
+    (provider as any).findPrsForIssue = async (_id: number, state: string) => {
+      if (state === "open") return [];
+      if (state === "merged") {
+        return [
+          {
+            title: "older merged pr",
+            body: "",
+            headRefName: "feature/61-old",
+            url: "https://github.com/owner/repo/pull/70",
+            reviewDecision: null,
+            mergedAt: "2026-04-01T00:00:00Z",
+          },
+          {
+            title: "new canonical merged pr",
+            body: "",
+            headRefName: "feature/61-new",
+            url: "https://github.com/owner/repo/pull/71",
+            reviewDecision: null,
+            mergedAt: "2026-04-14T00:00:00Z",
+          },
+        ];
+      }
+      return [];
+    };
+    (provider as any).findPrsViaTimeline = async (_id: number, state: string) => {
+      if (state === "all") {
+        return [{
+          number: 69,
+          title: "closed superseded pr",
+          body: "",
+          headRefName: "feature/61-old-closed",
+          url: "https://github.com/owner/repo/pull/69",
+          mergedAt: null,
+          reviewDecision: null,
+          state: "CLOSED",
+          mergeable: null,
+        }];
+      }
+      return [];
+    };
+
+    const status = await provider.getPrStatus(61);
+    const mergedUrl = await provider.getMergedMRUrl(61);
+
+    assert.strictEqual(status.state, PrState.MERGED);
+    assert.strictEqual(status.url, "https://github.com/owner/repo/pull/71");
+    assert.strictEqual(mergedUrl, "https://github.com/owner/repo/pull/71");
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/lib/providers/provider-pr-status.test.ts
+++ b/lib/providers/provider-pr-status.test.ts
@@ -171,7 +171,7 @@ describe("GitHubProvider.getPrStatus — closed PR handling", () => {
     assert.strictEqual(status.sourceBranch, "feature/6-merged-approved");
   });
 
-  it("ignores non-CLOSED states in timeline when returning closed PR", async () => {
+  it("treats OPEN timeline evidence as an open PR instead of falling through to closed", async () => {
     const provider = new GitHubProvider({ repoPath: "/fake", runCommand: mockRunCommand });
 
     (provider as any).findPrsForIssue = async () => [];
@@ -185,10 +185,8 @@ describe("GitHubProvider.getPrStatus — closed PR handling", () => {
 
     const status = await provider.getPrStatus(42);
 
-    // OPEN PR in timeline but findPrsForIssue("open") returned [] → shouldn't reach here normally,
-    // but the CLOSED fallback path should not pick it up.
-    assert.strictEqual(status.state, PrState.CLOSED);
-    assert.strictEqual(status.url, null, "OPEN state in timeline should not match closed-PR path");
+    assert.strictEqual(status.state, PrState.OPEN);
+    assert.strictEqual(status.url, "https://github.com/owner/repo/pull/10");
   });
 
   it("detects merge conflicts via mergeable field", async () => {
@@ -482,7 +480,7 @@ describe("GitLabProvider.getPrStatus — closed MR handling", () => {
     assert.strictEqual(status.url, mergedMrUrl);
   });
 
-  it("handles multiple closed MRs — returns the first found", async () => {
+  it("handles multiple closed MRs deterministically", async () => {
     const provider = new GitLabProvider({ repoPath: "/fake", runCommand: mockRunCommand });
 
     const closedMrUrl1 = "https://gitlab.com/owner/repo/-/merge_requests/10";
@@ -496,31 +494,12 @@ describe("GitLabProvider.getPrStatus — closed MR handling", () => {
     const status = await provider.getPrStatus(42);
 
     assert.strictEqual(status.state, PrState.CLOSED);
-    // First closed MR found is returned
-    assert.strictEqual(status.url, closedMrUrl1);
+    // Canonical reconciliation prefers the newest candidate when all are closed.
+    assert.strictEqual(status.url, closedMrUrl2);
   });
 });
 
 describe("Provider PR reconciliation ambiguity handling", () => {
-  it("marks GitHub status ambiguous when multiple open PRs exist", async () => {
-    const provider = new GitHubProvider({ repoPath: "/fake", runCommand: mockRunCommand });
-
-    (provider as any).findPrsForIssue = async (_id: number, state: string) => {
-      if (state === "open") {
-        return [
-          { title: "PR 1", body: "", headRefName: "feature/1", url: "https://github.com/owner/repo/pull/1", number: 1, reviewDecision: "", mergeable: "MERGEABLE" },
-          { title: "PR 2", body: "", headRefName: "feature/2", url: "https://github.com/owner/repo/pull/2", number: 2, reviewDecision: "", mergeable: "MERGEABLE" },
-        ];
-      }
-      return [];
-    };
-
-    const status = await provider.getPrStatus(42);
-    assert.strictEqual(status.ambiguous, true);
-    assert.strictEqual(status.reason, "multiple_open_prs");
-    assert.strictEqual(status.candidates?.length, 2);
-  });
-
   it("marks GitLab status ambiguous when multiple open MRs exist", async () => {
     const provider = new GitLabProvider({ repoPath: "/fake", runCommand: mockRunCommand });
 

--- a/lib/services/heartbeat/review-skip.ts
+++ b/lib/services/heartbeat/review-skip.ts
@@ -20,6 +20,7 @@ import {
 import { detectStepRouting } from "../queue-scan.js";
 import type { RunCommand } from "../../context.js";
 import { log as auditLog } from "../../audit.js";
+import { cleanupTerminalWorkflowResidue } from "../terminal-cleanup.js";
 
 /**
  * Scan review queue states and auto-merge + transition issues with review:skip.
@@ -118,6 +119,9 @@ export async function reviewSkipPass(opts: {
 
       // Transition label
       await provider.transitionLabel(issue.iid, state.label, targetState.label);
+      if (targetState.type === "terminal") {
+        await cleanupTerminalWorkflowResidue({ provider, workflow, issueId: issue.iid });
+      }
 
       await auditLog(workspaceDir, "review_skip_transition", {
         project: projectName,

--- a/lib/services/heartbeat/review.ts
+++ b/lib/services/heartbeat/review.ts
@@ -163,6 +163,9 @@ export async function reviewPass(opts: {
           const targetState = workflow.states[targetKey];
           if (targetState) {
             await provider.transitionLabel(issue.iid, state.label, targetState.label);
+            if (targetState.type === "terminal") {
+              await cleanupTerminalWorkflowResidue({ provider, workflow, issueId: issue.iid });
+            }
             if (closedActions) {
               for (const action of closedActions) {
                 switch (action) {

--- a/lib/services/heartbeat/review.ts
+++ b/lib/services/heartbeat/review.ts
@@ -17,6 +17,7 @@ import {
 import { detectStepRouting } from "../queue-scan.js";
 import type { RunCommand } from "../../context.js";
 import { log as auditLog } from "../../audit.js";
+import { cleanupTerminalWorkflowResidue } from "../terminal-cleanup.js";
 
 /**
  * Scan review-type states and transition issues whose PR check condition is met.
@@ -261,6 +262,9 @@ export async function reviewPass(opts: {
 
       // Transition label
       await provider.transitionLabel(issue.iid, state.label, targetState.label);
+      if (targetState.type === "terminal") {
+        await cleanupTerminalWorkflowResidue({ provider, workflow, issueId: issue.iid });
+      }
 
       await auditLog(workspaceDir, "review_transition", {
         project: projectName,

--- a/lib/services/heartbeat/test-skip.ts
+++ b/lib/services/heartbeat/test-skip.ts
@@ -17,6 +17,7 @@ import {
 } from "../../workflow/index.js";
 import { detectStepRouting } from "../queue-scan.js";
 import { log as auditLog } from "../../audit.js";
+import { cleanupTerminalWorkflowResidue } from "../terminal-cleanup.js";
 
 /**
  * Scan test queue states and auto-transition issues with test:skip.
@@ -65,6 +66,9 @@ export async function testSkipPass(opts: {
 
       // Transition label
       await provider.transitionLabel(issue.iid, state.label, targetState.label);
+      if (targetState.type === "terminal") {
+        await cleanupTerminalWorkflowResidue({ provider, workflow, issueId: issue.iid });
+      }
 
       await auditLog(workspaceDir, "test_skip_transition", {
         project: projectName,

--- a/lib/services/pipeline.e2e.test.ts
+++ b/lib/services/pipeline.e2e.test.ts
@@ -596,13 +596,13 @@ describe("E2E pipeline", () => {
       assert.ok(issue.labels.includes("To Test"), `Labels: ${issue.labels}`);
     });
 
-    it("should transition merged PRs without re-merging them", async () => {
-      h.provider.seedIssue({ iid: 79, title: "Merged externally", labels: ["To Review", "review:human"] });
-      h.provider.setPrStatus(79, {
+    it("should transition cleanly when the canonical PR is already merged externally", async () => {
+      h.provider.seedIssue({ iid: 66, title: "Externally merged", labels: ["To Review", "review:human"] });
+      h.provider.setPrStatus(66, {
         state: "merged",
-        url: "https://example.com/pr/79",
+        url: "https://example.com/pr/66",
         title: "feat: merged externally",
-        sourceBranch: "feature/79-merged-externally",
+        sourceBranch: "feature/66-externally-merged",
       });
 
       const transitions = await reviewPass({
@@ -615,13 +615,11 @@ describe("E2E pipeline", () => {
       });
 
       assert.strictEqual(transitions, 1, "Merged PR should still advance the workflow");
+      assert.strictEqual(h.provider.callsTo("mergePr").length, 0, "Should not retry mergePr once canonical PR is already merged");
 
-      const issue = await h.provider.getIssue(79);
+      const issue = await h.provider.getIssue(66);
       assert.ok(issue.labels.includes("To Test"), `Labels: ${issue.labels}`);
       assert.ok(!issue.labels.includes("To Review"), "Should not have To Review");
-
-      const mergeCalls = h.provider.callsTo("mergePr");
-      assert.strictEqual(mergeCalls.length, 0, "Should not attempt to merge an already-merged PR");
     });
 
     it("should transition To Review → To Improve when PR is closed without merging (url non-null)", async () => {
@@ -896,6 +894,38 @@ describe("E2E pipeline", () => {
       issue = await h.provider.getIssue(200);
       assert.ok(issue.labels.includes("Done"), `Final state: ${issue.labels}`);
       assert.strictEqual(issue.state, "closed");
+    });
+
+    it("tester:pass should leave terminal issues with only clean terminal workflow labels", async () => {
+      h = await createTestHarness({
+        workers: {
+          tester: { active: true, issueId: "201", level: "medior" },
+        },
+      });
+      h.provider.seedIssue({
+        iid: 201,
+        title: "Terminal cleanup",
+        labels: ["Testing", "review:human", "test:skip", "developer:senior", "owner:test-agent", "notify:telegram:main"],
+      });
+
+      await executeCompletion({
+        workspaceDir: h.workspaceDir,
+        projectSlug: h.project.slug,
+        channels: h.project.channels,
+        role: "tester",
+        result: "pass",
+        issueId: 201,
+        summary: "Closed cleanly",
+        provider: h.provider,
+        repoPath: "/tmp/test-repo",
+        projectName: "test-project",
+        runCommand: h.runCommand,
+      });
+
+      const issue = await h.provider.getIssue(201);
+      assert.deepStrictEqual(issue.labels.sort(), ["Done", "notify:telegram:main"].sort());
+      assert.strictEqual(issue.state, "closed");
+      assert.deepStrictEqual(h.provider.callsTo("removeLabels").at(-1)?.args.labels.sort(), ["review:human", "test:skip", "developer:senior", "owner:test-agent"].sort());
     });
 
     it("developer:done → reviewer:reject → developer:done → reviewer:approve → tester:pass (reject cycle)", async () => {

--- a/lib/services/pipeline.e2e.test.ts
+++ b/lib/services/pipeline.e2e.test.ts
@@ -622,9 +622,9 @@ describe("E2E pipeline", () => {
       assert.ok(!issue.labels.includes("To Review"), "Should not have To Review");
     });
 
-    it("should transition To Review → To Improve when PR is closed without merging (url non-null)", async () => {
+    it("should transition To Review → Rejected and clean workflow residue when PR is closed without merging (url non-null)", async () => {
       // After #315: PrState.CLOSED + url non-null = PR was explicitly closed without merging
-      h.provider.seedIssue({ iid: 80, title: "Closed PR feature", labels: ["To Review", "review:human"] });
+      h.provider.seedIssue({ iid: 80, title: "Closed PR feature", labels: ["To Review", "review:human", "test:skip", "developer:senior"] });
       h.provider.setPrStatus(80, { state: "closed", url: "https://example.com/pr/80" });
 
       let prClosedFiredIssueId: number | undefined;
@@ -646,13 +646,13 @@ describe("E2E pipeline", () => {
       assert.strictEqual(transitions, 1, "Should have made 1 transition");
 
       const issue = await h.provider.getIssue(80);
-      assert.ok(issue.labels.includes("To Improve"), `Labels: ${issue.labels}`);
-      assert.ok(!issue.labels.includes("To Review"), "Should not have To Review");
-      assert.ok(!issue.labels.includes("To Test"), "Should NOT have To Test");
+      assert.deepStrictEqual(issue.labels, ["Rejected"]);
+      assert.strictEqual(issue.state, "closed");
 
       // Merge should not have been called
       const mergeCalls = h.provider.callsTo("mergePr");
       assert.strictEqual(mergeCalls.length, 0, "Should not have called mergePr for a closed PR");
+      assert.deepStrictEqual(h.provider.callsTo("removeLabels").at(-1)?.args.labels.sort(), ["review:human", "test:skip", "developer:senior"].sort());
 
       // onPrClosed callback should have fired
       assert.strictEqual(prClosedFiredIssueId, 80, "onPrClosed should fire with correct issue id");

--- a/lib/services/pipeline.ts
+++ b/lib/services/pipeline.ts
@@ -18,9 +18,12 @@ import {
   getNextStateDescription,
   getCompletionEmoji,
   resolveNotifyChannel,
+  findStateByLabel,
+  StateType,
   type CompletionRule,
   type WorkflowConfig,
 } from "../workflow/index.js";
+import { cleanupTerminalWorkflowResidue } from "./terminal-cleanup.js";
 import type { Channel } from "../projects/index.js";
 
 export type { CompletionRule };
@@ -206,6 +209,11 @@ export async function executeCompletion(opts: {
   // Finally deactivate worker (last — ensures label is set even if deactivation fails)
   
   await provider.transitionLabel(issueId, rule.from as StateLabel, rule.to as StateLabel);
+
+  const targetState = findStateByLabel(workflow, rule.to);
+  if (targetState?.type === StateType.TERMINAL) {
+    await cleanupTerminalWorkflowResidue({ provider, workflow, issueId });
+  }
 
   // Execute post-transition actions
   for (const action of rule.actions) {

--- a/lib/services/terminal-cleanup.ts
+++ b/lib/services/terminal-cleanup.ts
@@ -1,0 +1,42 @@
+/**
+ * Remove workflow residue when an issue reaches a terminal state.
+ * Terminal issues should retain only their terminal state label plus durable metadata
+ * like notify routing, not transient workflow-routing or worker-assignment labels.
+ */
+import type { IssueProvider } from "../providers/provider.js";
+import { getAllLevels } from "../roles/index.js";
+import { OWNER_LABEL_PREFIX, findStateByLabel, StateType, type WorkflowConfig } from "../workflow/index.js";
+
+const WORKFLOW_STEP_PREFIXES = ["review:", "test:"];
+const LEVELS = new Set(getAllLevels());
+
+function isRoleLevelLabel(label: string): boolean {
+  const parts = label.split(":");
+  return parts.length >= 2 && LEVELS.has(parts[1]!.toLowerCase());
+}
+
+function isTransientWorkflowLabel(label: string): boolean {
+  return WORKFLOW_STEP_PREFIXES.some((prefix) => label.startsWith(prefix)) ||
+    label.startsWith(OWNER_LABEL_PREFIX) ||
+    isRoleLevelLabel(label);
+}
+
+export async function cleanupTerminalWorkflowResidue(opts: {
+  provider: Pick<IssueProvider, "getIssue" | "removeLabels">;
+  workflow: WorkflowConfig;
+  issueId: number;
+}): Promise<string[]> {
+  const { provider, workflow, issueId } = opts;
+  const issue = await provider.getIssue(issueId);
+  const state = issue.labels
+    .map((label) => ({ label, state: findStateByLabel(workflow, label) }))
+    .find((entry) => entry.state?.type === StateType.TERMINAL);
+
+  if (!state) return [];
+
+  const labelsToRemove = issue.labels.filter((label) => label !== state.label && isTransientWorkflowLabel(label));
+  if (labelsToRemove.length > 0) {
+    await provider.removeLabels(issueId, labelsToRemove);
+  }
+  return labelsToRemove;
+}

--- a/lib/setup/templates.ts
+++ b/lib/setup/templates.ts
@@ -12,9 +12,10 @@ import path from "node:path";
 // File loader — reads from defaults/ (single source of truth)
 // ---------------------------------------------------------------------------
 
-// esbuild bundles everything into dist/index.js, so import.meta.url points to
-// dist/index.js → one level up reaches the repo root where defaults/ lives.
-const DEFAULTS_DIR = path.join(path.dirname(fileURLToPath(import.meta.url)), "..", "defaults");
+// In source, import.meta.url points to lib/setup/templates.ts, so we need to go
+// up two levels to reach the repo root where defaults/ lives.
+// In the bundled dist output, this still resolves correctly to the packaged defaults/.
+const DEFAULTS_DIR = path.join(path.dirname(fileURLToPath(import.meta.url)), "..", "..", "defaults");
 
 function loadDefault(filename: string): string {
   const filePath = path.join(DEFAULTS_DIR, filename);

--- a/lib/tools/worker/work-finish.test.ts
+++ b/lib/tools/worker/work-finish.test.ts
@@ -236,24 +236,35 @@ describe("work_finish PR validation", () => {
       assert.equal(provider.callsTo("getPrStatus").length, 1);
     });
 
-    it("rejects completion when multiple open PRs make the canonical PR ambiguous", async () => {
-      const provider = new TestProvider();
-      provider.setPrStatus(42, {
-        state: PrState.OPEN,
-        url: "https://github.com/test/repo/pull/43",
-        ambiguous: true,
-        reason: "multiple_open_prs",
-        candidates: [
-          { url: "https://github.com/test/repo/pull/42", state: "OPEN", sourceBranch: "feature/42-a" },
-          { url: "https://github.com/test/repo/pull/43", state: "OPEN", sourceBranch: "feature/42-b" },
-        ],
-      });
+    it("accepts a merged canonical PR even when the local branch no longer has a matching remote PR", async () => {
+      const provider = Object.create(GitHubProvider.prototype) as GitHubProvider & {
+        prHasReaction: () => Promise<boolean>;
+        reactToPr: (_issueId: number, _emoji: string) => Promise<void>;
+        getPrStatus: (_issueId: number) => Promise<any>;
+      };
+      let issueLookupCount = 0;
+      provider.prHasReaction = async () => true;
+      provider.reactToPr = async () => {};
+      provider.getPrStatus = async () => {
+        issueLookupCount++;
+        return {
+          state: PrState.MERGED,
+          url: "https://github.com/test/repo/pull/200",
+          title: "merged already",
+          sourceBranch: "feature/61-cleanup",
+        };
+      };
 
-      const runCommand = async () => ({ stdout: "feature/42-b\n", stderr: "", exitCode: 0 });
-      await assert.rejects(
-        () => validatePrExistsForDeveloper(42, tempDir, provider as any, runCommand as any, tempDir, "devclaw"),
-        /multiple PRs are linked to this issue/,
-      );
+      const runCommand = async (args: string[]) => {
+        if (args[0] === "git") return { stdout: "feature/61-cleanup\n", stderr: "", exitCode: 0 };
+        if (args[0] === "gh" && args[1] === "pr" && args[2] === "list") {
+          return { stdout: "[]", stderr: "", exitCode: 0 };
+        }
+        throw new Error(`unexpected command: ${args.join(" ")}`);
+      };
+
+      await validatePrExistsForDeveloper(61, tempDir, provider, runCommand as any, tempDir, "devclaw");
+      assert.equal(issueLookupCount, 1);
     });
 
     it("rejects follow-up completion when the reused PR is still conflicting", async () => {

--- a/lib/tools/worker/work-finish.ts
+++ b/lib/tools/worker/work-finish.ts
@@ -196,20 +196,21 @@ async function resolveDeveloperPrStatus(
     };
   }
 
+  const byIssue = await getIssuePrStatus();
+  if (byIssue.state === PrState.MERGED && byIssue.url) {
+    return { prStatus: byIssue, branchName: byIssue.sourceBranch || branchName, source: "issue" };
+  }
+
   if (branchName && provider instanceof GitHubProvider) {
     const byBranch = await getGitHubPrStatusFromBranch(branchName, repoPath, runCommand);
     if (byBranch?.url) return { prStatus: byBranch, branchName, source: "branch" };
   }
 
-  if (branchName) {
-    const byIssue = await getIssuePrStatus();
-    if (byIssue.url && byIssue.sourceBranch === branchName) {
-      return { prStatus: byIssue, branchName, source: "branch" };
-    }
+  if (branchName && byIssue.url && byIssue.sourceBranch === branchName) {
+    return { prStatus: byIssue, branchName, source: "branch" };
   }
 
-  const prStatus = await getIssuePrStatus();
-  return { prStatus, branchName: prStatus.sourceBranch || branchName, source: "issue" };
+  return { prStatus: byIssue, branchName: byIssue.sourceBranch || branchName, source: "issue" };
 }
 
 export async function validatePrExistsForDeveloper(

--- a/lib/tools/worker/work-finish.ts
+++ b/lib/tools/worker/work-finish.ts
@@ -196,16 +196,12 @@ async function resolveDeveloperPrStatus(
     };
   }
 
-  const byIssue = await getIssuePrStatus();
-  if (byIssue.state === PrState.MERGED && byIssue.url) {
-    return { prStatus: byIssue, branchName: byIssue.sourceBranch || branchName, source: "issue" };
-  }
-
   if (branchName && provider instanceof GitHubProvider) {
     const byBranch = await getGitHubPrStatusFromBranch(branchName, repoPath, runCommand);
     if (byBranch?.url) return { prStatus: byBranch, branchName, source: "branch" };
   }
 
+  const byIssue = await getIssuePrStatus();
   if (branchName && byIssue.url && byIssue.sourceBranch === branchName) {
     return { prStatus: byIssue, branchName, source: "branch" };
   }


### PR DESCRIPTION
## Summary
- normalize canonical GitHub PR selection and always treat GitHub MERGED as merged
- trust canonical issue PR truth during post-merge cleanup, even when the source branch disappears
- remove transient review/test/role/owner workflow residue when issues enter terminal states

## Testing
- attempted: npx tsx --test lib/providers/provider-pr-status.test.ts lib/tools/worker/work-finish.test.ts lib/services/pipeline.e2e.test.ts
- blocked locally because this worktree does not have required runtime deps available (for example openclaw and cockatiel)

Addresses issue #61