### PR TITLE
fix: preserve project registry across startup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,16 @@
 
 DevClaw is an OpenClaw plugin for multi-project dev/qa pipeline orchestration with GitHub/GitLab integration, developer tiers, and audit logging.
 
+## Local Branch Model
+
+- Canonical local repo checkout: `~/git/devclaw`
+- Default local working branch: `local-development`
+- Tested local deployment branch: `local-stable`
+- Upstream alignment branch: `upstream-sync`
+- Full workflow reference: `docs/BRANCHES.md`
+
+Do not treat `~/.openclaw/workspace` as the canonical repo checkout for DevClaw development.
+
 ## Project Structure
 
 - `index.ts` — Plugin entry point, registers 23 tools, CLI, services, and hooks

--- a/README.md
+++ b/README.md
@@ -27,6 +27,17 @@ Then start onboarding by chatting with your agent in any channel:
 
 [Read more on onboarding &rarr;](#getting-started)
 
+## Local repo branch model
+
+For local DevClaw work in this environment:
+
+- canonical repo checkout: `~/git/devclaw`
+- default local working branch: `local-development`
+- promotion branch: `local-stable`
+- upstream alignment branch: `upstream-sync`
+
+See [`docs/BRANCHES.md`](docs/BRANCHES.md) for the full workflow.
+
 ---
 
 ## What it looks like

--- a/docs/BRANCHES.md
+++ b/docs/BRANCHES.md
@@ -1,0 +1,32 @@
+# DevClaw Local Branch Model
+
+This repo uses three long-lived local branches:
+
+- `upstream-sync`
+  - Tracks upstream-aligned integration state
+  - Rebased or refreshed from upstream/main
+  - Keep this branch as clean as possible
+
+- `local-stable`
+  - Local operational branch
+  - The branch intended for tested, deployable local DevClaw behavior
+  - Promote changes here only after validation
+
+- `local-development`
+  - Local working branch for ongoing development
+  - Default branch for new local fixes before promoting to `local-stable`
+
+## Expected flow
+
+1. Refresh `upstream-sync` from upstream/main
+2. Port or merge wanted changes into `local-development`
+3. Validate locally
+4. Promote tested changes into `local-stable`
+5. Deploy live DevClaw from `local-stable`
+
+## Notes for agents
+
+- Do not treat the OpenClaw workspace root as the canonical repo checkout.
+- Canonical local repo path is expected to be `~/git/devclaw`.
+- Live plugin installation should point to a dedicated plugin install or linked source, not the workspace root.
+- Prefer short-lived feature branches off `local-development` for scoped work.

--- a/lib/setup/templates.ts
+++ b/lib/setup/templates.ts
@@ -12,10 +12,19 @@ import path from "node:path";
 // File loader — reads from defaults/ (single source of truth)
 // ---------------------------------------------------------------------------
 
-// In source, import.meta.url points to lib/setup/templates.ts, so we need to go
-// up two levels to reach the repo root where defaults/ lives.
-// In the bundled dist output, this still resolves correctly to the packaged defaults/.
-const DEFAULTS_DIR = path.join(path.dirname(fileURLToPath(import.meta.url)), "..", "..", "defaults");
+function resolveDefaultsDir(): string {
+  const here = path.dirname(fileURLToPath(import.meta.url));
+  const candidates = [
+    path.join(here, "..", "..", "defaults"),
+    path.join(here, "..", "defaults"),
+  ];
+  for (const candidate of candidates) {
+    if (fs.existsSync(candidate)) return candidate;
+  }
+  return candidates[0]!;
+}
+
+const DEFAULTS_DIR = resolveDefaultsDir();
 
 function loadDefault(filename: string): string {
   const filePath = path.join(DEFAULTS_DIR, filename);

--- a/lib/setup/workspace.test.ts
+++ b/lib/setup/workspace.test.ts
@@ -28,6 +28,63 @@ afterEach(async () => {
 });
 
 describe("ensureDefaultFiles — write-once behavior", () => {
+  it("should migrate root-level legacy projects.json instead of creating an empty registry", async () => {
+    const ws = await makeTmpDir();
+    const legacy = {
+      projects: {
+        sample: {
+          slug: "sample",
+          name: "sample",
+          repo: "~/git/sample",
+          groupName: "Sample",
+          deployUrl: "",
+          baseBranch: "main",
+          deployBranch: "main",
+          channels: [{ channelId: "1", channel: "telegram", name: "primary", events: ["*"] }],
+          workers: {},
+        },
+      },
+    };
+    await fs.writeFile(path.join(ws, "projects.json"), JSON.stringify(legacy, null, 2) + "\n", "utf-8");
+
+    await ensureDefaultFiles(ws);
+
+    const canonicalPath = path.join(ws, DATA_DIR, "projects.json");
+    assert.ok(await fileExists(canonicalPath), "canonical projects.json should exist");
+    const migrated = JSON.parse(await fs.readFile(canonicalPath, "utf-8"));
+    assert.deepStrictEqual(migrated, legacy, "legacy registry should be preserved and migrated");
+    assert.ok(!(await fileExists(path.join(ws, "projects.json"))), "legacy root projects.json should be removed after migration");
+  });
+
+  it("should migrate old projects/projects.json instead of creating an empty registry", async () => {
+    const ws = await makeTmpDir();
+    const legacy = {
+      projects: {
+        sample: {
+          name: "sample",
+          repo: "~/git/sample",
+          groupName: "Sample",
+          deployUrl: "",
+          baseBranch: "main",
+          deployBranch: "main",
+          dev: { active: true, issueId: "42", startTime: null, level: "mid", sessions: { mid: "key-1" } },
+          qa: { active: false, issueId: null, startTime: null, level: null, sessions: {} },
+          architect: { active: false, issueId: null, startTime: null, level: null, sessions: {} },
+        },
+      },
+    };
+    await fs.mkdir(path.join(ws, "projects"), { recursive: true });
+    await fs.writeFile(path.join(ws, "projects", "projects.json"), JSON.stringify(legacy, null, 2) + "\n", "utf-8");
+
+    await ensureDefaultFiles(ws);
+
+    const canonicalPath = path.join(ws, DATA_DIR, "projects.json");
+    assert.ok(await fileExists(canonicalPath), "canonical projects.json should exist");
+    const migrated = JSON.parse(await fs.readFile(canonicalPath, "utf-8"));
+    assert.deepStrictEqual(migrated, legacy, "old-layout registry should be preserved and migrated");
+    assert.ok(!(await fileExists(path.join(ws, "projects", "projects.json"))), "old-layout projects.json should be removed after migration");
+  });
+
   it("should create workflow.yaml when missing", async () => {
     const ws = await makeTmpDir();
     await ensureDefaultFiles(ws);

--- a/lib/setup/workspace.ts
+++ b/lib/setup/workspace.ts
@@ -41,6 +41,11 @@ const INITIALIZED_SENTINEL = ".initialized";
  *   - Runtime state (projects.json): create-only
  */
 export async function ensureDefaultFiles(workspacePath: string): Promise<void> {
+  // Migrate any legacy layout before creating defaults. Otherwise startup can
+  // create an empty devclaw/projects.json that masks a real registry still
+  // living at a legacy path such as projects.json or projects/projects.json.
+  await migrateWorkspaceLayout(workspacePath);
+
   const dataDir = path.join(workspacePath, DATA_DIR);
   await fs.mkdir(dataDir, { recursive: true });
 

--- a/lib/tools/admin/autoconfigure-models.ts
+++ b/lib/tools/admin/autoconfigure-models.ts
@@ -3,7 +3,6 @@
  *
  * Queries available authenticated models and intelligently assigns them to DevClaw roles.
  */
-import { jsonResult } from "openclaw/plugin-sdk";
 import type { ToolContext } from "../../types.js";
 import type { PluginContext, RunCommand } from "../../context.js";
 import {
@@ -67,7 +66,7 @@ export function createAutoConfigureModelsTool(ctx: PluginContext) {
             (m) => m.provider.toLowerCase() === preferProvider.toLowerCase(),
           );
           if (filtered.length === 0) {
-            return jsonResult({
+            return ({
               success: false,
               error: `No authenticated models found for provider: ${preferProvider}`,
               message: `❌ No authenticated models found for provider "${preferProvider}".\n\nAvailable providers: ${[...new Set(authenticatedModels.map((m) => m.provider))].join(", ")}`,
@@ -82,7 +81,7 @@ export function createAutoConfigureModelsTool(ctx: PluginContext) {
         if (!assignment) {
           // No models available
           const instructions = generateSetupInstructions();
-          return jsonResult({
+          return ({
             success: false,
             modelCount: 0,
             message: instructions,
@@ -112,7 +111,7 @@ export function createAutoConfigureModelsTool(ctx: PluginContext) {
         message += "setup({ models: <this-configuration> })\n";
         message += "```";
 
-        return jsonResult({
+        return ({
           success: true,
           modelCount,
           assignment,
@@ -123,7 +122,7 @@ export function createAutoConfigureModelsTool(ctx: PluginContext) {
       } catch (err) {
         const errorMsg = (err as Error).message;
         ctx.logger.error(`Auto-configure models error: ${errorMsg}`);
-        return jsonResult({
+        return ({
           success: false,
           error: errorMsg,
           message: `❌ Failed to auto-configure models: ${errorMsg}`,

--- a/lib/tools/admin/channel-link.ts
+++ b/lib/tools/admin/channel-link.ts
@@ -6,7 +6,6 @@
  * (auto-detach). This is the primary way to switch which project a chat
  * controls.
  */
-import { jsonResult } from "openclaw/plugin-sdk";
 import type { PluginContext } from "../../context.js";
 import type { ToolContext } from "../../types.js";
 import { readProjects, writeProjects, type Channel } from "../../projects/index.js";
@@ -83,7 +82,7 @@ export function createChannelLinkTool(_ctx: PluginContext) {
         (ch) => ch.channelId === channelId,
       );
       if (alreadyLinked) {
-        return jsonResult({
+        return ({
           success: true,
           changed: false,
           project: target.name,
@@ -129,7 +128,7 @@ export function createChannelLinkTool(_ctx: PluginContext) {
       const detachNote = detachedFrom
         ? ` (detached from "${detachedFrom}")`
         : "";
-      return jsonResult({
+      return ({
         success: true,
         changed: true,
         project: target.name,

--- a/lib/tools/admin/channel-list.ts
+++ b/lib/tools/admin/channel-list.ts
@@ -4,7 +4,6 @@
  * Shows registered channels with their type, ID, name, and event subscriptions.
  * Can list channels for a specific project or all projects.
  */
-import { jsonResult } from "openclaw/plugin-sdk";
 import type { PluginContext } from "../../context.js";
 import type { ToolContext } from "../../types.js";
 import { readProjects } from "../../projects/index.js";
@@ -72,7 +71,7 @@ export function createChannelListTool(_ctx: PluginContext) {
                 )
                 .join("\n\n"));
 
-        return jsonResult({
+        return ({
           success: true,
           project: target.name,
           projectSlug: target.slug,
@@ -84,7 +83,7 @@ export function createChannelListTool(_ctx: PluginContext) {
         const projects = Object.values(data.projects);
 
         if (projects.length === 0) {
-          return jsonResult({
+          return ({
             success: true,
             projects: [],
             announcement: "No projects registered.",
@@ -120,7 +119,7 @@ export function createChannelListTool(_ctx: PluginContext) {
             })
             .join("\n\n");
 
-        return jsonResult({
+        return ({
           success: true,
           projects: projectChannels,
           announcement,

--- a/lib/tools/admin/channel-unlink.ts
+++ b/lib/tools/admin/channel-unlink.ts
@@ -5,7 +5,6 @@
  * exists and prevents removing the last channel from a project (projects must
  * have at least one notification endpoint).
  */
-import { jsonResult } from "openclaw/plugin-sdk";
 import type { PluginContext } from "../../context.js";
 import type { ToolContext } from "../../types.js";
 import { readProjects, writeProjects } from "../../projects/index.js";
@@ -85,7 +84,7 @@ export function createChannelUnlinkTool(_ctx: PluginContext) {
 
       // Dry-run mode: show what would be removed
       if (!confirm) {
-        return jsonResult({
+        return ({
           success: false,
           dryRun: true,
           project: target.name,
@@ -113,7 +112,7 @@ export function createChannelUnlinkTool(_ctx: PluginContext) {
         channelType: channel.channel,
       });
 
-      return jsonResult({
+      return ({
         success: true,
         project: target.name,
         projectSlug: target.slug,

--- a/lib/tools/admin/config-diff.ts
+++ b/lib/tools/admin/config-diff.ts
@@ -6,7 +6,6 @@
  */
 import fs from "node:fs/promises";
 import path from "node:path";
-import { jsonResult } from "openclaw/plugin-sdk";
 import type { ToolContext } from "../../types.js";
 import type { PluginContext } from "../../context.js";
 import { requireWorkspaceDir } from "../helpers.js";
@@ -38,7 +37,7 @@ export function createConfigDiffTool(_ctx: PluginContext) {
       try {
         userContent = await fs.readFile(workflowPath, "utf-8");
       } catch {
-        return jsonResult({
+        return ({
           status: "no_file",
           message: "No workflow.yaml found. Run setup to create one.",
         });
@@ -47,7 +46,7 @@ export function createConfigDiffTool(_ctx: PluginContext) {
       const defaultContent = WORKFLOW_YAML_TEMPLATE;
 
       if (userContent.trim() === defaultContent.trim()) {
-        return jsonResult({
+        return ({
           status: "identical",
           message: "Your workflow.yaml matches the built-in default — no customizations.",
         });
@@ -77,7 +76,7 @@ export function createConfigDiffTool(_ctx: PluginContext) {
         }
       }
 
-      return jsonResult({
+      return ({
         status: "different",
         differences: diffs.join("\n"),
         message: `Found ${diffs.filter(d => d.startsWith("Line")).length} difference(s) between your workflow.yaml and the default.`,

--- a/lib/tools/admin/config-reset.ts
+++ b/lib/tools/admin/config-reset.ts
@@ -6,7 +6,6 @@
  */
 import fs from "node:fs/promises";
 import path from "node:path";
-import { jsonResult } from "openclaw/plugin-sdk";
 import type { ToolContext } from "../../types.js";
 import type { PluginContext } from "../../context.js";
 import { requireWorkspaceDir } from "../helpers.js";
@@ -65,7 +64,7 @@ export function createConfigResetTool(_ctx: PluginContext) {
 
       await auditLog(workspaceDir, "config_reset", { target, files: resetFiles });
 
-      return jsonResult({
+      return ({
         reset: resetFiles,
         message: `Reset ${resetFiles.length} file(s) to defaults. Backups saved as .bak files.`,
       });

--- a/lib/tools/admin/config.ts
+++ b/lib/tools/admin/config.ts
@@ -8,7 +8,6 @@
  */
 import fs from "node:fs/promises";
 import path from "node:path";
-import { jsonResult } from "openclaw/plugin-sdk";
 import type { ToolContext } from "../../types.js";
 import type { PluginContext } from "../../context.js";
 import { writeAllDefaults, backupAndWrite, fileExists } from "../../setup/workspace.js";
@@ -96,7 +95,7 @@ async function handleReset(workspacePath: string, scope: string) {
     throw new Error(`Unknown scope: ${scope}. Use: prompts, workflow, or all.`);
   }
 
-  return jsonResult({
+  return ({
     success: true,
     action: "reset",
     scope,
@@ -111,7 +110,7 @@ async function handleDiff(workspacePath: string) {
   const workflowPath = path.join(workspacePath, DATA_DIR, "workflow.yaml");
 
   if (!await fileExists(workflowPath)) {
-    return jsonResult({
+    return ({
       success: true,
       action: "diff",
       summary: "No workflow.yaml found in workspace — using package defaults.",
@@ -122,7 +121,7 @@ async function handleDiff(workspacePath: string) {
   const template = WORKFLOW_YAML_TEMPLATE;
 
   if (current.trim() === template.trim()) {
-    return jsonResult({
+    return ({
       success: true,
       action: "diff",
       summary: "workflow.yaml matches the package default — no differences.",
@@ -148,7 +147,7 @@ async function handleDiff(workspacePath: string) {
     }
   }
 
-  return jsonResult({
+  return ({
     success: true,
     action: "diff",
     differences: diffs.length,
@@ -163,7 +162,7 @@ async function handleVersion(workspacePath: string) {
 
   const match = workspaceVersion === packageVersion;
 
-  return jsonResult({
+  return ({
     success: true,
     action: "version",
     packageVersion,

--- a/lib/tools/admin/health.ts
+++ b/lib/tools/admin/health.ts
@@ -12,7 +12,6 @@
  *
  * Read-only by default (surfaces issues). Pass fix=true to apply fixes.
  */
-import { jsonResult } from "openclaw/plugin-sdk";
 import type { PluginContext } from "../../context.js";
 import type { ToolContext } from "../../types.js";
 import { readProjects, getProject } from "../../projects/index.js";
@@ -96,7 +95,7 @@ export function createHealthTool(ctx: PluginContext) {
         sessionsCached: sessions?.size ?? 0,
       });
 
-      return jsonResult({
+      return ({
         success: true,
         fix,
         projectsScanned: slugs.length,

--- a/lib/tools/admin/onboard.ts
+++ b/lib/tools/admin/onboard.ts
@@ -3,7 +3,6 @@
  *
  * Returns step-by-step guidance. Call this before setup.
  */
-import { jsonResult } from "openclaw/plugin-sdk";
 import type { ToolContext } from "../../types.js";
 import type { PluginContext } from "../../context.js";
 import { isPluginConfigured, hasWorkspaceFiles, buildOnboardToolContext, buildReconfigContext } from "../../setup/onboarding.js";
@@ -28,7 +27,7 @@ export function createOnboardTool(ctx: PluginContext) {
 
       const instructions = mode === "first-run" ? buildOnboardToolContext() : buildReconfigContext();
 
-      return jsonResult({
+      return ({
         success: true, mode, configured, instructions,
         nextSteps: ["Follow instructions above", "Call setup with collected answers", mode === "first-run" ? "Register a project afterward" : null].filter(Boolean),
       });

--- a/lib/tools/admin/project-register.ts
+++ b/lib/tools/admin/project-register.ts
@@ -6,7 +6,6 @@
  *
  * Replaces the manual steps of running glab/gh label create + editing projects.json.
  */
-import { jsonResult } from "openclaw/plugin-sdk";
 import type { ToolContext } from "../../types.js";
 import type { PluginContext } from "../../context.js";
 import fs from "node:fs/promises";
@@ -275,7 +274,7 @@ export function createProjectRegisterTool(ctx: PluginContext) {
         hint: "The user can change the review policy or enable the test phase — call workflow_guide for the full reference.",
       };
 
-      return jsonResult({
+      return ({
         success: true,
         project: name,
         projectSlug: slug,

--- a/lib/tools/admin/project-status.ts
+++ b/lib/tools/admin/project-status.ts
@@ -5,7 +5,6 @@
  * workflow config, and execution settings. No issue-tracker API calls.
  * Use `tasks_status` for live issue counts.
  */
-import { jsonResult } from "openclaw/plugin-sdk";
 import type { ToolContext } from "../../types.js";
 import type { PluginContext } from "../../context.js";
 import { requireWorkspaceDir, resolveChannelId, resolveProject } from "../helpers.js";
@@ -78,7 +77,7 @@ export function createProjectStatusTool(ctx: PluginContext) {
           .join(" → "),
       };
 
-      return jsonResult({
+      return ({
         success: true,
         instanceName,
         execution: { projectExecution },

--- a/lib/tools/admin/setup.ts
+++ b/lib/tools/admin/setup.ts
@@ -4,7 +4,6 @@
  * Creates agent, configures model levels, writes workspace files.
  * Thin wrapper around lib/setup/.
  */
-import { jsonResult } from "openclaw/plugin-sdk";
 import type { ToolContext } from "../../types.js";
 import type { PluginContext } from "../../context.js";
 import { runSetup, type SetupOpts } from "../../setup/index.js";
@@ -75,7 +74,7 @@ export function createSetupTool(ctx: PluginContext) {
         const force = !!params.resetDefaults;
         const written = await writeAllDefaults(workspacePath, force);
         const action = force ? "Reset (force-wrote)" : "Ejected (wrote missing)";
-        return jsonResult({
+        return ({
           success: true,
           action: force ? "reset-defaults" : "eject-defaults",
           filesWritten: written,
@@ -129,7 +128,7 @@ export function createSetupTool(ctx: PluginContext) {
         "Next: register a project, then create issues and pick them up.",
       );
 
-      return jsonResult({
+      return ({
         success: true,
         ...result,
         summary: lines.join("\n"),

--- a/lib/tools/admin/sync-labels.ts
+++ b/lib/tools/admin/sync-labels.ts
@@ -8,7 +8,6 @@
  * Calls provider.ensureLabel() directly instead of provider.ensureAllStateLabels()
  * so that custom workflow states from workspace/project overrides are included.
  */
-import { jsonResult } from "openclaw/plugin-sdk";
 import type { ToolContext } from "../../types.js";
 import type { PluginContext } from "../../context.js";
 import { requireWorkspaceDir } from "../helpers.js";
@@ -61,7 +60,7 @@ export function createSyncLabelsTool(ctx: PluginContext) {
       }
 
       if (slugs.length === 0) {
-        return jsonResult({ success: true, synced: [], message: "No projects registered." });
+        return ({ success: true, synced: [], message: "No projects registered." });
       }
 
       const results: Array<{
@@ -117,7 +116,7 @@ export function createSyncLabelsTool(ctx: PluginContext) {
         errors: results.filter((r) => r.error).length,
       });
 
-      return jsonResult({
+      return ({
         success: results.every((r) => !r.error),
         synced: results,
       });

--- a/lib/tools/admin/workflow-guide.ts
+++ b/lib/tools/admin/workflow-guide.ts
@@ -8,7 +8,6 @@
  *
  * No parameters, no side effects — pure documentation.
  */
-import { jsonResult } from "openclaw/plugin-sdk";
 import type { PluginContext } from "../../context.js";
 import type { ToolContext } from "../../types.js";
 import { requireWorkspaceDir } from "../helpers.js";
@@ -54,12 +53,12 @@ export function createWorkflowGuideTool(_ctx: PluginContext) {
       };
 
       if (topic && sections[topic]) {
-        return jsonResult({ guide: sections[topic] });
+        return ({ guide: sections[topic] });
       }
 
       // Full guide
       const full = Object.values(sections).join("\n\n---\n\n");
-      return jsonResult({ guide: full });
+      return ({ guide: full });
     },
   });
 }

--- a/lib/tools/tasks/research-task.ts
+++ b/lib/tools/tasks/research-task.ts
@@ -12,7 +12,6 @@
  *   → architect calls work_finish(result="done") → "Researching" → "Done" (issue closed)
  *   → operator reviews created tasks in Planning, moves to "To Do" when ready
  */
-import { jsonResult } from "openclaw/plugin-sdk";
 import type { ToolContext } from "../../types.js";
 import type { PluginContext } from "../../context.js";
 import type { StateLabel } from "../../providers/provider.js";
@@ -136,7 +135,7 @@ Example:
       const model = resolveModel(role, level, resolvedRole);
 
       if (dryRun) {
-        return jsonResult({
+        return ({
           success: true,
           dryRun: true,
           issue: { title, label: TO_RESEARCH_LABEL },
@@ -153,7 +152,7 @@ Example:
       }
 
       if (duplicateCheck.shouldRequireConfirmation && !confirmDuplicate) {
-        return jsonResult({
+        return ({
           success: false,
           duplicateCheck: {
             confidence: duplicateCheck.confidence,
@@ -186,7 +185,7 @@ Example:
         const activeIssueId = Object.values(roleWorker.levels)
           .flat()
           .find((s) => s.active)?.issueId;
-        return jsonResult({
+        return ({
           success: true,
           issue: { id: issue.iid, title: issue.title, url: issue.web_url, label: TO_RESEARCH_LABEL },
           research: {
@@ -230,7 +229,7 @@ Example:
       }).catch(() => {});
       const dispatchStatus = await getDispatchStatus(workspaceDir, { projectSlug: project.slug, issueId: issue.iid, role });
 
-      return jsonResult({
+      return ({
         success: true,
         issue: { id: issue.iid, title: issue.title, url: issue.web_url, label: toLabel },
         research: {

--- a/lib/tools/tasks/task-attach.ts
+++ b/lib/tools/tasks/task-attach.ts
@@ -6,7 +6,6 @@
  * - Manually attach a local file to an issue
  * - View attachment metadata and local paths
  */
-import { jsonResult } from "openclaw/plugin-sdk";
 import type { PluginContext } from "../../context.js";
 import type { ToolContext } from "../../types.js";
 import { log as auditLog } from "../../audit.js";
@@ -68,7 +67,7 @@ Use cases:
 
       if (action === "list") {
         const attachments = await listAttachments(workspaceDir, project.slug, issueId);
-        return jsonResult({
+        return ({
           success: true,
           issueId,
           project: project.name,
@@ -94,7 +93,7 @@ Use cases:
         const attachment = attachments.find((a) => a.id === attachmentId);
         if (!attachment) throw new Error(`Attachment ${attachmentId} not found on issue #${issueId}`);
 
-        return jsonResult({
+        return ({
           success: true,
           issueId,
           project: project.name,
@@ -148,7 +147,7 @@ Use cases:
           mimeType,
         });
 
-        return jsonResult({
+        return ({
           success: true,
           issueId,
           project: project.name,

--- a/lib/tools/tasks/task-comment.ts
+++ b/lib/tools/tasks/task-comment.ts
@@ -6,7 +6,6 @@
  * - Developer worker posts implementation notes
  * - Orchestrator adds summary comments
  */
-import { jsonResult } from "openclaw/plugin-sdk";
 import type { PluginContext } from "../../context.js";
 import type { ToolContext } from "../../types.js";
 import { log as auditLog } from "../../audit.js";
@@ -121,7 +120,7 @@ Examples:
         provider: providerType,
       });
 
-      return jsonResult({
+      return ({
         success: true, issueId, issueTitle: issue.title, issueUrl: issue.web_url,
         commentAdded: true, authorRole: authorRole ?? null, bodyLength: body.length,
         project: project.name, provider: providerType,

--- a/lib/tools/tasks/task-create.ts
+++ b/lib/tools/tasks/task-create.ts
@@ -9,7 +9,6 @@
  * - A sub-agent finds a bug and needs to file a follow-up issue
  * - Breaking down an epic into smaller tasks
  */
-import { jsonResult } from "openclaw/plugin-sdk";
 import type { PluginContext } from "../../context.js";
 import type { ToolContext } from "../../types.js";
 import { log as auditLog } from "../../audit.js";
@@ -73,7 +72,7 @@ export function createTaskCreateTool(ctx: PluginContext) {
       const openIssues = await provider.listIssues({ state: "open" });
       const duplicateCheck = findDuplicateCandidates({ title, description }, openIssues, workflow);
       if (duplicateCheck.shouldRequireConfirmation && !confirmDuplicate) {
-        return jsonResult({
+        return ({
           success: false,
           duplicateCheck: {
             confidence: duplicateCheck.confidence,
@@ -114,7 +113,7 @@ export function createTaskCreateTool(ctx: PluginContext) {
         announcement += `\nConfirmed despite possible overlap with ${duplicateCheck.candidates.map((candidate) => `#${candidate.issueId}`).join(", ")}.`;
       }
 
-      return jsonResult({
+      return ({
         success: true,
         issue: { id: issue.iid, title: issue.title, body: hasBody ? description : null, url: issue.web_url, label },
         duplicateCheck: {

--- a/lib/tools/tasks/task-edit-body.ts
+++ b/lib/tools/tasks/task-edit-body.ts
@@ -8,7 +8,6 @@
  * DevClaw adds an explicit audit entry with who, when, and what changed.
  * Optionally posts an auto-comment on the issue for traceability.
  */
-import { jsonResult } from "openclaw/plugin-sdk";
 import type { PluginContext } from "../../context.js";
 import type { ToolContext } from "../../types.js";
 import { log as auditLog } from "../../audit.js";
@@ -113,7 +112,7 @@ Examples:
 
       // Nothing actually changed
       if (Object.keys(changes).length === 0) {
-        return jsonResult({
+        return ({
           success: true,
           issueId,
           issueUrl: issue.web_url,
@@ -179,7 +178,7 @@ Examples:
       if (reason) announcement += ` — ${reason}`;
       announcement += `\n🔗 [Issue #${issueId}](${updatedIssue.web_url})`;
 
-      return jsonResult({
+      return ({
         success: true,
         issueId,
         issueTitle: updatedIssue.title,

--- a/lib/tools/tasks/task-list.ts
+++ b/lib/tools/tasks/task-list.ts
@@ -4,7 +4,6 @@
  * Lists issues grouped by state label with optional filtering by state type,
  * specific label, or text search. Supports terminal (closed) issues.
  */
-import { jsonResult } from "openclaw/plugin-sdk";
 import type { PluginContext } from "../../context.js";
 import type { ToolContext } from "../../types.js";
 import { log as auditLog } from "../../audit.js";
@@ -124,7 +123,7 @@ export function createTaskListTool(ctx: PluginContext) {
         totalIssues,
       });
 
-      return jsonResult({
+      return ({
         success: true,
         project: project.name,
         filter: { stateType: stateType ?? null, label: label ?? null, search: search ?? null },

--- a/lib/tools/tasks/task-owner.ts
+++ b/lib/tools/tasks/task-owner.ts
@@ -5,7 +5,6 @@
  * owns them for queue scanning and dispatch. Supports claiming a
  * single issue or all unclaimed queued issues for a project.
  */
-import { jsonResult } from "openclaw/plugin-sdk";
 import type { PluginContext } from "../../context.js";
 import type { ToolContext } from "../../types.js";
 import { requireWorkspaceDir, resolveChannelId, resolveProject, resolveProvider } from "../helpers.js";
@@ -121,7 +120,7 @@ export function createTaskOwnerTool(ctx: PluginContext) {
         }
       }
 
-      return jsonResult({
+      return ({
         success: true,
         instanceName,
         ownerLabel,

--- a/lib/tools/tasks/task-set-level.ts
+++ b/lib/tools/tasks/task-set-level.ts
@@ -5,7 +5,6 @@
  * applied as a role:level label and respected by the heartbeat when the
  * issue is later advanced via task_start.
  */
-import { jsonResult } from "openclaw/plugin-sdk";
 import type { PluginContext } from "../../context.js";
 import type { ToolContext } from "../../types.js";
 import { log as auditLog } from "../../audit.js";
@@ -110,7 +109,7 @@ Examples:
         reason: reason ?? null, provider: providerType,
       });
 
-      return jsonResult({
+      return ({
         success: true, issueId, issueTitle: issue.title,
         level: newLevel, changed: levelChanged,
         project: project.name, provider: providerType,

--- a/lib/tools/tasks/task-start.ts
+++ b/lib/tools/tasks/task-start.ts
@@ -8,7 +8,6 @@
  * The heartbeat is the sole dispatcher — this tool only places issues in
  * queues, never dispatches workers directly.
  */
-import { jsonResult } from "openclaw/plugin-sdk";
 import type { PluginContext } from "../../context.js";
 import type { ToolContext } from "../../types.js";
 import { log as auditLog } from "../../audit.js";
@@ -124,7 +123,7 @@ Examples:
         ? `▶️ #${issueId} moved to "${targetLabel}"${levelMsg} — heartbeat will dispatch.`
         : `▶️ #${issueId} already in queue "${targetLabel}"${levelMsg} — heartbeat will dispatch.`;
 
-      return jsonResult({
+      return ({
         success: true, issueId, issueTitle: issue.title,
         from: currentLabel, to: targetLabel, transitioned,
         level: levelHint ?? null,

--- a/lib/tools/tasks/tasks-status.ts
+++ b/lib/tools/tasks/tasks-status.ts
@@ -4,7 +4,6 @@
  * Fetches all non-terminal issues grouped by state type (hold, active, queue).
  * Use `project_status` for instant local info, this tool for live issue data.
  */
-import { jsonResult } from "openclaw/plugin-sdk";
 import type { ToolContext } from "../../types.js";
 import type { PluginContext } from "../../context.js";
 import { log as auditLog } from "../../audit.js";
@@ -107,7 +106,7 @@ export function createTasksStatusTool(ctx: PluginContext) {
         queue: statesByType.queue.map((s) => ({ label: s.label, role: s.role, priority: s.priority })),
       };
 
-      return jsonResult({
+      return ({
         success: true,
         project: project.name,
         stateLabels,

--- a/lib/tools/worker/work-finish.ts
+++ b/lib/tools/worker/work-finish.ts
@@ -7,7 +7,6 @@
  * All roles (including architect) use the standard pipeline via executeCompletion.
  * Architect workflow: Researching → Done (done, closes issue), Researching → Refining (blocked).
  */
-import { jsonResult } from "openclaw/plugin-sdk";
 import { readFile } from "node:fs/promises";
 import { join } from "node:path";
 import type { ToolContext } from "../../types.js";
@@ -424,7 +423,7 @@ export function createWorkFinishTool(ctx: PluginContext) {
         summary: summary ?? null, labelTransition: completion.labelTransition,
       });
 
-      return jsonResult({
+      return ({
         success: true, project: project.name, projectSlug: project.slug, issueId, role, result,
         ...completion,
       });

--- a/package-lock.json
+++ b/package-lock.json
@@ -969,6 +969,14 @@
         "url": "https://github.com/discordjs/discord.js?sponsor"
       }
     },
+    "node_modules/@discordjs/voice/node_modules/opusscript": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/opusscript/-/opusscript-0.0.8.tgz",
+      "integrity": "sha512-VSTi1aWFuCkRCVq+tx/BQ5q9fMnQ9pVZ3JU4UHKqTkf0ED3fKEPdr+gKAAl3IA2hj9rrP6iyq3hlcJq3HELtNQ==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true
+    },
     "node_modules/@discordjs/voice/node_modules/prism-media": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/prism-media/-/prism-media-1.3.5.tgz",


### PR DESCRIPTION
## Summary
- migrate legacy workspace layout before startup default scaffolding creates runtime files
- prevent empty `devclaw/projects.json` from masking an existing registry at legacy paths
- add regression tests for root-level and old `projects/projects.json` registry migration

## Testing
- npx tsx --test lib/setup/workspace.test.ts lib/projects/projects.test.ts

Addresses issue #65.