### PR TITLE
fix: preserve project registry across startup (#65)

### DIFF
--- a/lib/setup/workspace.test.ts
+++ b/lib/setup/workspace.test.ts
@@ -28,6 +28,63 @@ afterEach(async () => {
 });
 
 describe("ensureDefaultFiles — write-once behavior", () => {
+  it("should migrate root-level legacy projects.json instead of creating an empty registry", async () => {
+    const ws = await makeTmpDir();
+    const legacy = {
+      projects: {
+        sample: {
+          slug: "sample",
+          name: "sample",
+          repo: "~/git/sample",
+          groupName: "Sample",
+          deployUrl: "",
+          baseBranch: "main",
+          deployBranch: "main",
+          channels: [{ channelId: "1", channel: "telegram", name: "primary", events: ["*"] }],
+          workers: {},
+        },
+      },
+    };
+    await fs.writeFile(path.join(ws, "projects.json"), JSON.stringify(legacy, null, 2) + "\n", "utf-8");
+
+    await ensureDefaultFiles(ws);
+
+    const canonicalPath = path.join(ws, DATA_DIR, "projects.json");
+    assert.ok(await fileExists(canonicalPath), "canonical projects.json should exist");
+    const migrated = JSON.parse(await fs.readFile(canonicalPath, "utf-8"));
+    assert.deepStrictEqual(migrated, legacy, "legacy registry should be preserved and migrated");
+    assert.ok(!(await fileExists(path.join(ws, "projects.json"))), "legacy root projects.json should be removed after migration");
+  });
+
+  it("should migrate old projects/projects.json instead of creating an empty registry", async () => {
+    const ws = await makeTmpDir();
+    const legacy = {
+      projects: {
+        sample: {
+          name: "sample",
+          repo: "~/git/sample",
+          groupName: "Sample",
+          deployUrl: "",
+          baseBranch: "main",
+          deployBranch: "main",
+          dev: { active: true, issueId: "42", startTime: null, level: "mid", sessions: { mid: "key-1" } },
+          qa: { active: false, issueId: null, startTime: null, level: null, sessions: {} },
+          architect: { active: false, issueId: null, startTime: null, level: null, sessions: {} },
+        },
+      },
+    };
+    await fs.mkdir(path.join(ws, "projects"), { recursive: true });
+    await fs.writeFile(path.join(ws, "projects", "projects.json"), JSON.stringify(legacy, null, 2) + "\n", "utf-8");
+
+    await ensureDefaultFiles(ws);
+
+    const canonicalPath = path.join(ws, DATA_DIR, "projects.json");
+    assert.ok(await fileExists(canonicalPath), "canonical projects.json should exist");
+    const migrated = JSON.parse(await fs.readFile(canonicalPath, "utf-8"));
+    assert.deepStrictEqual(migrated, legacy, "old-layout registry should be preserved and migrated");
+    assert.ok(!(await fileExists(path.join(ws, "projects", "projects.json"))), "old-layout projects.json should be removed after migration");
+  });
+
   it("should create workflow.yaml when missing", async () => {
     const ws = await makeTmpDir();
     await ensureDefaultFiles(ws);

--- a/lib/setup/workspace.ts
+++ b/lib/setup/workspace.ts
@@ -41,6 +41,11 @@ const INITIALIZED_SENTINEL = ".initialized";
  *   - Runtime state (projects.json): create-only
  */
 export async function ensureDefaultFiles(workspacePath: string): Promise<void> {
+  // Migrate any legacy layout before creating defaults. Otherwise startup can
+  // create an empty devclaw/projects.json that masks a real registry still
+  // living at a legacy path such as projects.json or projects/projects.json.
+  await migrateWorkspaceLayout(workspacePath);
+
   const dataDir = path.join(workspacePath, DATA_DIR);
   await fs.mkdir(dataDir, { recursive: true });
 


### PR DESCRIPTION
## Summary
- migrate legacy workspace layout before scaffolding defaults on startup
- prevent startup from masking an existing legacy project registry with a fresh empty canonical registry
- add regression coverage for legacy `projects.json` locations

## Testing
- npx tsx --test lib/setup/workspace.test.ts

Addresses issue #65