### PR TITLE
docs: add workflow smoke test note

### DIFF
--- a/docs/WORKFLOW.md
+++ b/docs/WORKFLOW.md
@@ -4,6 +4,8 @@ The issue lifecycle in DevClaw is a configurable state machine defined in `workf
 
 For config file format and location, see [Configuration](CONFIGURATION.md).
 
+> For workflow validation and smoke tests, prefer a fresh issue when older issues have been manually relabeled, redispatched, or otherwise modified outside the normal pipeline. That keeps state history clean and makes stale redispatch or ghost-announcement bugs easier to detect.
+
 ---
 
 ## Default Pipeline


### PR DESCRIPTION
## Summary
- add a small visible docs note for workflow smoke-test guidance
- recommend using a fresh issue when older issues were manually modified outside the normal pipeline
- keep the change docs-only to validate the normal DevClaw workflow path

Closes #80