### PR TITLE
fix: rebuild local stable lane from main and isolate safe slices (#84)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,9 +5,9 @@ DevClaw is an OpenClaw plugin for multi-project dev/qa pipeline orchestration wi
 ## Local Branch Model
 
 - Canonical local repo checkout: `~/git/devclaw`
-- Default local working branch: `local-development`
-- Tested local deployment branch: `local-stable`
-- Upstream alignment branch: `upstream-sync`
+- Upstream sync branch: `main`
+- Active local integration branch: `devclaw-local-current` (live local runtime lane)
+- Tested local deployment branch: `devclaw-local-stable` (known-good fallback lane)
 - Full workflow reference: `docs/BRANCHES.md`
 
 Do not treat `~/.openclaw/workspace` as the canonical repo checkout for DevClaw development.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,16 @@
 
 DevClaw is an OpenClaw plugin for multi-project dev/qa pipeline orchestration with GitHub/GitLab integration, developer tiers, and audit logging.
 
+## Local Branch Model
+
+- Canonical local repo checkout: `~/git/devclaw`
+- Default local working branch: `local-development`
+- Tested local deployment branch: `local-stable`
+- Upstream alignment branch: `upstream-sync`
+- Full workflow reference: `docs/BRANCHES.md`
+
+Do not treat `~/.openclaw/workspace` as the canonical repo checkout for DevClaw development.
+
 ## Project Structure
 
 - `index.ts` — Plugin entry point, registers 23 tools, CLI, services, and hooks

--- a/README.md
+++ b/README.md
@@ -32,9 +32,9 @@ Then start onboarding by chatting with your agent in any channel:
 For local DevClaw work in this environment:
 
 - canonical repo checkout: `~/git/devclaw`
-- default local working branch: `local-development`
-- promotion branch: `local-stable`
-- upstream alignment branch: `upstream-sync`
+- upstream sync branch: `main`
+- active local integration branch: `devclaw-local-current` (live local runtime lane)
+- tested deployment branch: `devclaw-local-stable` (known-good fallback lane)
 
 See [`docs/BRANCHES.md`](docs/BRANCHES.md) for the full workflow.
 

--- a/README.md
+++ b/README.md
@@ -27,6 +27,17 @@ Then start onboarding by chatting with your agent in any channel:
 
 [Read more on onboarding &rarr;](#getting-started)
 
+## Local repo branch model
+
+For local DevClaw work in this environment:
+
+- canonical repo checkout: `~/git/devclaw`
+- default local working branch: `local-development`
+- promotion branch: `local-stable`
+- upstream alignment branch: `upstream-sync`
+
+See [`docs/BRANCHES.md`](docs/BRANCHES.md) for the full workflow.
+
 ---
 
 ## What it looks like

--- a/docs/BRANCHES.md
+++ b/docs/BRANCHES.md
@@ -1,0 +1,32 @@
+# DevClaw Local Branch Model
+
+This repo uses three long-lived local branches:
+
+- `upstream-sync`
+  - Tracks upstream-aligned integration state
+  - Rebased or refreshed from upstream/main
+  - Keep this branch as clean as possible
+
+- `local-stable`
+  - Local operational branch
+  - The branch intended for tested, deployable local DevClaw behavior
+  - Promote changes here only after validation
+
+- `local-development`
+  - Local working branch for ongoing development
+  - Default branch for new local fixes before promoting to `local-stable`
+
+## Expected flow
+
+1. Refresh `upstream-sync` from upstream/main
+2. Port or merge wanted changes into `local-development`
+3. Validate locally
+4. Promote tested changes into `local-stable`
+5. Deploy live DevClaw from `local-stable`
+
+## Notes for agents
+
+- Do not treat the OpenClaw workspace root as the canonical repo checkout.
+- Canonical local repo path is expected to be `~/git/devclaw`.
+- Live plugin installation should point to a dedicated plugin install or linked source, not the workspace root.
+- Prefer short-lived feature branches off `local-development` for scoped work.

--- a/docs/BRANCHES.md
+++ b/docs/BRANCHES.md
@@ -1,32 +1,45 @@
 # DevClaw Local Branch Model
 
-This repo uses three long-lived local branches:
+This repo now uses this local branch flow:
 
-- `upstream-sync`
-  - Tracks upstream-aligned integration state
-  - Rebased or refreshed from upstream/main
-  - Keep this branch as clean as possible
+- `main`
+  - Upstream/offical sync lane
+  - Keep it as close to official upstream state as possible
+  - Refresh it from `origin/main`
 
-- `local-stable`
-  - Local operational branch
+- `devclaw-local-stable`
+  - Local known-good deployment lane
   - The branch intended for tested, deployable local DevClaw behavior
   - Promote changes here only after validation
 
-- `local-development`
-  - Local working branch for ongoing development
-  - Default branch for new local fixes before promoting to `local-stable`
+- `devclaw-local-current`
+  - Local integration lane for active local work
+  - New local fixes should generally land here before promotion to stable
+
+- `feature/...`
+  - Short-lived issue/task branches
+  - Branch from `devclaw-local-current`
+  - Merge or cherry-pick back into `devclaw-local-current`
 
 ## Expected flow
 
-1. Refresh `upstream-sync` from upstream/main
-2. Port or merge wanted changes into `local-development`
-3. Validate locally
-4. Promote tested changes into `local-stable`
-5. Deploy live DevClaw from `local-stable`
+1. Refresh `main` from `origin/main`
+2. Port or merge wanted changes into `devclaw-local-current`
+3. Run live/local DevClaw from `devclaw-local-current`
+4. Vet changes in real use
+5. Promote tested changes into `devclaw-local-stable`
+
+## Deployment policy
+
+- `devclaw-local-current` is the live local runtime lane.
+- `devclaw-local-stable` is the known-good fallback and promotion lane.
+- Feature/task branches should generally target `devclaw-local-current`, not `devclaw-local-stable`.
+- Promote from `devclaw-local-current` to `devclaw-local-stable` only after the live/current lane is vetted.
 
 ## Notes for agents
 
 - Do not treat the OpenClaw workspace root as the canonical repo checkout.
 - Canonical local repo path is expected to be `~/git/devclaw`.
 - Live plugin installation should point to a dedicated plugin install or linked source, not the workspace root.
-- Prefer short-lived feature branches off `local-development` for scoped work.
+- Prefer short-lived feature branches off `devclaw-local-current` for scoped work.
+- `local-development`, `local-stable`, and older release-style branches should be treated as legacy names unless explicitly needed for migration/history.

--- a/docs/local-branch-cleanup-inventory.md
+++ b/docs/local-branch-cleanup-inventory.md
@@ -1,0 +1,219 @@
+# Local branch and worktree cleanup inventory
+
+Date: 2026-04-14
+
+## Current policy target
+
+The intended active local integration branch is:
+
+- `development/devclaw-local`
+
+Configured DevClaw project target (`devclaw/projects.json`):
+
+- `baseBranch = development/devclaw-local`
+- `deployBranch = development/devclaw-local`
+
+## Important current mismatch
+
+At the time of this inventory:
+
+- the local repo checkout is still on `release/devclaw-local-2026-04-12`
+- `development/devclaw-local` does **not** currently exist as a local branch
+- `origin/development/devclaw-local` does **not** currently exist as a remote branch
+
+This means branch-policy documentation and project config have been updated, but the actual Git branch migration is not complete yet.
+
+## Local branch inventory
+
+Current local branches observed:
+
+- `release/devclaw-local-2026-04-12` (current checked out branch)
+- `master`
+- `saisucks`
+- `test/apply-nonmerge-release`
+- `test/apply-release-to-upstream`
+- `feature/31-prevent-duplicate-drift`
+- `feature/31-workflow-integrity-guardrails`
+- `feature/33-duplicate-issue-detection`
+- `feature/34-pr-reconciliation`
+- `feature/34-pr-workflow-reconciliation`
+- `feature/35-regression-tests-workflow-integrity`
+- `feature/35-workflow-integrity-regression-tests`
+- `feature/35-workflow-integrity-regressions`
+
+Current remotes observed:
+
+- `origin/main`
+- `origin/release/devclaw-local-2026-04-12`
+- `origin/fix/follow-up-pr-validation`
+- `origin/fix/follow-up-pr-validation-v2`
+- several `origin/feature/*` workflow-fix branches
+- `upstream/main`
+
+## Attached Git worktrees in the main DevClaw repo
+
+Currently attached worktrees:
+
+- main checkout on `release/devclaw-local-2026-04-12`
+- `feature/31-prevent-duplicate-drift`
+- `feature/31-workflow-integrity-guardrails`
+- `feature/33-duplicate-issue-detection`
+- `feature/34-pr-reconciliation`
+- `feature/34-pr-workflow-reconciliation`
+- `feature/35-regression-tests-workflow-integrity`
+- `feature/35-workflow-integrity-regression-tests`
+- `feature/35-workflow-integrity-regressions`
+
+Notes:
+
+- These worktrees are attached under `/home/sai/.openclaw/workspace.worktrees/`
+- `feature/34-pr-workflow-reconciliation` currently points at the same commit as the main checkout, which makes it a good candidate for review during cleanup
+- none of these attached worktrees currently represent the intended `development/devclaw-local` integration lane
+
+## Nested sibling repos / scratch worktrees inside the workspace
+
+Observed sibling repos and scratch directories likely related to prior isolation work:
+
+- `devclaw-plugin`
+- `devclaw-plugin-issue20`
+- `devclaw-plugin-issue20-head`
+- `devclaw-plugin-issue25-observability`
+- `devclaw-plugin-issue25-validate`
+- `devclaw-plugin-issue26`
+- `devclaw-plugin-issue26-result-compat`
+- `devclaw-plugin-issue27`
+- `devclaw-plugin-issue27-task-manage-comment`
+- `devclaw-plugin-issue28-notify-canary`
+- `devclaw-plugin-issue28-notify-canary-docs`
+- `devclaw-plugin-issue28-notify-runtime`
+- `devclaw-plugin-issue29-build-provenance`
+- `devclaw-plugin-notification-split`
+- `devclaw-plugin-task-manage-comment`
+- `devclaw-plugin-validate-clean`
+- `devclaw-plugin-validate-issue20`
+
+Status notes from quick inspection:
+
+- several are detached-head validation worktrees
+- several are issue-split branches ahead of `origin/main`
+- several still have uncommitted changes and should be reviewed before deletion
+- these are not attached worktrees of the main DevClaw repo, but they are part of the broader local clutter and should be triaged deliberately
+
+## Safe cleanup classification
+
+### Preserve for now
+
+Preserve until reviewed and either merged, archived, or explicitly discarded:
+
+- all `feature/31` to `feature/35` branches and attached worktrees
+- `release/devclaw-local-2026-04-12`
+- `origin/fix/follow-up-pr-validation*` related local checkouts
+- issue-split repos under `devclaw-plugin-*` that are ahead of `origin/main`
+
+### Review for possible archive or deletion after confirmation
+
+Candidates for cleanup review once their value is confirmed:
+
+- detached validation worktrees (`*-validate*`, `*-head`)
+- duplicate or superseded split repos for the same issue bucket
+- test branches (`test/apply-*`)
+- ad-hoc local branches such as `saisucks` if they are no longer needed
+- legacy `master` if it is unused and redundant
+
+## Recommended staged cleanup sequence
+
+1. Create the actual branch `development/devclaw-local` from the intended source commit.
+2. Push it to `origin`.
+3. Repoint any active operational work and future PRs to that branch.
+4. Decide whether `release/devclaw-local-2026-04-12` stays as a frozen release marker.
+5. Triage attached `feature/*` worktrees: merge, archive, or delete.
+6. Triage `devclaw-plugin-*` sibling repos: keep only active issue-isolation worktrees.
+7. Remove obsolete scratch directories only after confirming there are no unpushed commits or needed local diffs.
+
+## Follow-up tasks suggested
+
+1. Create and publish `development/devclaw-local`, then retarget any open local operational PRs.
+2. Audit attached `feature/*` worktrees for merged/superseded/stale status and produce a safe delete list.
+3. Audit `devclaw-plugin-*` sibling repos and collapse duplicate validation/split worktrees.
+4. Optionally document a naming convention for temporary validation worktrees so future cleanup is easier.
+
+## Reviewed cleanup plan (issue #45)
+
+Review date: 2026-04-14
+
+### Attached worktrees
+
+| Path / branch | Status signals | Recommendation | Why |
+| --- | --- | --- | --- |
+| `workspace` on `release/devclaw-local-2026-04-12` | **dirty**, not compared to upstream, local config/docs edits present | **keep** | Active main checkout with uncommitted work. Not safe to archive or delete. |
+| `workspace.worktrees/development/devclaw-local` | clean, tracks `origin/development/devclaw-local`, ahead 0 / behind 0 | **keep** | This is the intended integration lane and should remain attached. |
+| `feature/31-prevent-duplicate-drift` | clean, tracks remote, **2 commits ahead of `origin/main`**, not merged to `origin/main` | **archive after review** | No dirt, but contains unique branch work. Safe delete would risk losing issue #31 history unless merged or bundled first. |
+| `feature/31-workflow-integrity-guardrails` | clean, tracks remote, merged to `origin/main` | **delete candidate** | Clean and merged, so low-risk cleanup once confirmed no PR/review context still needs local checkout. |
+| `feature/33-duplicate-issue-detection` | clean, tracks remote, merged to `origin/main` | **delete candidate** | Same as above. |
+| `feature/34-pr-reconciliation` | clean, tracks remote, merged to `origin/main` | **delete candidate** | Same as above. |
+| `feature/34-pr-workflow-reconciliation` | **dirty**, no usable upstream signal, same HEAD as release checkout | **keep** | The branch itself is merged-equivalent, but the worktree contains uncommitted changes, so deletion is unsafe until diff is reviewed or moved elsewhere. |
+| `feature/35-regression-tests-workflow-integrity` | clean, tracks remote, **3 commits ahead of `origin/main`**, not merged to `origin/main` | **archive after review** | Unique local/branch history is still present. Preserve until merged, tagged, or exported. |
+| `feature/35-workflow-integrity-regression-tests` | **dirty**, tracks remote, branch merged to `origin/main` | **keep** | Merged branch, but worktree has uncommitted test edits. Unsafe to delete before triage. |
+| `feature/35-workflow-integrity-regressions` | clean, tracks remote, **2 commits ahead of `origin/main`**, not merged to `origin/main` | **archive after review** | Holds unique regression-history commits and should not be dropped casually. |
+
+### Sibling `devclaw-plugin-*` repos
+
+| Repo | Status signals | Recommendation | Why |
+| --- | --- | --- | --- |
+| `devclaw-plugin-issue20` | **dirty detached HEAD**, staged/unstaged changes in audit and workflow observability files | **keep** | Highest-risk cleanup target. Contains live uncommitted work. |
+| `devclaw-plugin-issue20-head` | clean detached HEAD, **3 commits ahead of `origin/main`** | **archive after review** | Detached validation snapshot, but it points at unique local history. Preserve before cleanup. |
+| `devclaw-plugin-issue25-observability` | clean branch, tracks `origin/main`, **ahead by 6** | **archive after review** | Significant unmerged split branch. Preserve unless intentionally squashed or merged. |
+| `devclaw-plugin-issue25-validate` | clean detached HEAD, **4 commits ahead of `origin/main`** | **archive after review** | Validation clone with unique history. Archive or merge, not delete blind. |
+| `devclaw-plugin-issue26` | branch tracks `origin/main`, **dirty working tree** | **keep** | Uncommitted result-compat changes exist locally. |
+| `devclaw-plugin-issue26-result-compat` | clean branch, tracks `origin/main`, **ahead by 2** | **archive after review** | Contains isolated issue #26 commits. |
+| `devclaw-plugin-issue27` | clean branch, **2 commits ahead of `origin/main`** | **archive after review** | Local task-manage-comment work still exists only here. |
+| `devclaw-plugin-issue27-task-manage-comment` | clean branch, tracks `origin/main`, **ahead by 1** | **archive after review** | Probably superseded by the fuller issue27 repo, but still unique history. |
+| `devclaw-plugin-issue28-notify-canary` | clean branch, tracks `origin/main`, **ahead by 1** | **archive after review** | Unique split branch state. |
+| `devclaw-plugin-issue28-notify-canary-docs` | clean branch, tracks `origin/main`, **ahead by 1** | **archive after review** | Docs-only split, low risk after archival, but still unique. |
+| `devclaw-plugin-issue28-notify-runtime` | clean branch, no local-only commits vs `origin/main` | **delete candidate** | No dirty state and no unique history detected. Best low-risk sibling cleanup target. |
+| `devclaw-plugin-issue29-build-provenance` | clean branch, tracks `origin/main`, **ahead by 1** | **archive after review** | Unique split branch history remains. |
+| `devclaw-plugin-notification-split` | **dirty branch**, **3 commits ahead of `origin/main`** | **keep** | Mixed dirty state plus unique local history. Do not delete. |
+| `devclaw-plugin-task-manage-comment` | clean branch, **4 commits ahead of `origin/main`** | **archive after review** | Strong archive candidate, not delete candidate. |
+| `devclaw-plugin-validate-clean` | clean detached HEAD, **3 commits ahead of `origin/main`** | **archive after review** | Detached validation checkout with unique local commits. |
+| `devclaw-plugin-validate-issue20` | clean detached HEAD, no local-only commits vs `origin/main` | **delete candidate** | Clean validation clone with no unique commits detected. Lowest-risk detached cleanup target. |
+
+### Explicit risk callouts
+
+Do **not** delete these before extracting or committing the changes:
+
+- `workspace` (`release/devclaw-local-2026-04-12`) because it is dirty
+- `feature/34-pr-workflow-reconciliation` because it is dirty
+- `feature/35-workflow-integrity-regression-tests` because it is dirty
+- `devclaw-plugin-issue20` because it is dirty and detached
+- `devclaw-plugin-issue26` because it is dirty
+- `devclaw-plugin-notification-split` because it is dirty and also contains local-only commits
+
+Do **not** delete these without archiving, because they contain commits not present on `origin/main`:
+
+- `feature/31-prevent-duplicate-drift`
+- `feature/35-regression-tests-workflow-integrity`
+- `feature/35-workflow-integrity-regressions`
+- `devclaw-plugin-issue20-head`
+- `devclaw-plugin-issue25-observability`
+- `devclaw-plugin-issue25-validate`
+- `devclaw-plugin-issue26-result-compat`
+- `devclaw-plugin-issue27`
+- `devclaw-plugin-issue27-task-manage-comment`
+- `devclaw-plugin-issue28-notify-canary`
+- `devclaw-plugin-issue28-notify-canary-docs`
+- `devclaw-plugin-issue29-build-provenance`
+- `devclaw-plugin-notification-split`
+- `devclaw-plugin-task-manage-comment`
+- `devclaw-plugin-validate-clean`
+
+### Safe staged cleanup order
+
+1. Preserve all dirty trees first by either committing, exporting patches, or bundling branches.
+2. Delete the low-risk clean/no-unique-history candidates first:
+   - `feature/31-workflow-integrity-guardrails`
+   - `feature/33-duplicate-issue-detection`
+   - `feature/34-pr-reconciliation`
+   - `devclaw-plugin-issue28-notify-runtime`
+   - `devclaw-plugin-validate-issue20`
+3. Archive the clean but unique-history candidates by branch push, `git bundle`, or patch export.
+4. Only after archive/merge confirmation, remove the remaining duplicate validation and split repos.

--- a/docs/upgrade-strategy.md
+++ b/docs/upgrade-strategy.md
@@ -11,12 +11,17 @@ That split keeps upgrades understandable and repeatable.
 
 - Upstream repo: `yaqub0r/devclaw`
 - Default branch: `main`
-- Custom release branch pattern: `release/devclaw-<identifier>`
+- Canonical local operational branch: `release/devclaw-local`
+- Historical dated release branches may exist temporarily during migration or upgrade work
 - Temporary upgrade branch pattern: `upgrade/devclaw-<target-version>`
 
-Current branch created for local customization tracking:
+Current canonical branch for local customization tracking:
 
-- `release/devclaw-local-2026-04-12`
+- `release/devclaw-local`
+
+Migration note:
+
+- `release/devclaw-local-2026-04-12` is a predecessor branch retained for history and cleanup safety
 
 ## 1) Prefer supported overrides first
 
@@ -47,7 +52,8 @@ Examples:
 ### Stable branches
 
 - `main` tracks the base integration line
-- `release/devclaw-<identifier>` carries validated custom source patches
+- `release/devclaw-local` carries the validated local operational patch line
+- future dated release branches should be treated as transitional upgrade artifacts, not the default long-lived operational name
 
 ### Temporary branches
 
@@ -72,9 +78,10 @@ When upgrading DevClaw to a newer upstream version:
 4. Reapply custom commits using cherry-pick or rebase.
 5. Resolve conflicts.
 6. Test behavior.
-7. Create or update `release/devclaw-<new-version>`.
-8. Merge the validated release branch as desired.
-9. Update this document if the process changes.
+7. Reconstruct or validate the candidate release branch for the upgrade.
+8. Promote the validated result into `release/devclaw-local` when it becomes the operational lane.
+9. Archive or retain any dated predecessor release branch until the new lane is confirmed.
+10. Update this document if the process changes.
 
 ### Cherry-pick vs rebase
 

--- a/lib/context.ts
+++ b/lib/context.ts
@@ -5,7 +5,8 @@
  * Replaces the global singleton in run-command.ts with explicit injection.
  */
 import type { OpenClawPluginApi, PluginRuntime } from "openclaw/plugin-sdk";
-import { spawn } from "node:child_process";
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
 
 /**
  * RunCommand — the signature of api.runtime.system.runCommandWithTimeout.
@@ -37,6 +38,7 @@ export type PluginContext = {
  */
 export function createPluginContext(api: OpenClawPluginApi): PluginContext {
   const sdkRunCommand = api.runtime.system.runCommandWithTimeout;
+  const execFileAsync = promisify(execFile);
 
   const runCommand: RunCommand = async (argv, optionsOrTimeout) => {
     const command = argv[0] ?? "";
@@ -49,44 +51,28 @@ export function createPluginContext(api: OpenClawPluginApi): PluginContext {
     const timeoutMs = options.timeoutMs ?? 30_000;
     const env = { ...process.env, ...(options.env ?? {}) } as Record<string, string>;
 
-    return await new Promise<any>((resolve, reject) => {
-      const child = spawn(command, argv.slice(1), {
+    try {
+      const { stdout, stderr } = await execFileAsync(command, argv.slice(1), {
         cwd: options.cwd,
         env,
-        stdio: [options.input !== undefined ? "pipe" : "ignore", "pipe", "pipe"],
+        timeout: timeoutMs,
         windowsHide: true,
+        maxBuffer: 10 * 1024 * 1024,
       });
-
-      let stdout = "";
-      let stderr = "";
-      let settled = false;
-      let timedOut = false;
-      const timer = setTimeout(() => {
-        if (settled) return;
-        timedOut = true;
-        child.kill("SIGKILL");
-      }, timeoutMs);
-
-      child.stdout?.on("data", (d) => { stdout += d.toString(); });
-      child.stderr?.on("data", (d) => { stderr += d.toString(); });
-      child.on("error", (err) => {
-        if (settled) return;
-        settled = true;
-        clearTimeout(timer);
-        reject(err);
-      });
-      child.on("close", (code, signal) => {
-        if (settled) return;
-        settled = true;
-        clearTimeout(timer);
-        resolve({ stdout, stderr, code, signal, killed: timedOut, termination: timedOut ? "timeout" : "exit" });
-      });
-
-      if (options.input !== undefined && child.stdin) {
-        child.stdin.write(options.input);
-        child.stdin.end();
+      return { stdout, stderr, code: 0, signal: null, killed: false, termination: "exit" } as any;
+    } catch (error: any) {
+      if (typeof error?.stdout === "string" || typeof error?.stderr === "string") {
+        return {
+          stdout: error.stdout ?? "",
+          stderr: error.stderr ?? (error.message ?? ""),
+          code: typeof error.code === "number" ? error.code : 1,
+          signal: error.signal ?? null,
+          killed: Boolean(error.killed),
+          termination: error.killed ? "timeout" : "exit",
+        } as any;
       }
-    });
+      throw error;
+    }
   };
 
   return {

--- a/lib/context.ts
+++ b/lib/context.ts
@@ -5,6 +5,7 @@
  * Replaces the global singleton in run-command.ts with explicit injection.
  */
 import type { OpenClawPluginApi, PluginRuntime } from "openclaw/plugin-sdk";
+import { spawn } from "node:child_process";
 
 /**
  * RunCommand — the signature of api.runtime.system.runCommandWithTimeout.
@@ -35,8 +36,61 @@ export type PluginContext = {
  * Build a PluginContext from the raw plugin API. Called once in register().
  */
 export function createPluginContext(api: OpenClawPluginApi): PluginContext {
+  const sdkRunCommand = api.runtime.system.runCommandWithTimeout;
+
+  const runCommand: RunCommand = async (argv, optionsOrTimeout) => {
+    const command = argv[0] ?? "";
+    const isPinnedCli = command === "/usr/bin/gh" || command === "/usr/local/bin/gh" || command === "/usr/bin/glab" || command === "/usr/local/bin/glab";
+    if (!isPinnedCli) {
+      return sdkRunCommand(argv, optionsOrTimeout as any);
+    }
+
+    const options = typeof optionsOrTimeout === "number" ? { timeoutMs: optionsOrTimeout } : (optionsOrTimeout ?? {});
+    const timeoutMs = options.timeoutMs ?? 30_000;
+    const env = { ...process.env, ...(options.env ?? {}) } as Record<string, string>;
+
+    return await new Promise<any>((resolve, reject) => {
+      const child = spawn(command, argv.slice(1), {
+        cwd: options.cwd,
+        env,
+        stdio: [options.input !== undefined ? "pipe" : "ignore", "pipe", "pipe"],
+        windowsHide: true,
+      });
+
+      let stdout = "";
+      let stderr = "";
+      let settled = false;
+      let timedOut = false;
+      const timer = setTimeout(() => {
+        if (settled) return;
+        timedOut = true;
+        child.kill("SIGKILL");
+      }, timeoutMs);
+
+      child.stdout?.on("data", (d) => { stdout += d.toString(); });
+      child.stderr?.on("data", (d) => { stderr += d.toString(); });
+      child.on("error", (err) => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timer);
+        reject(err);
+      });
+      child.on("close", (code, signal) => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timer);
+        resolve({ stdout, stderr, code, signal, killed: timedOut, termination: timedOut ? "timeout" : "exit" });
+      });
+
+      if (options.input !== undefined && child.stdin) {
+        child.stdin.write(options.input);
+        child.stdin.end();
+      }
+    });
+  };
+
   return {
-    runCommand: api.runtime.system.runCommandWithTimeout,
+    runCommand,
     runtime: api.runtime,
     pluginConfig: api.pluginConfig as Record<string, unknown> | undefined,
     config: api.config,

--- a/lib/providers/github.ts
+++ b/lib/providers/github.ts
@@ -40,15 +40,17 @@ export class GitHubProvider implements IssueProvider {
   private repoPath: string;
   private workflow: WorkflowConfig;
   private runCommand: RunCommand;
+  private resilienceScopeKey: string;
 
   constructor(opts: { repoPath: string; runCommand: RunCommand; workflow?: WorkflowConfig }) {
     this.repoPath = opts.repoPath;
     this.runCommand = opts.runCommand;
     this.workflow = opts.workflow ?? DEFAULT_WORKFLOW;
+    this.resilienceScopeKey = `github:${this.repoPath}`;
   }
 
   private async gh(args: string[]): Promise<string> {
-    return withResilience(async () => {
+    return withResilience(this.resilienceScopeKey, async () => {
       const result = await this.runCommand(["gh", ...args], { timeoutMs: 30_000, cwd: this.repoPath });
       if (result.code != null && result.code !== 0) {
         throw new Error(result.stderr?.trim() || `gh command failed with exit code ${result.code}`);

--- a/lib/providers/github.ts
+++ b/lib/providers/github.ts
@@ -41,6 +41,7 @@ export class GitHubProvider implements IssueProvider {
   private workflow: WorkflowConfig;
   private runCommand: RunCommand;
   private resilienceScopeKey: string;
+  private ghExecutable: string | null | undefined = undefined;
 
   constructor(opts: { repoPath: string; runCommand: RunCommand; workflow?: WorkflowConfig }) {
     this.repoPath = opts.repoPath;
@@ -49,9 +50,31 @@ export class GitHubProvider implements IssueProvider {
     this.resilienceScopeKey = `github:${this.repoPath}`;
   }
 
+  private async resolveGhExecutable(): Promise<string> {
+    if (this.ghExecutable) return this.ghExecutable;
+    if (this.ghExecutable === null) return "gh";
+
+    const candidates = ["/usr/bin/gh", "/usr/local/bin/gh", "gh"];
+    for (const candidate of candidates) {
+      try {
+        const result = await this.runCommand([candidate, "--version"], { timeoutMs: 5_000, cwd: this.repoPath });
+        if (result.code === 0) {
+          this.ghExecutable = candidate;
+          return candidate;
+        }
+      } catch {
+        // try next candidate
+      }
+    }
+
+    this.ghExecutable = null;
+    return "gh";
+  }
+
   private async gh(args: string[]): Promise<string> {
     return withResilience(this.resilienceScopeKey, async () => {
-      const result = await this.runCommand(["gh", ...args], { timeoutMs: 30_000, cwd: this.repoPath });
+      const ghExecutable = await this.resolveGhExecutable();
+      const result = await this.runCommand([ghExecutable, ...args], { timeoutMs: 30_000, cwd: this.repoPath });
       if (result.code != null && result.code !== 0) {
         throw new Error(result.stderr?.trim() || `gh command failed with exit code ${result.code}`);
       }

--- a/lib/providers/github.ts
+++ b/lib/providers/github.ts
@@ -41,40 +41,19 @@ export class GitHubProvider implements IssueProvider {
   private workflow: WorkflowConfig;
   private runCommand: RunCommand;
   private resilienceScopeKey: string;
-  private ghExecutable: string | null | undefined = undefined;
+  private ghExecutable: string;
 
-  constructor(opts: { repoPath: string; runCommand: RunCommand; workflow?: WorkflowConfig }) {
+  constructor(opts: { repoPath: string; runCommand: RunCommand; workflow?: WorkflowConfig; ghExecutable?: string }) {
     this.repoPath = opts.repoPath;
     this.runCommand = opts.runCommand;
     this.workflow = opts.workflow ?? DEFAULT_WORKFLOW;
     this.resilienceScopeKey = `github:${this.repoPath}`;
-  }
-
-  private async resolveGhExecutable(): Promise<string> {
-    if (this.ghExecutable) return this.ghExecutable;
-    if (this.ghExecutable === null) return "gh";
-
-    const candidates = ["/usr/bin/gh", "/usr/local/bin/gh", "gh"];
-    for (const candidate of candidates) {
-      try {
-        const result = await this.runCommand([candidate, "--version"], { timeoutMs: 5_000, cwd: this.repoPath });
-        if (result.code === 0) {
-          this.ghExecutable = candidate;
-          return candidate;
-        }
-      } catch {
-        // try next candidate
-      }
-    }
-
-    this.ghExecutable = null;
-    return "gh";
+    this.ghExecutable = opts.ghExecutable ?? "/usr/bin/gh";
   }
 
   private async gh(args: string[]): Promise<string> {
     return withResilience(this.resilienceScopeKey, async () => {
-      const ghExecutable = await this.resolveGhExecutable();
-      const result = await this.runCommand([ghExecutable, ...args], { timeoutMs: 30_000, cwd: this.repoPath });
+      const result = await this.runCommand([this.ghExecutable, ...args], { timeoutMs: 30_000, cwd: this.repoPath });
       if (result.code != null && result.code !== 0) {
         throw new Error(result.stderr?.trim() || `gh command failed with exit code ${result.code}`);
       }

--- a/lib/providers/gitlab.ts
+++ b/lib/providers/gitlab.ts
@@ -36,6 +36,7 @@ export class GitLabProvider implements IssueProvider {
   private workflow: WorkflowConfig;
   private runCommand: RunCommand;
   private resilienceScopeKey: string;
+  private glabExecutable: string | null | undefined = undefined;
 
   constructor(opts: { repoPath: string; runCommand: RunCommand; workflow?: WorkflowConfig }) {
     this.repoPath = opts.repoPath;
@@ -44,9 +45,31 @@ export class GitLabProvider implements IssueProvider {
     this.resilienceScopeKey = `gitlab:${this.repoPath}`;
   }
 
+  private async resolveGlabExecutable(): Promise<string> {
+    if (this.glabExecutable) return this.glabExecutable;
+    if (this.glabExecutable === null) return "glab";
+
+    const candidates = ["/usr/bin/glab", "/usr/local/bin/glab", "glab"];
+    for (const candidate of candidates) {
+      try {
+        const result = await this.runCommand([candidate, "--version"], { timeoutMs: 5_000, cwd: this.repoPath });
+        if (result.code === 0) {
+          this.glabExecutable = candidate;
+          return candidate;
+        }
+      } catch {
+        // try next candidate
+      }
+    }
+
+    this.glabExecutable = null;
+    return "glab";
+  }
+
   private async glab(args: string[]): Promise<string> {
     return withResilience(this.resilienceScopeKey, async () => {
-      const result = await this.runCommand(["glab", ...args], { timeoutMs: 30_000, cwd: this.repoPath });
+      const glabExecutable = await this.resolveGlabExecutable();
+      const result = await this.runCommand([glabExecutable, ...args], { timeoutMs: 30_000, cwd: this.repoPath });
       return result.stdout.trim();
     });
   }

--- a/lib/providers/gitlab.ts
+++ b/lib/providers/gitlab.ts
@@ -35,15 +35,17 @@ export class GitLabProvider implements IssueProvider {
   private repoPath: string;
   private workflow: WorkflowConfig;
   private runCommand: RunCommand;
+  private resilienceScopeKey: string;
 
   constructor(opts: { repoPath: string; runCommand: RunCommand; workflow?: WorkflowConfig }) {
     this.repoPath = opts.repoPath;
     this.runCommand = opts.runCommand;
     this.workflow = opts.workflow ?? DEFAULT_WORKFLOW;
+    this.resilienceScopeKey = `gitlab:${this.repoPath}`;
   }
 
   private async glab(args: string[]): Promise<string> {
-    return withResilience(async () => {
+    return withResilience(this.resilienceScopeKey, async () => {
       const result = await this.runCommand(["glab", ...args], { timeoutMs: 30_000, cwd: this.repoPath });
       return result.stdout.trim();
     });

--- a/lib/providers/gitlab.ts
+++ b/lib/providers/gitlab.ts
@@ -36,40 +36,19 @@ export class GitLabProvider implements IssueProvider {
   private workflow: WorkflowConfig;
   private runCommand: RunCommand;
   private resilienceScopeKey: string;
-  private glabExecutable: string | null | undefined = undefined;
+  private glabExecutable: string;
 
-  constructor(opts: { repoPath: string; runCommand: RunCommand; workflow?: WorkflowConfig }) {
+  constructor(opts: { repoPath: string; runCommand: RunCommand; workflow?: WorkflowConfig; glabExecutable?: string }) {
     this.repoPath = opts.repoPath;
     this.runCommand = opts.runCommand;
     this.workflow = opts.workflow ?? DEFAULT_WORKFLOW;
     this.resilienceScopeKey = `gitlab:${this.repoPath}`;
-  }
-
-  private async resolveGlabExecutable(): Promise<string> {
-    if (this.glabExecutable) return this.glabExecutable;
-    if (this.glabExecutable === null) return "glab";
-
-    const candidates = ["/usr/bin/glab", "/usr/local/bin/glab", "glab"];
-    for (const candidate of candidates) {
-      try {
-        const result = await this.runCommand([candidate, "--version"], { timeoutMs: 5_000, cwd: this.repoPath });
-        if (result.code === 0) {
-          this.glabExecutable = candidate;
-          return candidate;
-        }
-      } catch {
-        // try next candidate
-      }
-    }
-
-    this.glabExecutable = null;
-    return "glab";
+    this.glabExecutable = opts.glabExecutable ?? "/usr/bin/glab";
   }
 
   private async glab(args: string[]): Promise<string> {
     return withResilience(this.resilienceScopeKey, async () => {
-      const glabExecutable = await this.resolveGlabExecutable();
-      const result = await this.runCommand([glabExecutable, ...args], { timeoutMs: 30_000, cwd: this.repoPath });
+      const result = await this.runCommand([this.glabExecutable, ...args], { timeoutMs: 30_000, cwd: this.repoPath });
       return result.stdout.trim();
     });
   }

--- a/lib/providers/index.ts
+++ b/lib/providers/index.ts
@@ -34,7 +34,7 @@ export async function createProvider(opts: ProviderOptions): Promise<ProviderWit
   const rc = opts.runCommand;
   const type = opts.provider ?? await detectProvider(repoPath, rc);
   const provider = type === "github"
-    ? new GitHubProvider({ repoPath, runCommand: rc })
-    : new GitLabProvider({ repoPath, runCommand: rc });
+    ? new GitHubProvider({ repoPath, runCommand: rc, ghExecutable: "/usr/bin/gh" })
+    : new GitLabProvider({ repoPath, runCommand: rc, glabExecutable: "/usr/bin/glab" });
   return { provider, type };
 }

--- a/lib/providers/resilience.test.ts
+++ b/lib/providers/resilience.test.ts
@@ -1,0 +1,53 @@
+import { afterEach, describe, it } from "node:test";
+import assert from "node:assert";
+import { BrokenCircuitError } from "cockatiel";
+import { getProviderPolicy, resetProviderPoliciesForTest, withResilience } from "./resilience.js";
+
+afterEach(() => {
+  resetProviderPoliciesForTest();
+});
+
+describe("provider resilience scoping", () => {
+  it("opens the breaker only for the failing scope", async () => {
+    for (let i = 0; i < 5; i += 1) {
+      await assert.rejects(
+        withResilience("github:/repo-a", async () => {
+          throw new Error(`repo A failure ${i}`);
+        }),
+      );
+    }
+
+    await assert.rejects(
+      withResilience("github:/repo-a", async () => "should not run"),
+      BrokenCircuitError,
+    );
+
+    const result = await withResilience("github:/repo-b", async () => "repo-b-ok");
+    assert.strictEqual(result, "repo-b-ok");
+  });
+
+  it("reuses breaker state within the same scope", async () => {
+    const scopedPolicy = getProviderPolicy("github:/repo-a", {
+      consecutiveFailures: 2,
+      halfOpenAfter: 60_000,
+    });
+
+    for (let i = 0; i < 2; i += 1) {
+      await assert.rejects(
+        scopedPolicy.execute(async () => {
+          throw new Error(`same repo failure ${i}`);
+        }),
+      );
+    }
+
+    await assert.rejects(
+      scopedPolicy.execute(async () => "should not run"),
+      BrokenCircuitError,
+    );
+
+    await assert.rejects(
+      withResilience("github:/repo-a", async () => "should still be blocked"),
+      BrokenCircuitError,
+    );
+  });
+});

--- a/lib/providers/resilience.ts
+++ b/lib/providers/resilience.ts
@@ -17,6 +17,7 @@ import {
 /**
  * Default retry policy: 3 attempts with exponential backoff.
  * Handles all errors (network, timeout, CLI failure).
+ * Safe to share globally because it carries no failure state between calls.
  */
 const retryPolicy = retry(handleAll, {
   maxAttempts: 3,
@@ -26,24 +27,44 @@ const retryPolicy = retry(handleAll, {
   }),
 });
 
-/**
- * Circuit breaker: opens after 5 consecutive failures, half-opens after 30s.
- * Prevents hammering a provider that's down.
- */
-const breakerPolicy = circuitBreaker(handleAll, {
-  halfOpenAfter: 30_000,
-  breaker: new ConsecutiveBreaker(5),
-});
+type ProviderPolicyOptions = {
+  halfOpenAfter?: number;
+  consecutiveFailures?: number;
+};
 
-/**
- * Combined policy: circuit breaker wrapping retry.
- * If circuit is open, calls fail fast without retrying.
- */
-export const providerPolicy: IPolicy = wrap(breakerPolicy, retryPolicy);
+const DEFAULT_POLICY_OPTIONS: Required<ProviderPolicyOptions> = {
+  halfOpenAfter: 30_000,
+  consecutiveFailures: 5,
+};
+
+const providerPolicies = new Map<string, IPolicy>();
+
+function createProviderPolicy(opts: ProviderPolicyOptions = {}): IPolicy {
+  const resolved = { ...DEFAULT_POLICY_OPTIONS, ...opts };
+  const breakerPolicy = circuitBreaker(handleAll, {
+    halfOpenAfter: resolved.halfOpenAfter,
+    breaker: new ConsecutiveBreaker(resolved.consecutiveFailures),
+  });
+  return wrap(breakerPolicy, retryPolicy);
+}
+
+export function getProviderPolicy(scopeKey: string, opts?: ProviderPolicyOptions): IPolicy {
+  const existing = providerPolicies.get(scopeKey);
+  if (existing) return existing;
+
+  const created = createProviderPolicy(opts);
+  providerPolicies.set(scopeKey, created);
+  return created;
+}
 
 /**
  * Execute a provider call with retry + circuit breaker.
+ * Circuit breaker state is scoped per provider/repo key instead of shared globally.
  */
-export function withResilience<T>(fn: () => Promise<T>): Promise<T> {
-  return providerPolicy.execute(() => fn());
+export function withResilience<T>(scopeKey: string, fn: () => Promise<T>): Promise<T> {
+  return getProviderPolicy(scopeKey).execute(() => fn()) as Promise<T>;
+}
+
+export function resetProviderPoliciesForTest(): void {
+  providerPolicies.clear();
 }

--- a/lib/setup/templates.ts
+++ b/lib/setup/templates.ts
@@ -12,9 +12,19 @@ import path from "node:path";
 // File loader — reads from defaults/ (single source of truth)
 // ---------------------------------------------------------------------------
 
-// esbuild bundles everything into dist/index.js, so import.meta.url points to
-// dist/index.js → one level up reaches the repo root where defaults/ lives.
-const DEFAULTS_DIR = path.join(path.dirname(fileURLToPath(import.meta.url)), "..", "defaults");
+function resolveDefaultsDir(): string {
+  const here = path.dirname(fileURLToPath(import.meta.url));
+  const candidates = [
+    path.join(here, "..", "..", "defaults"),
+    path.join(here, "..", "defaults"),
+  ];
+  for (const candidate of candidates) {
+    if (fs.existsSync(candidate)) return candidate;
+  }
+  return candidates[0]!;
+}
+
+const DEFAULTS_DIR = resolveDefaultsDir();
 
 function loadDefault(filename: string): string {
   const filePath = path.join(DEFAULTS_DIR, filename);

--- a/lib/setup/workspace.test.ts
+++ b/lib/setup/workspace.test.ts
@@ -28,6 +28,63 @@ afterEach(async () => {
 });
 
 describe("ensureDefaultFiles — write-once behavior", () => {
+  it("should migrate root-level legacy projects.json instead of creating an empty registry", async () => {
+    const ws = await makeTmpDir();
+    const legacy = {
+      projects: {
+        sample: {
+          slug: "sample",
+          name: "sample",
+          repo: "~/git/sample",
+          groupName: "Sample",
+          deployUrl: "",
+          baseBranch: "main",
+          deployBranch: "main",
+          channels: [{ channelId: "1", channel: "telegram", name: "primary", events: ["*"] }],
+          workers: {},
+        },
+      },
+    };
+    await fs.writeFile(path.join(ws, "projects.json"), JSON.stringify(legacy, null, 2) + "\n", "utf-8");
+
+    await ensureDefaultFiles(ws);
+
+    const canonicalPath = path.join(ws, DATA_DIR, "projects.json");
+    assert.ok(await fileExists(canonicalPath), "canonical projects.json should exist");
+    const migrated = JSON.parse(await fs.readFile(canonicalPath, "utf-8"));
+    assert.deepStrictEqual(migrated, legacy, "legacy registry should be preserved and migrated");
+    assert.ok(!(await fileExists(path.join(ws, "projects.json"))), "legacy root projects.json should be removed after migration");
+  });
+
+  it("should migrate old projects/projects.json instead of creating an empty registry", async () => {
+    const ws = await makeTmpDir();
+    const legacy = {
+      projects: {
+        sample: {
+          name: "sample",
+          repo: "~/git/sample",
+          groupName: "Sample",
+          deployUrl: "",
+          baseBranch: "main",
+          deployBranch: "main",
+          dev: { active: true, issueId: "42", startTime: null, level: "mid", sessions: { mid: "key-1" } },
+          qa: { active: false, issueId: null, startTime: null, level: null, sessions: {} },
+          architect: { active: false, issueId: null, startTime: null, level: null, sessions: {} },
+        },
+      },
+    };
+    await fs.mkdir(path.join(ws, "projects"), { recursive: true });
+    await fs.writeFile(path.join(ws, "projects", "projects.json"), JSON.stringify(legacy, null, 2) + "\n", "utf-8");
+
+    await ensureDefaultFiles(ws);
+
+    const canonicalPath = path.join(ws, DATA_DIR, "projects.json");
+    assert.ok(await fileExists(canonicalPath), "canonical projects.json should exist");
+    const migrated = JSON.parse(await fs.readFile(canonicalPath, "utf-8"));
+    assert.deepStrictEqual(migrated, legacy, "old-layout registry should be preserved and migrated");
+    assert.ok(!(await fileExists(path.join(ws, "projects", "projects.json"))), "old-layout projects.json should be removed after migration");
+  });
+
   it("should create workflow.yaml when missing", async () => {
     const ws = await makeTmpDir();
     await ensureDefaultFiles(ws);

--- a/lib/setup/workspace.ts
+++ b/lib/setup/workspace.ts
@@ -41,6 +41,11 @@ const INITIALIZED_SENTINEL = ".initialized";
  *   - Runtime state (projects.json): create-only
  */
 export async function ensureDefaultFiles(workspacePath: string): Promise<void> {
+  // Migrate any legacy layout before creating defaults. Otherwise startup can
+  // create an empty devclaw/projects.json that masks a real registry still
+  // living at a legacy path such as projects.json or projects/projects.json.
+  await migrateWorkspaceLayout(workspacePath);
+
   const dataDir = path.join(workspacePath, DATA_DIR);
   await fs.mkdir(dataDir, { recursive: true });
 

--- a/lib/tools/admin/autoconfigure-models.ts
+++ b/lib/tools/admin/autoconfigure-models.ts
@@ -3,7 +3,6 @@
  *
  * Queries available authenticated models and intelligently assigns them to DevClaw roles.
  */
-import { jsonResult } from "openclaw/plugin-sdk";
 import type { ToolContext } from "../../types.js";
 import type { PluginContext, RunCommand } from "../../context.js";
 import {
@@ -67,7 +66,7 @@ export function createAutoConfigureModelsTool(ctx: PluginContext) {
             (m) => m.provider.toLowerCase() === preferProvider.toLowerCase(),
           );
           if (filtered.length === 0) {
-            return jsonResult({
+            return ({
               success: false,
               error: `No authenticated models found for provider: ${preferProvider}`,
               message: `❌ No authenticated models found for provider "${preferProvider}".\n\nAvailable providers: ${[...new Set(authenticatedModels.map((m) => m.provider))].join(", ")}`,
@@ -82,7 +81,7 @@ export function createAutoConfigureModelsTool(ctx: PluginContext) {
         if (!assignment) {
           // No models available
           const instructions = generateSetupInstructions();
-          return jsonResult({
+          return ({
             success: false,
             modelCount: 0,
             message: instructions,
@@ -112,7 +111,7 @@ export function createAutoConfigureModelsTool(ctx: PluginContext) {
         message += "setup({ models: <this-configuration> })\n";
         message += "```";
 
-        return jsonResult({
+        return ({
           success: true,
           modelCount,
           assignment,
@@ -123,7 +122,7 @@ export function createAutoConfigureModelsTool(ctx: PluginContext) {
       } catch (err) {
         const errorMsg = (err as Error).message;
         ctx.logger.error(`Auto-configure models error: ${errorMsg}`);
-        return jsonResult({
+        return ({
           success: false,
           error: errorMsg,
           message: `❌ Failed to auto-configure models: ${errorMsg}`,

--- a/lib/tools/admin/channel-link.ts
+++ b/lib/tools/admin/channel-link.ts
@@ -6,7 +6,6 @@
  * (auto-detach). This is the primary way to switch which project a chat
  * controls.
  */
-import { jsonResult } from "openclaw/plugin-sdk";
 import type { PluginContext } from "../../context.js";
 import type { ToolContext } from "../../types.js";
 import { readProjects, writeProjects, type Channel } from "../../projects/index.js";
@@ -83,7 +82,7 @@ export function createChannelLinkTool(_ctx: PluginContext) {
         (ch) => ch.channelId === channelId,
       );
       if (alreadyLinked) {
-        return jsonResult({
+        return ({
           success: true,
           changed: false,
           project: target.name,
@@ -129,7 +128,7 @@ export function createChannelLinkTool(_ctx: PluginContext) {
       const detachNote = detachedFrom
         ? ` (detached from "${detachedFrom}")`
         : "";
-      return jsonResult({
+      return ({
         success: true,
         changed: true,
         project: target.name,

--- a/lib/tools/admin/channel-list.ts
+++ b/lib/tools/admin/channel-list.ts
@@ -4,7 +4,6 @@
  * Shows registered channels with their type, ID, name, and event subscriptions.
  * Can list channels for a specific project or all projects.
  */
-import { jsonResult } from "openclaw/plugin-sdk";
 import type { PluginContext } from "../../context.js";
 import type { ToolContext } from "../../types.js";
 import { readProjects } from "../../projects/index.js";
@@ -72,7 +71,7 @@ export function createChannelListTool(_ctx: PluginContext) {
                 )
                 .join("\n\n"));
 
-        return jsonResult({
+        return ({
           success: true,
           project: target.name,
           projectSlug: target.slug,
@@ -84,7 +83,7 @@ export function createChannelListTool(_ctx: PluginContext) {
         const projects = Object.values(data.projects);
 
         if (projects.length === 0) {
-          return jsonResult({
+          return ({
             success: true,
             projects: [],
             announcement: "No projects registered.",
@@ -120,7 +119,7 @@ export function createChannelListTool(_ctx: PluginContext) {
             })
             .join("\n\n");
 
-        return jsonResult({
+        return ({
           success: true,
           projects: projectChannels,
           announcement,

--- a/lib/tools/admin/channel-unlink.ts
+++ b/lib/tools/admin/channel-unlink.ts
@@ -5,7 +5,6 @@
  * exists and prevents removing the last channel from a project (projects must
  * have at least one notification endpoint).
  */
-import { jsonResult } from "openclaw/plugin-sdk";
 import type { PluginContext } from "../../context.js";
 import type { ToolContext } from "../../types.js";
 import { readProjects, writeProjects } from "../../projects/index.js";
@@ -85,7 +84,7 @@ export function createChannelUnlinkTool(_ctx: PluginContext) {
 
       // Dry-run mode: show what would be removed
       if (!confirm) {
-        return jsonResult({
+        return ({
           success: false,
           dryRun: true,
           project: target.name,
@@ -113,7 +112,7 @@ export function createChannelUnlinkTool(_ctx: PluginContext) {
         channelType: channel.channel,
       });
 
-      return jsonResult({
+      return ({
         success: true,
         project: target.name,
         projectSlug: target.slug,

--- a/lib/tools/admin/config-diff.ts
+++ b/lib/tools/admin/config-diff.ts
@@ -6,7 +6,6 @@
  */
 import fs from "node:fs/promises";
 import path from "node:path";
-import { jsonResult } from "openclaw/plugin-sdk";
 import type { ToolContext } from "../../types.js";
 import type { PluginContext } from "../../context.js";
 import { requireWorkspaceDir } from "../helpers.js";
@@ -38,7 +37,7 @@ export function createConfigDiffTool(_ctx: PluginContext) {
       try {
         userContent = await fs.readFile(workflowPath, "utf-8");
       } catch {
-        return jsonResult({
+        return ({
           status: "no_file",
           message: "No workflow.yaml found. Run setup to create one.",
         });
@@ -47,7 +46,7 @@ export function createConfigDiffTool(_ctx: PluginContext) {
       const defaultContent = WORKFLOW_YAML_TEMPLATE;
 
       if (userContent.trim() === defaultContent.trim()) {
-        return jsonResult({
+        return ({
           status: "identical",
           message: "Your workflow.yaml matches the built-in default — no customizations.",
         });
@@ -77,7 +76,7 @@ export function createConfigDiffTool(_ctx: PluginContext) {
         }
       }
 
-      return jsonResult({
+      return ({
         status: "different",
         differences: diffs.join("\n"),
         message: `Found ${diffs.filter(d => d.startsWith("Line")).length} difference(s) between your workflow.yaml and the default.`,

--- a/lib/tools/admin/config-reset.ts
+++ b/lib/tools/admin/config-reset.ts
@@ -6,7 +6,6 @@
  */
 import fs from "node:fs/promises";
 import path from "node:path";
-import { jsonResult } from "openclaw/plugin-sdk";
 import type { ToolContext } from "../../types.js";
 import type { PluginContext } from "../../context.js";
 import { requireWorkspaceDir } from "../helpers.js";
@@ -65,7 +64,7 @@ export function createConfigResetTool(_ctx: PluginContext) {
 
       await auditLog(workspaceDir, "config_reset", { target, files: resetFiles });
 
-      return jsonResult({
+      return ({
         reset: resetFiles,
         message: `Reset ${resetFiles.length} file(s) to defaults. Backups saved as .bak files.`,
       });

--- a/lib/tools/admin/config.ts
+++ b/lib/tools/admin/config.ts
@@ -8,7 +8,6 @@
  */
 import fs from "node:fs/promises";
 import path from "node:path";
-import { jsonResult } from "openclaw/plugin-sdk";
 import type { ToolContext } from "../../types.js";
 import type { PluginContext } from "../../context.js";
 import { writeAllDefaults, backupAndWrite, fileExists } from "../../setup/workspace.js";
@@ -96,7 +95,7 @@ async function handleReset(workspacePath: string, scope: string) {
     throw new Error(`Unknown scope: ${scope}. Use: prompts, workflow, or all.`);
   }
 
-  return jsonResult({
+  return ({
     success: true,
     action: "reset",
     scope,
@@ -111,7 +110,7 @@ async function handleDiff(workspacePath: string) {
   const workflowPath = path.join(workspacePath, DATA_DIR, "workflow.yaml");
 
   if (!await fileExists(workflowPath)) {
-    return jsonResult({
+    return ({
       success: true,
       action: "diff",
       summary: "No workflow.yaml found in workspace — using package defaults.",
@@ -122,7 +121,7 @@ async function handleDiff(workspacePath: string) {
   const template = WORKFLOW_YAML_TEMPLATE;
 
   if (current.trim() === template.trim()) {
-    return jsonResult({
+    return ({
       success: true,
       action: "diff",
       summary: "workflow.yaml matches the package default — no differences.",
@@ -148,7 +147,7 @@ async function handleDiff(workspacePath: string) {
     }
   }
 
-  return jsonResult({
+  return ({
     success: true,
     action: "diff",
     differences: diffs.length,
@@ -163,7 +162,7 @@ async function handleVersion(workspacePath: string) {
 
   const match = workspaceVersion === packageVersion;
 
-  return jsonResult({
+  return ({
     success: true,
     action: "version",
     packageVersion,

--- a/lib/tools/admin/health.ts
+++ b/lib/tools/admin/health.ts
@@ -12,7 +12,6 @@
  *
  * Read-only by default (surfaces issues). Pass fix=true to apply fixes.
  */
-import { jsonResult } from "openclaw/plugin-sdk";
 import type { PluginContext } from "../../context.js";
 import type { ToolContext } from "../../types.js";
 import { readProjects, getProject } from "../../projects/index.js";
@@ -96,7 +95,7 @@ export function createHealthTool(ctx: PluginContext) {
         sessionsCached: sessions?.size ?? 0,
       });
 
-      return jsonResult({
+      return ({
         success: true,
         fix,
         projectsScanned: slugs.length,

--- a/lib/tools/admin/onboard.ts
+++ b/lib/tools/admin/onboard.ts
@@ -3,7 +3,6 @@
  *
  * Returns step-by-step guidance. Call this before setup.
  */
-import { jsonResult } from "openclaw/plugin-sdk";
 import type { ToolContext } from "../../types.js";
 import type { PluginContext } from "../../context.js";
 import { isPluginConfigured, hasWorkspaceFiles, buildOnboardToolContext, buildReconfigContext } from "../../setup/onboarding.js";
@@ -28,7 +27,7 @@ export function createOnboardTool(ctx: PluginContext) {
 
       const instructions = mode === "first-run" ? buildOnboardToolContext() : buildReconfigContext();
 
-      return jsonResult({
+      return ({
         success: true, mode, configured, instructions,
         nextSteps: ["Follow instructions above", "Call setup with collected answers", mode === "first-run" ? "Register a project afterward" : null].filter(Boolean),
       });

--- a/lib/tools/admin/project-register.ts
+++ b/lib/tools/admin/project-register.ts
@@ -6,7 +6,6 @@
  *
  * Replaces the manual steps of running glab/gh label create + editing projects.json.
  */
-import { jsonResult } from "openclaw/plugin-sdk";
 import type { ToolContext } from "../../types.js";
 import type { PluginContext } from "../../context.js";
 import fs from "node:fs/promises";
@@ -275,7 +274,7 @@ export function createProjectRegisterTool(ctx: PluginContext) {
         hint: "The user can change the review policy or enable the test phase — call workflow_guide for the full reference.",
       };
 
-      return jsonResult({
+      return ({
         success: true,
         project: name,
         projectSlug: slug,

--- a/lib/tools/admin/project-status.ts
+++ b/lib/tools/admin/project-status.ts
@@ -5,7 +5,6 @@
  * workflow config, and execution settings. No issue-tracker API calls.
  * Use `tasks_status` for live issue counts.
  */
-import { jsonResult } from "openclaw/plugin-sdk";
 import type { ToolContext } from "../../types.js";
 import type { PluginContext } from "../../context.js";
 import { requireWorkspaceDir, resolveChannelId, resolveProject } from "../helpers.js";
@@ -78,7 +77,7 @@ export function createProjectStatusTool(ctx: PluginContext) {
           .join(" → "),
       };
 
-      return jsonResult({
+      return ({
         success: true,
         instanceName,
         execution: { projectExecution },

--- a/lib/tools/admin/setup.ts
+++ b/lib/tools/admin/setup.ts
@@ -4,7 +4,6 @@
  * Creates agent, configures model levels, writes workspace files.
  * Thin wrapper around lib/setup/.
  */
-import { jsonResult } from "openclaw/plugin-sdk";
 import type { ToolContext } from "../../types.js";
 import type { PluginContext } from "../../context.js";
 import { runSetup, type SetupOpts } from "../../setup/index.js";
@@ -75,7 +74,7 @@ export function createSetupTool(ctx: PluginContext) {
         const force = !!params.resetDefaults;
         const written = await writeAllDefaults(workspacePath, force);
         const action = force ? "Reset (force-wrote)" : "Ejected (wrote missing)";
-        return jsonResult({
+        return ({
           success: true,
           action: force ? "reset-defaults" : "eject-defaults",
           filesWritten: written,
@@ -129,7 +128,7 @@ export function createSetupTool(ctx: PluginContext) {
         "Next: register a project, then create issues and pick them up.",
       );
 
-      return jsonResult({
+      return ({
         success: true,
         ...result,
         summary: lines.join("\n"),

--- a/lib/tools/admin/sync-labels.ts
+++ b/lib/tools/admin/sync-labels.ts
@@ -8,7 +8,6 @@
  * Calls provider.ensureLabel() directly instead of provider.ensureAllStateLabels()
  * so that custom workflow states from workspace/project overrides are included.
  */
-import { jsonResult } from "openclaw/plugin-sdk";
 import type { ToolContext } from "../../types.js";
 import type { PluginContext } from "../../context.js";
 import { requireWorkspaceDir } from "../helpers.js";
@@ -61,7 +60,7 @@ export function createSyncLabelsTool(ctx: PluginContext) {
       }
 
       if (slugs.length === 0) {
-        return jsonResult({ success: true, synced: [], message: "No projects registered." });
+        return ({ success: true, synced: [], message: "No projects registered." });
       }
 
       const results: Array<{
@@ -117,7 +116,7 @@ export function createSyncLabelsTool(ctx: PluginContext) {
         errors: results.filter((r) => r.error).length,
       });
 
-      return jsonResult({
+      return ({
         success: results.every((r) => !r.error),
         synced: results,
       });

--- a/lib/tools/admin/workflow-guide.ts
+++ b/lib/tools/admin/workflow-guide.ts
@@ -8,7 +8,6 @@
  *
  * No parameters, no side effects — pure documentation.
  */
-import { jsonResult } from "openclaw/plugin-sdk";
 import type { PluginContext } from "../../context.js";
 import type { ToolContext } from "../../types.js";
 import { requireWorkspaceDir } from "../helpers.js";
@@ -54,12 +53,12 @@ export function createWorkflowGuideTool(_ctx: PluginContext) {
       };
 
       if (topic && sections[topic]) {
-        return jsonResult({ guide: sections[topic] });
+        return ({ guide: sections[topic] });
       }
 
       // Full guide
       const full = Object.values(sections).join("\n\n---\n\n");
-      return jsonResult({ guide: full });
+      return ({ guide: full });
     },
   });
 }

--- a/lib/tools/tasks/research-task.ts
+++ b/lib/tools/tasks/research-task.ts
@@ -24,7 +24,6 @@ import { getActiveLabel, loadWorkflow } from "../../workflow/index.js";
 import { selectLevel } from "../../roles/model-selector.js";
 import { resolveModel } from "../../roles/index.js";
 import { findDuplicateCandidates, buildDuplicateConfirmationMessage } from "../../services/issue-dedup.js";
-import { getDispatchStatus, upsertDispatchStatus } from "../../services/dispatch-status.js";
 
 /** Queue label for research tasks. */
 const TO_RESEARCH_LABEL = "To Research";
@@ -218,16 +217,6 @@ Example:
         runtime: ctx.runtime,
         runCommand: ctx.runCommand,
       });
-
-      const progressCommentId = await provider.addComment(
-        issue.iid,
-        `📡 Research dispatch started.\n\n- Architect: **${level}**\n- Session: \`${dr.sessionKey}\`\n- Delivery: session prepared, awaiting architect output.`,
-      );
-      provider.reactToIssueComment(issue.iid, progressCommentId, "eyes").catch(() => {});
-      await upsertDispatchStatus(workspaceDir, { projectSlug: project.slug, issueId: issue.iid, role }, {
-        progressCommentId,
-      }).catch(() => {});
-      await getDispatchStatus(workspaceDir, { projectSlug: project.slug, issueId: issue.iid, role });
 
       return ({
         success: true,

--- a/lib/tools/tasks/research-task.ts
+++ b/lib/tools/tasks/research-task.ts
@@ -12,7 +12,6 @@
  *   → architect calls work_finish(result="done") → "Researching" → "Done" (issue closed)
  *   → operator reviews created tasks in Planning, moves to "To Do" when ready
  */
-import { jsonResult } from "openclaw/plugin-sdk";
 import type { ToolContext } from "../../types.js";
 import type { PluginContext } from "../../context.js";
 import type { StateLabel } from "../../providers/provider.js";
@@ -25,6 +24,7 @@ import { getActiveLabel, loadWorkflow } from "../../workflow/index.js";
 import { selectLevel } from "../../roles/model-selector.js";
 import { resolveModel } from "../../roles/index.js";
 import { findDuplicateCandidates, buildDuplicateConfirmationMessage } from "../../services/issue-dedup.js";
+import { getDispatchStatus, upsertDispatchStatus } from "../../services/dispatch-status.js";
 
 /** Queue label for research tasks. */
 const TO_RESEARCH_LABEL = "To Research";
@@ -135,7 +135,7 @@ Example:
       const model = resolveModel(role, level, resolvedRole);
 
       if (dryRun) {
-        return jsonResult({
+        return ({
           success: true,
           dryRun: true,
           issue: { title, label: TO_RESEARCH_LABEL },
@@ -152,7 +152,7 @@ Example:
       }
 
       if (duplicateCheck.shouldRequireConfirmation && !confirmDuplicate) {
-        return jsonResult({
+        return ({
           success: false,
           duplicateCheck: {
             confidence: duplicateCheck.confidence,
@@ -185,7 +185,7 @@ Example:
         const activeIssueId = Object.values(roleWorker.levels)
           .flat()
           .find((s) => s.active)?.issueId;
-        return jsonResult({
+        return ({
           success: true,
           issue: { id: issue.iid, title: issue.title, url: issue.web_url, label: TO_RESEARCH_LABEL },
           research: {
@@ -219,7 +219,17 @@ Example:
         runCommand: ctx.runCommand,
       });
 
-      return jsonResult({
+      const progressCommentId = await provider.addComment(
+        issue.iid,
+        `📡 Research dispatch started.\n\n- Architect: **${level}**\n- Session: \`${dr.sessionKey}\`\n- Delivery: session prepared, awaiting architect output.`,
+      );
+      provider.reactToIssueComment(issue.iid, progressCommentId, "eyes").catch(() => {});
+      await upsertDispatchStatus(workspaceDir, { projectSlug: project.slug, issueId: issue.iid, role }, {
+        progressCommentId,
+      }).catch(() => {});
+      await getDispatchStatus(workspaceDir, { projectSlug: project.slug, issueId: issue.iid, role });
+
+      return ({
         success: true,
         issue: { id: issue.iid, title: issue.title, url: issue.web_url, label: toLabel },
         research: {

--- a/lib/tools/tasks/task-attach.ts
+++ b/lib/tools/tasks/task-attach.ts
@@ -6,7 +6,6 @@
  * - Manually attach a local file to an issue
  * - View attachment metadata and local paths
  */
-import { jsonResult } from "openclaw/plugin-sdk";
 import type { PluginContext } from "../../context.js";
 import type { ToolContext } from "../../types.js";
 import { log as auditLog } from "../../audit.js";
@@ -68,7 +67,7 @@ Use cases:
 
       if (action === "list") {
         const attachments = await listAttachments(workspaceDir, project.slug, issueId);
-        return jsonResult({
+        return ({
           success: true,
           issueId,
           project: project.name,
@@ -94,7 +93,7 @@ Use cases:
         const attachment = attachments.find((a) => a.id === attachmentId);
         if (!attachment) throw new Error(`Attachment ${attachmentId} not found on issue #${issueId}`);
 
-        return jsonResult({
+        return ({
           success: true,
           issueId,
           project: project.name,
@@ -148,7 +147,7 @@ Use cases:
           mimeType,
         });
 
-        return jsonResult({
+        return ({
           success: true,
           issueId,
           project: project.name,

--- a/lib/tools/tasks/task-comment.ts
+++ b/lib/tools/tasks/task-comment.ts
@@ -6,7 +6,6 @@
  * - Developer worker posts implementation notes
  * - Orchestrator adds summary comments
  */
-import { jsonResult } from "openclaw/plugin-sdk";
 import type { PluginContext } from "../../context.js";
 import type { ToolContext } from "../../types.js";
 import { log as auditLog } from "../../audit.js";
@@ -95,7 +94,7 @@ Examples:
         provider: providerType,
       });
 
-      return jsonResult({
+      return ({
         success: true, issueId, issueTitle: issue.title, issueUrl: issue.web_url,
         commentAdded: true, authorRole: authorRole ?? null, bodyLength: body.length,
         project: project.name, provider: providerType,

--- a/lib/tools/tasks/task-create.ts
+++ b/lib/tools/tasks/task-create.ts
@@ -9,7 +9,6 @@
  * - A sub-agent finds a bug and needs to file a follow-up issue
  * - Breaking down an epic into smaller tasks
  */
-import { jsonResult } from "openclaw/plugin-sdk";
 import type { PluginContext } from "../../context.js";
 import type { ToolContext } from "../../types.js";
 import { log as auditLog } from "../../audit.js";
@@ -73,7 +72,7 @@ export function createTaskCreateTool(ctx: PluginContext) {
       const openIssues = await provider.listIssues({ state: "open" });
       const duplicateCheck = findDuplicateCandidates({ title, description }, openIssues, workflow);
       if (duplicateCheck.shouldRequireConfirmation && !confirmDuplicate) {
-        return jsonResult({
+        return ({
           success: false,
           duplicateCheck: {
             confidence: duplicateCheck.confidence,
@@ -114,7 +113,7 @@ export function createTaskCreateTool(ctx: PluginContext) {
         announcement += `\nConfirmed despite possible overlap with ${duplicateCheck.candidates.map((candidate) => `#${candidate.issueId}`).join(", ")}.`;
       }
 
-      return jsonResult({
+      return ({
         success: true,
         issue: { id: issue.iid, title: issue.title, body: hasBody ? description : null, url: issue.web_url, label },
         duplicateCheck: {

--- a/lib/tools/tasks/task-edit-body.ts
+++ b/lib/tools/tasks/task-edit-body.ts
@@ -8,7 +8,6 @@
  * DevClaw adds an explicit audit entry with who, when, and what changed.
  * Optionally posts an auto-comment on the issue for traceability.
  */
-import { jsonResult } from "openclaw/plugin-sdk";
 import type { PluginContext } from "../../context.js";
 import type { ToolContext } from "../../types.js";
 import { log as auditLog } from "../../audit.js";
@@ -113,7 +112,7 @@ Examples:
 
       // Nothing actually changed
       if (Object.keys(changes).length === 0) {
-        return jsonResult({
+        return ({
           success: true,
           issueId,
           issueUrl: issue.web_url,
@@ -179,7 +178,7 @@ Examples:
       if (reason) announcement += ` — ${reason}`;
       announcement += `\n🔗 [Issue #${issueId}](${updatedIssue.web_url})`;
 
-      return jsonResult({
+      return ({
         success: true,
         issueId,
         issueTitle: updatedIssue.title,

--- a/lib/tools/tasks/task-list.ts
+++ b/lib/tools/tasks/task-list.ts
@@ -4,7 +4,6 @@
  * Lists issues grouped by state label with optional filtering by state type,
  * specific label, or text search. Supports terminal (closed) issues.
  */
-import { jsonResult } from "openclaw/plugin-sdk";
 import type { PluginContext } from "../../context.js";
 import type { ToolContext } from "../../types.js";
 import { log as auditLog } from "../../audit.js";
@@ -124,7 +123,7 @@ export function createTaskListTool(ctx: PluginContext) {
         totalIssues,
       });
 
-      return jsonResult({
+      return ({
         success: true,
         project: project.name,
         filter: { stateType: stateType ?? null, label: label ?? null, search: search ?? null },

--- a/lib/tools/tasks/task-owner.ts
+++ b/lib/tools/tasks/task-owner.ts
@@ -5,7 +5,6 @@
  * owns them for queue scanning and dispatch. Supports claiming a
  * single issue or all unclaimed queued issues for a project.
  */
-import { jsonResult } from "openclaw/plugin-sdk";
 import type { PluginContext } from "../../context.js";
 import type { ToolContext } from "../../types.js";
 import { requireWorkspaceDir, resolveChannelId, resolveProject, resolveProvider } from "../helpers.js";
@@ -121,7 +120,7 @@ export function createTaskOwnerTool(ctx: PluginContext) {
         }
       }
 
-      return jsonResult({
+      return ({
         success: true,
         instanceName,
         ownerLabel,

--- a/lib/tools/tasks/task-set-level.ts
+++ b/lib/tools/tasks/task-set-level.ts
@@ -5,7 +5,6 @@
  * applied as a role:level label and respected by the heartbeat when the
  * issue is later advanced via task_start.
  */
-import { jsonResult } from "openclaw/plugin-sdk";
 import type { PluginContext } from "../../context.js";
 import type { ToolContext } from "../../types.js";
 import { log as auditLog } from "../../audit.js";
@@ -110,7 +109,7 @@ Examples:
         reason: reason ?? null, provider: providerType,
       });
 
-      return jsonResult({
+      return ({
         success: true, issueId, issueTitle: issue.title,
         level: newLevel, changed: levelChanged,
         project: project.name, provider: providerType,

--- a/lib/tools/tasks/task-start.ts
+++ b/lib/tools/tasks/task-start.ts
@@ -8,7 +8,6 @@
  * The heartbeat is the sole dispatcher — this tool only places issues in
  * queues, never dispatches workers directly.
  */
-import { jsonResult } from "openclaw/plugin-sdk";
 import type { PluginContext } from "../../context.js";
 import type { ToolContext } from "../../types.js";
 import { log as auditLog } from "../../audit.js";
@@ -124,7 +123,7 @@ Examples:
         ? `▶️ #${issueId} moved to "${targetLabel}"${levelMsg} — heartbeat will dispatch.`
         : `▶️ #${issueId} already in queue "${targetLabel}"${levelMsg} — heartbeat will dispatch.`;
 
-      return jsonResult({
+      return ({
         success: true, issueId, issueTitle: issue.title,
         from: currentLabel, to: targetLabel, transitioned,
         level: levelHint ?? null,

--- a/lib/tools/tasks/tasks-status.ts
+++ b/lib/tools/tasks/tasks-status.ts
@@ -4,7 +4,6 @@
  * Fetches all non-terminal issues grouped by state type (hold, active, queue).
  * Use `project_status` for instant local info, this tool for live issue data.
  */
-import { jsonResult } from "openclaw/plugin-sdk";
 import type { ToolContext } from "../../types.js";
 import type { PluginContext } from "../../context.js";
 import { log as auditLog } from "../../audit.js";
@@ -91,7 +90,7 @@ export function createTasksStatusTool(ctx: PluginContext) {
         queue: statesByType.queue.map((s) => ({ label: s.label, role: s.role, priority: s.priority })),
       };
 
-      return jsonResult({
+      return ({
         success: true,
         project: project.name,
         stateLabels,

--- a/lib/tools/worker/work-finish.ts
+++ b/lib/tools/worker/work-finish.ts
@@ -7,7 +7,6 @@
  * All roles (including architect) use the standard pipeline via executeCompletion.
  * Architect workflow: Researching → Done (done, closes issue), Researching → Refining (blocked).
  */
-import { jsonResult } from "openclaw/plugin-sdk";
 import { readFile } from "node:fs/promises";
 import { join } from "node:path";
 import type { ToolContext } from "../../types.js";
@@ -415,7 +414,7 @@ export function createWorkFinishTool(ctx: PluginContext) {
         summary: summary ?? null, labelTransition: completion.labelTransition,
       });
 
-      return jsonResult({
+      return ({
         success: true, project: project.name, projectSlug: project.slug, issueId, role, result,
         ...completion,
       });

--- a/package-lock.json
+++ b/package-lock.json
@@ -969,6 +969,14 @@
         "url": "https://github.com/discordjs/discord.js?sponsor"
       }
     },
+    "node_modules/@discordjs/voice/node_modules/opusscript": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/opusscript/-/opusscript-0.0.8.tgz",
+      "integrity": "sha512-VSTi1aWFuCkRCVq+tx/BQ5q9fMnQ9pVZ3JU4UHKqTkf0ED3fKEPdr+gKAAl3IA2hj9rrP6iyq3hlcJq3HELtNQ==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true
+    },
     "node_modules/@discordjs/voice/node_modules/prism-media": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/prism-media/-/prism-media-1.3.5.tgz",


### PR DESCRIPTION
Closes #84

## Summary
- rebuild the local stable lane from a clean `main` baseline instead of trusting the old `-stable` line
- keep only the documented safe slices from issue #84
- exclude the quarantined workflow-integrity / loop-recovery lane from the stable promotion candidate
- repoint live local DevClaw to the new `devclaw-local-stable` checkout

## Included keep slices
- branch-model and local-environment docs
- local linked runtime stabilization
- project registry preservation
- provider circuit-breaker scoping
- explicit provider CLI path resolution / execution fixes

## Notes
- the old `release/devclaw-local` / prior `-stable` line is treated as untrusted history, not as a promotion base
- a small follow-up correction was added on top of the salvaged commits to keep this stable line decoupled from `dispatch-status` so it does not pull quarantined workflow-lane code back in
- live local runtime is now loading from `~/git/devclaw.worktrees/devclaw-local-stable/dist/index.js`

## Validation
- `npm run build`
- `npx tsx --test lib/providers/resilience.test.ts lib/setup/workspace.test.ts`
- verified live local OpenClaw is loading DevClaw from `~/git/devclaw.worktrees/devclaw-local-stable/dist/index.js`
