### PR TITLE
fix: route task_create to configured tracker repo (#95)

### DIFF
--- a/docs/devclaw-self-hosting.md
+++ b/docs/devclaw-self-hosting.md
@@ -137,6 +137,32 @@ In that case:
 
 Use this when you want to verify a local DevClaw install in an already-running environment without creating new projects or tasks.
 
+## Tracker routing verification for fork-based installs
+
+If your local checkout has both a fork and an upstream remote, do not trust ambient GitHub CLI repo inference.
+
+Before relying on issue-creation flows, verify both the configured tracker target and the checkout's ambient `gh` target:
+
+```bash
+python3 - <<'PY'
+import json
+p=json.load(open('devclaw/projects.json'))['projects']['devclaw']
+print(p['repoRemote'])
+PY
+git -C <repo-or-worktree> remote -v
+gh repo view --json nameWithOwner --jq .nameWithOwner
+```
+
+Expected safety rule:
+
+- DevClaw issue/task tooling must route to the repository configured in `projects.json`
+- it must not drift to the repo that `gh` happens to infer from the checkout context
+
+When validating a fix for tracker-routing bugs, record both:
+
+- a pre-change proof showing config target versus ambient `gh` target
+- a post-change proof showing issue/task creation calls explicitly target the configured repo
+
 Read-only checks:
 
 ```bash

--- a/lib/providers/github.ts
+++ b/lib/providers/github.ts
@@ -10,6 +10,7 @@ import {
   type PrReviewComment,
   PrState,
 } from "./provider.js";
+import type { ProviderTarget } from "./provider.js";
 import type { RunCommand } from "../context.js";
 import { withResilience } from "./resilience.js";
 import {
@@ -39,21 +40,41 @@ export class GitHubProvider implements IssueProvider {
   private repoPath: string;
   private workflow: WorkflowConfig;
   private runCommand: RunCommand;
+  private targetRepo?: string;
 
-  constructor(opts: { repoPath: string; runCommand: RunCommand; workflow?: WorkflowConfig }) {
+  constructor(opts: { repoPath: string; runCommand: RunCommand; workflow?: WorkflowConfig; target?: ProviderTarget }) {
     this.repoPath = opts.repoPath;
     this.runCommand = opts.runCommand;
     this.workflow = opts.workflow ?? DEFAULT_WORKFLOW;
+    this.targetRepo = opts.target?.repo;
   }
 
   private async gh(args: string[]): Promise<string> {
     return withResilience(async () => {
-      const result = await this.runCommand(["gh", ...args], { timeoutMs: 30_000, cwd: this.repoPath });
+      const fullArgs = ["gh", ...this.withRepo(args)];
+      const result = await this.runCommand(fullArgs, { timeoutMs: 30_000, cwd: this.repoPath });
       if (result.code != null && result.code !== 0) {
         throw new Error(result.stderr?.trim() || `gh command failed with exit code ${result.code}`);
       }
       return result.stdout.trim();
     });
+  }
+
+  private withRepo(args: string[]): string[] {
+    if (!this.targetRepo) return args;
+    const needsExplicitRepo = this.commandSupportsRepo(args);
+    if (!needsExplicitRepo) return args;
+    if (args.includes("--repo") || args.includes("-R")) return args;
+    return [...args, "--repo", this.targetRepo];
+  }
+
+  private commandSupportsRepo(args: string[]): boolean {
+    if (args.length === 0) return false;
+    if (args[0] === "repo") return true;
+    if (args[0] === "issue") return true;
+    if (args[0] === "pr") return true;
+    if (args[0] !== "api") return false;
+    return !args.includes("graphql");
   }
 
   /** Cached repo owner/name for GraphQL queries. */
@@ -66,6 +87,13 @@ export class GitHubProvider implements IssueProvider {
   private async getRepoInfo(): Promise<{ owner: string; name: string } | null> {
     if (this.repoInfo !== undefined) return this.repoInfo;
     try {
+      if (this.targetRepo) {
+        const [owner, name] = this.targetRepo.split("/");
+        if (owner && name) {
+          this.repoInfo = { owner, name };
+          return this.repoInfo;
+        }
+      }
       const raw = await this.gh(["repo", "view", "--json", "owner,name"]);
       const data = JSON.parse(raw);
       this.repoInfo = { owner: data.owner.login, name: data.name };

--- a/lib/providers/gitlab.ts
+++ b/lib/providers/gitlab.ts
@@ -10,6 +10,7 @@ import {
   type PrReviewComment,
   PrState,
 } from "./provider.js";
+import type { ProviderTarget } from "./provider.js";
 import type { RunCommand } from "../context.js";
 import { withResilience } from "./resilience.js";
 import {
@@ -35,16 +36,19 @@ export class GitLabProvider implements IssueProvider {
   private repoPath: string;
   private workflow: WorkflowConfig;
   private runCommand: RunCommand;
+  private targetRepo?: string;
 
-  constructor(opts: { repoPath: string; runCommand: RunCommand; workflow?: WorkflowConfig }) {
+  constructor(opts: { repoPath: string; runCommand: RunCommand; workflow?: WorkflowConfig; target?: ProviderTarget }) {
     this.repoPath = opts.repoPath;
     this.runCommand = opts.runCommand;
     this.workflow = opts.workflow ?? DEFAULT_WORKFLOW;
+    this.targetRepo = opts.target?.repo;
   }
 
   private async glab(args: string[]): Promise<string> {
     return withResilience(async () => {
-      const result = await this.runCommand(["glab", ...args], { timeoutMs: 30_000, cwd: this.repoPath });
+      const fullArgs = this.targetRepo && !args.includes("--repo") ? ["glab", ...args, "--repo", this.targetRepo] : ["glab", ...args];
+      const result = await this.runCommand(fullArgs, { timeoutMs: 30_000, cwd: this.repoPath });
       return result.stdout.trim();
     });
   }

--- a/lib/providers/index.ts
+++ b/lib/providers/index.ts
@@ -2,6 +2,7 @@
  * Provider factory — auto-detects GitHub vs GitLab from git remote.
  */
 import type { IssueProvider } from "./provider.js";
+import type { ProviderTarget } from "./provider.js";
 import type { RunCommand } from "../context.js";
 import { GitLabProvider } from "./gitlab.js";
 import { GitHubProvider } from "./github.js";
@@ -11,6 +12,7 @@ export type ProviderOptions = {
   provider?: "gitlab" | "github";
   repo?: string;
   repoPath?: string;
+  target?: ProviderTarget;
   runCommand: RunCommand;
 };
 
@@ -34,7 +36,7 @@ export async function createProvider(opts: ProviderOptions): Promise<ProviderWit
   const rc = opts.runCommand;
   const type = opts.provider ?? await detectProvider(repoPath, rc);
   const provider = type === "github"
-    ? new GitHubProvider({ repoPath, runCommand: rc })
-    : new GitLabProvider({ repoPath, runCommand: rc });
+    ? new GitHubProvider({ repoPath, runCommand: rc, target: opts.target })
+    : new GitLabProvider({ repoPath, runCommand: rc, target: opts.target });
   return { provider, type };
 }

--- a/lib/providers/provider-targeting.test.ts
+++ b/lib/providers/provider-targeting.test.ts
@@ -1,0 +1,48 @@
+/**
+ * Regression tests for explicit tracker targeting from project config.
+ *
+ * Run with: npx tsx --test lib/providers/provider-targeting.test.ts
+ */
+import { describe, it, mock } from "node:test";
+import assert from "node:assert/strict";
+import { GitHubProvider } from "./github.js";
+
+describe("GitHubProvider explicit repo targeting", () => {
+  it("passes --repo for issue creation when target repo is configured", async () => {
+    const calls: string[][] = [];
+    const runCommand = mock.fn(async (args: string[]) => {
+      calls.push(args);
+      if (args[1] === "issue" && args[2] === "create") {
+        return { stdout: "https://github.com/yaqub0r/devclaw/issues/999\n", stderr: "", code: 0 };
+      }
+      if (args[1] === "issue" && args[2] === "view") {
+        return {
+          stdout: JSON.stringify({ number: 999, title: "t", body: "d", labels: [{ name: "Planning" }], state: "OPEN", url: "https://github.com/yaqub0r/devclaw/issues/999" }),
+          stderr: "",
+          code: 0,
+        };
+      }
+      throw new Error(`Unexpected command: ${args.join(" ")}`);
+    });
+
+    const provider = new GitHubProvider({ repoPath: "/fake", runCommand: runCommand as any, target: { repo: "yaqub0r/devclaw" } });
+    const issue = await provider.createIssue("t", "d", "Planning");
+
+    assert.equal(issue.iid, 999);
+    const createCall = calls.find((c) => c[1] === "issue" && c[2] === "create");
+    assert.ok(createCall, "expected issue create call");
+    assert.deepEqual(createCall.slice(-2), ["--repo", "yaqub0r/devclaw"]);
+  });
+
+  it("uses configured target repo for repo info without gh repo view", async () => {
+    const runCommand = mock.fn(async (_args: string[]) => {
+      throw new Error("gh repo view should not be called when target is configured");
+    });
+
+    const provider = new GitHubProvider({ repoPath: "/fake", runCommand: runCommand as any, target: { repo: "yaqub0r/devclaw" } });
+    const info = await (provider as any).getRepoInfo();
+
+    assert.deepEqual(info, { owner: "yaqub0r", name: "devclaw" });
+    assert.equal(runCommand.mock.calls.length, 0);
+  });
+});

--- a/lib/providers/provider.ts
+++ b/lib/providers/provider.ts
@@ -170,3 +170,13 @@ export interface IssueProvider {
   }): Promise<string | null>;
   healthCheck(): Promise<boolean>;
 }
+
+/**
+ * Optional tracker target override derived from project configuration.
+ *
+ * Example GitHub target: "yaqub0r/devclaw"
+ * Example GitLab target: "group/project"
+ */
+export type ProviderTarget = {
+  repo?: string;
+};

--- a/lib/tools/helpers.ts
+++ b/lib/tools/helpers.ts
@@ -66,7 +66,25 @@ export async function resolveProject(
  * Uses stored provider type from project config if available, otherwise auto-detects.
  */
 export async function resolveProvider(project: Project, runCommand: RunCommand): Promise<ProviderWithType> {
-  return createProvider({ repo: project.repo, provider: project.provider, runCommand });
+  const target = project.repoRemote ? { repo: normalizeRepoTarget(project.repoRemote) } : undefined;
+  return createProvider({ repo: project.repo, provider: project.provider, target, runCommand });
+}
+
+function normalizeRepoTarget(repoRemote: string): string | undefined {
+  const trimmed = repoRemote.trim();
+  if (!trimmed) return undefined;
+
+  const sshMatch = trimmed.match(/github\.com[:/]([^/]+\/[^/.]+)(?:\.git)?$/i)
+    ?? trimmed.match(/gitlab\.com[:/]([^/]+\/[^/.]+)(?:\.git)?$/i);
+  if (sshMatch) return sshMatch[1];
+
+  try {
+    const url = new URL(trimmed);
+    const path = url.pathname.replace(/^\/+/, "").replace(/\.git$/i, "");
+    return path || undefined;
+  } catch {
+    return trimmed.replace(/\.git$/i, "");
+  }
 }
 
 /**


### PR DESCRIPTION
## Summary

Fix `task_create` / provider issue creation drift when the registered project repo is a fork but ambient `gh` checkout inference prefers upstream.

This makes tracker operations use the configured project repo target instead of relying on checkout-context inference.

Addresses issue #95.

## Changes

- derive explicit tracker target from `project.repoRemote`
- thread provider target through provider creation
- pass explicit `--repo` to GitHub issue/PR/repo commands that support it
- use configured target repo identity directly for repo info when available
- add focused regression test for GitHub provider targeting
- document fork-routing verification in the self-hosting guide

## Validation

Pre-fix:
- confirmed project config targeted `yaqub0r/devclaw`
- confirmed ambient `gh repo view` from checkout resolved to `laurentenhoor/devclaw`

Automated:
- `npx tsx --test lib/providers/provider-targeting.test.ts`

Live post-fix:
- switched live DevClaw install to `issue-95`
- created disposable validation issue through live `task_create`
- verified it landed on `yaqub0r/devclaw#96`
- closed validation issue after proof
