### PR TITLE
fix: route label operations to configured repo (#95)

### DIFF
--- a/lib/providers/github.ts
+++ b/lib/providers/github.ts
@@ -73,6 +73,7 @@ export class GitHubProvider implements IssueProvider {
     if (args[0] === "repo") return true;
     if (args[0] === "issue") return true;
     if (args[0] === "pr") return true;
+    if (args[0] === "label") return true;
     if (args[0] !== "api") return false;
     return !args.includes("graphql");
   }

--- a/lib/providers/provider-targeting.test.ts
+++ b/lib/providers/provider-targeting.test.ts
@@ -34,6 +34,71 @@ describe("GitHubProvider explicit repo targeting", () => {
     assert.deepEqual(createCall.slice(-2), ["--repo", "yaqub0r/devclaw"]);
   });
 
+  it("passes --repo for issue read, edit, label, and comment paths when target repo is configured", async () => {
+    const calls: string[][] = [];
+    let issue95State = "Planning";
+    const runCommand = mock.fn(async (args: string[]) => {
+      calls.push(args);
+
+      if (args[1] === "issue" && args[2] === "view") {
+        const issueId = args[3];
+        const labels = issueId === "95"
+          ? [{ name: issue95State }, { name: "telegram:DevClaw" }]
+          : [{ name: "To Do" }, { name: "telegram:DevClaw" }];
+        return {
+          stdout: JSON.stringify({ number: Number(issueId), title: "Issue", body: "Body", labels, state: "OPEN", url: `https://github.com/yaqub0r/devclaw/issues/${issueId}` }),
+          stderr: "",
+          code: 0,
+        };
+      }
+
+      if (args[1] === "issue" && args[2] === "edit") {
+        if (args.includes("--add-label") && args.includes("To Do")) issue95State = "To Do";
+        return { stdout: "", stderr: "", code: 0 };
+      }
+
+      if (args[1] === "label" && args[2] === "create") {
+        return { stdout: "", stderr: "", code: 0 };
+      }
+
+      if (args[1] === "api" && args[2] === "repos/:owner/:repo/issues/95/comments") {
+        return { stdout: JSON.stringify({ id: 12345 }), stderr: "", code: 0 };
+      }
+
+      throw new Error(`Unexpected command: ${args.join(" ")}`);
+    });
+
+    const provider = new GitHubProvider({ repoPath: "/fake", runCommand: runCommand as any, target: { repo: "yaqub0r/devclaw" } });
+
+    const issue = await provider.getIssue(95);
+    assert.equal(issue.iid, 95);
+
+    await provider.transitionLabel(95, "Planning", "To Do");
+    await provider.ensureLabel("developer:medior", "#123456");
+    const commentId = await provider.addComment(95, "routing proof");
+    assert.equal(commentId, 12345);
+
+    const issueViewCalls = calls.filter((c) => c[1] === "issue" && c[2] === "view");
+    assert.ok(issueViewCalls.length >= 2, "expected issue view calls for read + transition validation");
+    for (const call of issueViewCalls) {
+      assert.deepEqual(call.slice(-2), ["--repo", "yaqub0r/devclaw"]);
+    }
+
+    const issueEditCalls = calls.filter((c) => c[1] === "issue" && c[2] === "edit");
+    assert.ok(issueEditCalls.length >= 1, "expected issue edit calls during transition");
+    for (const call of issueEditCalls) {
+      assert.deepEqual(call.slice(-2), ["--repo", "yaqub0r/devclaw"]);
+    }
+
+    const labelCreateCall = calls.find((c) => c[1] === "label" && c[2] === "create");
+    assert.ok(labelCreateCall, "expected label create call");
+    assert.deepEqual(labelCreateCall.slice(-2), ["--repo", "yaqub0r/devclaw"]);
+
+    const commentCall = calls.find((c) => c[1] === "api" && c[2] === "repos/:owner/:repo/issues/95/comments");
+    assert.ok(commentCall, "expected issue comment api call");
+    assert.deepEqual(commentCall.slice(-2), ["--repo", "yaqub0r/devclaw"]);
+  });
+
   it("uses configured target repo for repo info without gh repo view", async () => {
     const runCommand = mock.fn(async (_args: string[]) => {
       throw new Error("gh repo view should not be called when target is configured");


### PR DESCRIPTION
## Summary

Complete the issue #95 repo-target routing fix by covering GitHub label operations as well.

The earlier fix handled issue creation and other GitHub command families, but `label` commands still did not force the configured `--repo` target. That left `task_start` and related label-management paths able to drift to upstream.

Fixes the remaining stable repro for #95.

## Changes

- add `label` to the GitHub command families that receive explicit `--repo`
- expand regression coverage to include:
  - issue reads
  - issue edits / transition-label path
  - label creation
  - issue comment API path

## Validation

- `npx tsx --test lib/providers/provider-targeting.test.ts`
- `npx tsx --test lib/providers/provider-pr-status.test.ts lib/providers/provider-targeting.test.ts`
- `npm run build`
