### PR TITLE
chore: add dev tree and stable release regressions

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Then start onboarding by chatting with your agent in any channel:
 
 [Read more on onboarding &rarr;](#getting-started)
 
-For developing DevClaw while running it through OpenClaw, including a generic non-destructive smoke test, see [Developing DevClaw with OpenClaw](docs/devclaw-self-hosting.md).
+For developing DevClaw while running it through OpenClaw, including a generic non-destructive smoke test, see [Developing DevClaw with OpenClaw](dev/runbooks/developing-devclaw-with-openclaw.md). Developer-only material and release regression coverage now live under [`dev/`](dev/README.md).
 
 ---
 

--- a/dev/README.md
+++ b/dev/README.md
@@ -1,0 +1,13 @@
+# DevClaw developer package
+
+This `dev/` tree is the canonical in-repo home for developer-only material.
+
+## Layout
+
+- `dev/regression/tests/` executable regression coverage for release-relevant fixes
+- `dev/regression/issues/` issue-linked bug notes, triggering conditions, and validation context
+- `dev/regression/fixtures/` sample inputs and future regression fixtures
+- `dev/runbooks/` developer and self-hosting procedures
+
+Release-user documentation stays under `docs/`.
+Developer-only runbooks and release hardening notes belong here.

--- a/dev/regression/fixtures/README.md
+++ b/dev/regression/fixtures/README.md
@@ -1,0 +1,3 @@
+# Regression fixtures
+
+Place sample configs, issue payloads, or tracker responses here when a regression test needs stable input data.

--- a/dev/regression/issues/github-repo-routing-95.md
+++ b/dev/regression/issues/github-repo-routing-95.md
@@ -1,0 +1,27 @@
+# Regression note: GitHub repo routing, issue #95 family
+
+- Related issues: #95 family on the local stable line
+- Scope: tracker operations must target the configured GitHub repo, not whichever repo the local checkout happens to be in
+
+## Bug summary
+
+When DevClaw operated from a local checkout with explicit project tracker routing, some GitHub issue operations risked falling back to ambient repo context instead of the configured tracker target.
+
+## Triggering conditions
+
+- project config includes `repoRemote`
+- DevClaw uses GitHub provider operations for issue reads, transitions, labels, or comments
+- local checkout repo differs from the intended tracker repo, or ambient gh repo context is wrong
+
+## Automated coverage
+
+`dev/regression/tests/github-repo-routing-95.sh` verifies that:
+
+1. `resolveProvider()` derives an explicit provider target from `project.repoRemote`
+2. `normalizeRepoTarget()` still handles SSH, HTTPS, and plain owner/repo forms
+3. `GitHubProvider` continues to append `--repo` for issue, PR, label, and REST API calls when a target repo is configured
+4. the focused TypeScript regression suite `lib/providers/provider-targeting.test.ts` remains present
+
+## Manual validation notes
+
+For a live check, use a project whose working tree repo and issue tracker repo differ, then confirm issue create/read/comment flows hit the configured tracker repo rather than the local checkout repo.

--- a/dev/regression/issues/jsonresult.md
+++ b/dev/regression/issues/jsonresult.md
@@ -1,0 +1,25 @@
+# Regression note: jsonResult helper contract
+
+- Related issue: plugin-sdk `jsonResult` removal on the release line
+- Scope: tool response formatting for DevClaw admin, task, and worker tools
+
+## Bug summary
+
+`openclaw/plugin-sdk` stopped exporting `jsonResult`, but multiple DevClaw tools still imported it directly. That broke type-checking and test/module loading before tool code could run.
+
+## Triggering conditions
+
+- OpenClaw/plugin-sdk version without a `jsonResult` export
+- Any DevClaw tool module importing `jsonResult` from the plugin SDK instead of repo-local helpers
+
+## Automated coverage
+
+`dev/regression/tests/jsonresult-regression.sh` verifies that:
+
+1. `lib/tools/helpers.ts` defines the repo-local `jsonResult` wrapper
+2. no file under `lib/tools/` imports `jsonResult` from `openclaw/plugin-sdk`
+3. representative tool modules import `jsonResult` from `../helpers.js`
+
+## Manual validation notes
+
+If you need runtime confirmation, run the stable-line test or build command after dependency install and confirm tool modules load without `jsonResult` import errors.

--- a/dev/regression/tests/github-repo-routing-95.sh
+++ b/dev/regression/tests/github-repo-routing-95.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "$0")/../../.." && pwd)"
+cd "$repo_root"
+
+python3 - <<'PY'
+from pathlib import Path
+
+helpers = Path("lib/tools/helpers.ts").read_text()
+github = Path("lib/providers/github.ts").read_text()
+provider_test = Path("lib/providers/provider-targeting.test.ts")
+
+assert "project.repoRemote ? { repo: normalizeRepoTarget(project.repoRemote) } : undefined" in helpers, "resolveProvider no longer derives explicit target repo from project.repoRemote"
+for needle in [
+    'trimmed.match(/github\\.com[:/]([^/]+\\/[^/.]+)(?:\\.git)?$/i)',
+    'trimmed.match(/gitlab\\.com[:/]([^/]+\\/[^/.]+)(?:\\.git)?$/i)',
+    'const url = new URL(trimmed)',
+    'return trimmed.replace(/\\.git$/i, "")',
+]:
+    assert needle in helpers, f"normalizeRepoTarget coverage snippet missing: {needle}"
+
+for needle in [
+    'return [...args, "--repo", this.targetRepo];',
+    'if (args[0] === "issue") return true;',
+    'if (args[0] === "pr") return true;',
+    'if (args[0] === "label") return true;',
+    'if (args[0] !== "api") return false;',
+    'if (this.targetRepo) {',
+    'const [owner, name] = this.targetRepo.split("/");',
+]:
+    assert needle in github, f"GitHub provider routing guard missing: {needle}"
+
+assert provider_test.exists(), "provider-targeting regression suite is missing"
+text = provider_test.read_text()
+for needle in [
+    'passes --repo for issue creation when target repo is configured',
+    'passes --repo for issue read, edit, label, and comment paths when target repo is configured',
+    'uses configured target repo for repo info without gh repo view',
+]:
+    assert needle in text, f"provider-targeting test no longer covers: {needle}"
+
+print("GitHub repo routing regression checks passed")
+PY

--- a/dev/regression/tests/jsonresult-regression.sh
+++ b/dev/regression/tests/jsonresult-regression.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "$0")/../../.." && pwd)"
+cd "$repo_root"
+
+python3 - <<'PY'
+from pathlib import Path
+import re
+
+helpers = Path("lib/tools/helpers.ts").read_text()
+assert "export function jsonResult(payload: unknown)" in helpers, "jsonResult helper missing from lib/tools/helpers.ts"
+assert 'JSON.stringify(payload, null, 2)' in helpers, "jsonResult helper no longer pretty-prints payload"
+assert 'details: payload' in helpers, "jsonResult helper no longer preserves details payload"
+
+bad_imports = []
+for path in Path("lib/tools").rglob("*.ts"):
+    text = path.read_text()
+    if re.search(r'import\s*\{[^}]*\bjsonResult\b[^}]*\}\s*from\s*["\']openclaw/plugin-sdk["\']', text):
+        bad_imports.append(str(path))
+
+assert not bad_imports, "jsonResult still imported from openclaw/plugin-sdk: " + ", ".join(sorted(bad_imports))
+
+expected = [
+    Path("lib/tools/tasks/task-create.ts"),
+    Path("lib/tools/tasks/research-task.ts"),
+    Path("lib/tools/worker/work-finish.ts"),
+]
+for path in expected:
+    text = path.read_text()
+    assert "jsonResult" in text, f"{path} should still use jsonResult"
+    assert "from \"../helpers.js\"" in text or "from \"../helpers.js\";" in text or "from \"../helpers.js\"\n" in text, f"{path} should import jsonResult from ../helpers.js"
+
+print("jsonResult regression checks passed")
+PY

--- a/dev/regression/tests/run-all.sh
+++ b/dev/regression/tests/run-all.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+root="$(cd "$(dirname "$0")" && pwd)"
+"$root/jsonresult-regression.sh"
+"$root/github-repo-routing-95.sh"
+
+echo "All release regression checks passed"

--- a/dev/runbooks/developing-devclaw-with-openclaw.md
+++ b/dev/runbooks/developing-devclaw-with-openclaw.md
@@ -85,26 +85,6 @@ git -C <live-source-root> rev-parse HEAD
 
 Do not assume that the installed extension directory or your current shell checkout is the live commit.
 
-## Stronger proof for linked local installs
-
-If you are using a linked local install and want stronger proof that the live plugin really comes from the intended worktree, verify both the install path target and the branch name:
-
-```bash
-openclaw plugins inspect devclaw
-readlink -f ~/.openclaw/extensions/devclaw
-git -C <intended-worktree> rev-parse --abbrev-ref HEAD
-git -C <intended-worktree> rev-parse HEAD
-```
-
-This gives you four checks:
-
-- the live plugin id and loaded source
-- the real filesystem target behind the installed extension path
-- the branch name of the intended worktree
-- the exact commit of that worktree
-
-For example, if you intend to run from a `devclaw-local-stable` worktree, these checks should agree on both the path and the branch identity before you treat the switch as complete.
-
 ## Avoid duplicate plugin-source collisions
 
 A common failure mode is loading DevClaw from more than one place at once, for example:
@@ -132,62 +112,6 @@ In that case:
 2. inspect the live plugin path again
 3. remove or disable competing DevClaw plugin sources
 4. restart and verify again
-
-## Generic smoke test for a running environment
-
-Use this when you want to verify a local DevClaw install in an already-running environment without creating new projects or tasks.
-
-## Tracker routing verification for fork-based installs
-
-If your local checkout has both a fork and an upstream remote, do not trust ambient GitHub CLI repo inference.
-
-Before relying on issue-creation flows, verify both the configured tracker target and the checkout's ambient `gh` target:
-
-```bash
-python3 - <<'PY'
-import json
-p=json.load(open('devclaw/projects.json'))['projects']['devclaw']
-print(p['repoRemote'])
-PY
-git -C <repo-or-worktree> remote -v
-gh repo view --json nameWithOwner --jq .nameWithOwner
-```
-
-Expected safety rule:
-
-- DevClaw issue/task tooling must route to the repository configured in `projects.json`
-- it must not drift to the repo that `gh` happens to infer from the checkout context
-
-When validating a fix for tracker-routing bugs, record both:
-
-- a pre-change proof showing config target versus ambient `gh` target
-- a post-change proof showing issue/task creation calls explicitly target the configured repo
-
-Read-only checks:
-
-```bash
-openclaw plugins inspect devclaw
-openclaw plugins list
-openclaw gateway status
-openclaw agent --agent <agent-id> --message 'Call project_status with channelId "<channel-id>" and reply with the result only.' --json
-openclaw agent --agent <agent-id> --message 'Call tasks_status and reply with the result only.' --json
-openclaw agent --agent <agent-id> --message 'Call channel_list and reply with the result only.' --json
-```
-
-What this verifies:
-
-- the plugin is loaded
-- the gateway is healthy
-- the live agent can read local project state
-- the live agent can read tracker-backed task state
-- channel bindings are visible
-
-Expected result note:
-
-- in an unbound DM or admin session, `project_status` and `tasks_status` may correctly return `No project found` for that channel
-- treat that as a passing result for this smoke test unless you were specifically testing a known project-bound chat
-
-Avoid using project-creating or task-creating commands for smoke tests in a shared live environment unless you also have an explicit cleanup plan.
 
 ## Keep generic guidance separate from local policy
 

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "defaults/",
     "roles/",
     "docs/",
+    "dev/",
     "openclaw.plugin.json"
   ],
   "publishConfig": {

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "build": "node build.mjs",
     "check": "tsc --noEmit",
     "watch": "tsc --noEmit --watch",
+    "regression:release": "bash dev/regression/tests/run-all.sh",
     "prepublishOnly": "npm run build"
   },
   "peerDependencies": {


### PR DESCRIPTION
## Summary
- create a repo-local `dev/` tree as the canonical home for developer-only runbooks and regression material
- move the self-hosting development guide into `dev/runbooks/`
- add executable release-regression checks and issue-linked notes for the jsonResult and GitHub repo-routing fixes

Addresses issue #100

## Verification
- `bash dev/regression/tests/run-all.sh`
- `npm run regression:release`
