### PR TITLE
fix: complete provider targeting across github paths (#95)

### DIFF
--- a/lib/dispatch/attachment-hook.ts
+++ b/lib/dispatch/attachment-hook.ts
@@ -19,6 +19,7 @@ import {
 } from "./attachments.js";
 import { readProjects, type Project } from "../projects/index.js";
 import { createProvider } from "../providers/index.js";
+import { normalizeRepoTarget } from "../tools/helpers.js";
 import { log as auditLog } from "../audit.js";
 
 /**
@@ -93,7 +94,12 @@ export function registerAttachmentHook(api: OpenClawPluginApi, ctx: PluginContex
     // Process each referenced issue
     for (const issueId of issueIds) {
       try {
-        const { provider } = await createProvider({ repo: project.repo, provider: project.provider, runCommand: ctx.runCommand });
+        const { provider } = await createProvider({
+          repo: project.repo,
+          provider: project.provider,
+          target: project.repoRemote ? { repo: normalizeRepoTarget(project.repoRemote) } : undefined,
+          runCommand: ctx.runCommand,
+        });
 
         await processAttachmentMessage({
           workspaceDir,

--- a/lib/providers/github.ts
+++ b/lib/providers/github.ts
@@ -61,11 +61,25 @@ export class GitHubProvider implements IssueProvider {
   }
 
   private withRepo(args: string[]): string[] {
-    if (!this.targetRepo) return args;
-    const needsExplicitRepo = this.commandSupportsRepo(args);
-    if (!needsExplicitRepo) return args;
+    if (!this.targetRepo || args.length === 0) return args;
+    if (args[0] === "api") return this.withApiTarget(args);
+    if (!this.commandSupportsRepo(args)) return args;
     if (args.includes("--repo") || args.includes("-R")) return args;
     return [...args, "--repo", this.targetRepo];
+  }
+
+  private withApiTarget(args: string[]): string[] {
+    if (args.includes("graphql")) return args;
+    const repo = this.getTargetRepoParts();
+    if (!repo) return args;
+    if (args.length < 2) return args;
+
+    const route = args[1]
+      .replace(/(^|\/)repos\/:owner\/:repo(?=\/|$)/, `$1repos/${repo.owner}/${repo.name}`)
+      .replace(/(^|\/)projects\/:id(?=\/|$)/, `$1repos/${repo.owner}/${repo.name}`);
+
+    if (route === args[1]) return args;
+    return [args[0], route, ...args.slice(2)];
   }
 
   private commandSupportsRepo(args: string[]): boolean {
@@ -74,8 +88,13 @@ export class GitHubProvider implements IssueProvider {
     if (args[0] === "issue") return true;
     if (args[0] === "pr") return true;
     if (args[0] === "label") return true;
-    if (args[0] !== "api") return false;
-    return !args.includes("graphql");
+    return false;
+  }
+
+  private getTargetRepoParts(): { owner: string; name: string } | null {
+    if (!this.targetRepo) return null;
+    const [owner, name] = this.targetRepo.split("/");
+    return owner && name ? { owner, name } : null;
   }
 
   /** Cached repo owner/name for GraphQL queries. */
@@ -88,12 +107,10 @@ export class GitHubProvider implements IssueProvider {
   private async getRepoInfo(): Promise<{ owner: string; name: string } | null> {
     if (this.repoInfo !== undefined) return this.repoInfo;
     try {
-      if (this.targetRepo) {
-        const [owner, name] = this.targetRepo.split("/");
-        if (owner && name) {
-          this.repoInfo = { owner, name };
-          return this.repoInfo;
-        }
+      const targetRepo = this.getTargetRepoParts();
+      if (targetRepo) {
+        this.repoInfo = targetRepo;
+        return this.repoInfo;
       }
       const raw = await this.gh(["repo", "view", "--json", "owner,name"]);
       const data = JSON.parse(raw);

--- a/lib/providers/provider-targeting.test.ts
+++ b/lib/providers/provider-targeting.test.ts
@@ -34,7 +34,7 @@ describe("GitHubProvider explicit repo targeting", () => {
     assert.deepEqual(createCall.slice(-2), ["--repo", "yaqub0r/devclaw"]);
   });
 
-  it("passes --repo for issue read, edit, label, and comment paths when target repo is configured", async () => {
+  it("passes --repo for issue read, edit, and label paths when target repo is configured", async () => {
     const calls: string[][] = [];
     let issue95State = "Planning";
     const runCommand = mock.fn(async (args: string[]) => {
@@ -61,7 +61,7 @@ describe("GitHubProvider explicit repo targeting", () => {
         return { stdout: "", stderr: "", code: 0 };
       }
 
-      if (args[1] === "api" && args[2] === "repos/:owner/:repo/issues/95/comments") {
+      if (args[1] === "api" && args[2] === "repos/yaqub0r/devclaw/issues/95/comments") {
         return { stdout: JSON.stringify({ id: 12345 }), stderr: "", code: 0 };
       }
 
@@ -94,9 +94,48 @@ describe("GitHubProvider explicit repo targeting", () => {
     assert.ok(labelCreateCall, "expected label create call");
     assert.deepEqual(labelCreateCall.slice(-2), ["--repo", "yaqub0r/devclaw"]);
 
-    const commentCall = calls.find((c) => c[1] === "api" && c[2] === "repos/:owner/:repo/issues/95/comments");
+    const commentCall = calls.find((c) => c[1] === "api" && c[2] === "repos/yaqub0r/devclaw/issues/95/comments");
     assert.ok(commentCall, "expected issue comment api call");
-    assert.deepEqual(commentCall.slice(-2), ["--repo", "yaqub0r/devclaw"]);
+    assert.ok(!commentCall.includes("--repo"), "gh api must not receive --repo");
+  });
+
+  it("rewrites only the gh api route placeholder to the configured repo without adding --repo", async () => {
+    const calls: string[][] = [];
+    const runCommand = mock.fn(async (args: string[]) => {
+      calls.push(args);
+
+      if (args[1] === "api" && args[2] === "repos/yaqub0r/devclaw/issues/95/comments") {
+        return { stdout: JSON.stringify([]), stderr: "", code: 0 };
+      }
+
+      if (args[1] === "api" && args[2] === "repos/yaqub0r/devclaw/issues/comments/42/reactions") {
+        return { stdout: "", stderr: "", code: 0 };
+      }
+
+      if (args[1] === "api" && args[2] === "repos/yaqub0r/devclaw/pulls/7/reviews") {
+        return { stdout: JSON.stringify([]), stderr: "", code: 0 };
+      }
+
+      throw new Error(`Unexpected command: ${args.join(" ")}`);
+    });
+
+    const provider = new GitHubProvider({ repoPath: "/fake", runCommand: runCommand as any, target: { repo: "yaqub0r/devclaw" } });
+
+    await provider.listComments(95);
+    await provider.reactToIssueComment(95, 42, "repos/:owner/:repo");
+    await (provider as any).hasChangesRequestedReview(7);
+
+    const apiCalls = calls.filter((c) => c[1] === "api");
+    assert.equal(apiCalls.length, 3);
+    for (const call of apiCalls) {
+      assert.ok(!call.includes("--repo"), "gh api must not receive --repo");
+      assert.ok(call[2]?.startsWith("repos/yaqub0r/devclaw/"), `expected concrete repo path, got ${call[2]}`);
+    }
+
+    const reactionCall = apiCalls.find((c) => c[2] === "repos/yaqub0r/devclaw/issues/comments/42/reactions");
+    assert.ok(reactionCall, "expected reactions api call");
+    const fieldIndex = reactionCall.indexOf("--field");
+    assert.equal(reactionCall[fieldIndex + 1], "content=repos/:owner/:repo", "non-route args must remain untouched");
   });
 
   it("uses configured target repo for repo info without gh repo view", async () => {

--- a/lib/services/heartbeat/tick-runner.ts
+++ b/lib/services/heartbeat/tick-runner.ts
@@ -13,6 +13,7 @@ import {
 } from "./health.js";
 import { projectTick } from "../tick.js";
 import { createProvider } from "../../providers/index.js";
+import { normalizeRepoTarget } from "../../tools/helpers.js";
 import { loadConfig } from "../../config/index.js";
 import { ExecutionMode } from "../../workflow/index.js";
 import type { HeartbeatConfig } from "./config.js";
@@ -91,6 +92,7 @@ export async function tick(opts: {
       const { provider } = await createProvider({
         repo: project.repo,
         provider: project.provider,
+        target: project.repoRemote ? { repo: normalizeRepoTarget(project.repoRemote) } : undefined,
         runCommand,
       });
       const resolvedConfig = await loadConfig(workspaceDir, project.name);

--- a/lib/services/tick-provider-targeting.test.ts
+++ b/lib/services/tick-provider-targeting.test.ts
@@ -1,0 +1,51 @@
+/**
+ * Regression tests for projectTick provider creation with repoRemote targeting.
+ *
+ * Run with: npx tsx --test lib/services/tick-provider-targeting.test.ts
+ */
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { createTestHarness } from "../testing/index.js";
+import { projectTick } from "./tick.js";
+
+describe("projectTick provider targeting", () => {
+  it("threads project repoRemote into provider creation from persisted project config", async () => {
+    const h = await createTestHarness();
+    try {
+      const projects = await h.readProjects();
+      projects.projects[h.project.slug] = {
+        ...projects.projects[h.project.slug]!,
+        repoRemote: "https://github.com/yaqub0r/devclaw.git",
+        provider: "github",
+      };
+      await h.writeProjects(projects);
+
+      const ghCalls: string[][] = [];
+      const runCommand = async (argv: string[]) => {
+        if (argv[0] === "gh") {
+          ghCalls.push(argv);
+          if (argv[1] === "issue" && argv[2] === "list") {
+            return { stdout: "[]", stderr: "", code: 0, signal: null, killed: false as const };
+          }
+        }
+        return { stdout: "{}", stderr: "", code: 0, signal: null, killed: false as const };
+      };
+
+      const result = await projectTick({
+        workspaceDir: h.workspaceDir,
+        projectSlug: h.project.slug,
+        targetRole: "developer",
+        runCommand: runCommand as any,
+      });
+
+      assert.equal(result.pickups.length, 0);
+      const issueListCalls = ghCalls.filter((call) => call[1] === "issue" && call[2] === "list");
+      assert.ok(issueListCalls.length >= 1, "expected projectTick to hit gh through a created provider");
+      for (const call of issueListCalls) {
+        assert.deepEqual(call.slice(-2), ["--repo", "yaqub0r/devclaw"]);
+      }
+    } finally {
+      await h.cleanup();
+    }
+  });
+});

--- a/lib/services/tick.ts
+++ b/lib/services/tick.ts
@@ -8,6 +8,7 @@ import type { PluginRuntime } from "openclaw/plugin-sdk";
 import type { RunCommand } from "../context.js";
 import type { Issue, IssueProvider } from "../providers/provider.js";
 import { createProvider } from "../providers/index.js";
+import { normalizeRepoTarget } from "../tools/helpers.js";
 import { selectLevel } from "../roles/model-selector.js";
 import { getRoleWorker, getProject, readProjects, findFreeSlot, countActiveSlots, reconcileSlots } from "../projects/index.js";
 import { dispatchTask } from "../dispatch/index.js";
@@ -82,7 +83,12 @@ export async function projectTick(opts: {
   const resolvedConfig = await loadConfig(workspaceDir, project.name);
   const workflow = opts.workflow ?? resolvedConfig.workflow;
 
-  const provider = opts.provider ?? (await createProvider({ repo: project.repo, provider: project.provider, runCommand: runCommand! })).provider;
+  const provider = opts.provider ?? (await createProvider({
+    repo: project.repo,
+    provider: project.provider,
+    target: project.repoRemote ? { repo: normalizeRepoTarget(project.repoRemote) } : undefined,
+    runCommand: runCommand!,
+  })).provider;
   const roleExecution = workflow.roleExecution ?? ExecutionMode.PARALLEL;
   const enabledRoles = Object.entries(resolvedConfig.roles)
     .filter(([, r]) => r.enabled)

--- a/lib/setup/templates.ts
+++ b/lib/setup/templates.ts
@@ -12,9 +12,21 @@ import path from "node:path";
 // File loader — reads from defaults/ (single source of truth)
 // ---------------------------------------------------------------------------
 
-// esbuild bundles everything into dist/index.js, so import.meta.url points to
-// dist/index.js → one level up reaches the repo root where defaults/ lives.
-const DEFAULTS_DIR = path.join(path.dirname(fileURLToPath(import.meta.url)), "..", "defaults");
+function resolveDefaultsDir(): string {
+  const here = path.dirname(fileURLToPath(import.meta.url));
+  const candidates = [
+    path.join(here, "..", "..", "defaults"),
+    path.join(here, "..", "defaults"),
+  ];
+
+  for (const candidate of candidates) {
+    if (fs.existsSync(candidate)) return candidate;
+  }
+
+  throw new Error(`Failed to locate defaults directory from ${here}`);
+}
+
+const DEFAULTS_DIR = resolveDefaultsDir();
 
 function loadDefault(filename: string): string {
   const filePath = path.join(DEFAULTS_DIR, filename);

--- a/lib/tools/admin/sync-labels.ts
+++ b/lib/tools/admin/sync-labels.ts
@@ -13,6 +13,7 @@ import type { PluginContext } from "../../context.js";
 import { jsonResult, requireWorkspaceDir } from "../helpers.js";
 import { readProjects, getProject } from "../../projects/index.js";
 import { createProvider } from "../../providers/index.js";
+import { normalizeRepoTarget } from "../helpers.js";
 import { loadConfig } from "../../config/index.js";
 import {
   getStateLabels,
@@ -80,6 +81,7 @@ export function createSyncLabelsTool(ctx: PluginContext) {
           const { provider } = await createProvider({
             repo: project.repo,
             provider: project.provider,
+            target: project.repoRemote ? { repo: normalizeRepoTarget(project.repoRemote) } : undefined,
             runCommand: ctx.runCommand,
           });
 

--- a/lib/tools/helpers.test.ts
+++ b/lib/tools/helpers.test.ts
@@ -1,0 +1,18 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { normalizeRepoTarget } from "./helpers.js";
+
+describe("normalizeRepoTarget", () => {
+  it("normalizes github https and ssh remotes", () => {
+    assert.equal(normalizeRepoTarget("https://github.com/yaqub0r/devclaw.git"), "yaqub0r/devclaw");
+    assert.equal(normalizeRepoTarget("git@github.com:yaqub0r/devclaw.git"), "yaqub0r/devclaw");
+  });
+
+  it("normalizes gitlab remotes and trims whitespace", () => {
+    assert.equal(normalizeRepoTarget("  https://gitlab.com/group/project.git  "), "group/project");
+  });
+
+  it("preserves already-normalized owner repo targets", () => {
+    assert.equal(normalizeRepoTarget("yaqub0r/devclaw"), "yaqub0r/devclaw");
+  });
+});

--- a/lib/tools/helpers.ts
+++ b/lib/tools/helpers.ts
@@ -70,7 +70,7 @@ export async function resolveProvider(project: Project, runCommand: RunCommand):
   return createProvider({ repo: project.repo, provider: project.provider, target, runCommand });
 }
 
-function normalizeRepoTarget(repoRemote: string): string | undefined {
+export function normalizeRepoTarget(repoRemote: string): string | undefined {
   const trimmed = repoRemote.trim();
   if (!trimmed) return undefined;
 


### PR DESCRIPTION
Addresses issue #95.

## What changed
- stop passing --repo to  gh api paths and rewrite API routes instead
- thread configured repo targets through remaining provider creation call sites
- add higher-level regression coverage for persisted project repo targeting
- fix template loading so the new regression tests run directly from source

## Validation
- npm run build
- npx tsx --test lib/services/tick-provider-targeting.test.ts lib/providers/provider-targeting.test.ts lib/tools/helpers.test.ts