### PR TITLE
test: guard against local fork identifiers

### DIFF
--- a/dev/regression/issues/fork-identifiers-108.md
+++ b/dev/regression/issues/fork-identifiers-108.md
@@ -1,0 +1,18 @@
+# Issue #108: keep local fork identifiers out of generic materials
+
+## Summary
+
+Generic-facing DevClaw code, tests, fixtures, and docs should not embed local fork repo identifiers such as `yaqub0r/devclaw`.
+Neutral placeholders should be used unless a real upstream identity is intentionally required.
+
+## Automated coverage
+
+- `lib/regression/fork-identifiers.test.ts`
+  - scans repository sources for known local fork identifiers
+  - excludes local-only runbooks and regression notes, where environment-specific references may be documented intentionally
+
+## Validation notes
+
+- Searched the repo for `yaqub0r/devclaw`, related owner strings, and common local branch/operator markers
+- Confirmed current remaining real repo/package identifiers are upstream/package metadata or publishing context, not local fork fixture data
+- Added developer-tree guidance so the rule is documented alongside regression expectations

--- a/docs/REQUIREMENTS.md
+++ b/docs/REQUIREMENTS.md
@@ -2,7 +2,7 @@
 
 Requirements for the next iteration of DevClaw's task model: step-based execution, plan-driven workflows, and PR lifecycle standardization.
 
-**Context:** [WORKFLOW-ALTERNATIVES.md](exploratory/WORKFLOW-ALTERNATIVES.md) (approach comparison), [STEP-BASED-TASKS.md](exploratory/STEP-BASED-TASKS.md) (early exploratory), [#443](https://github.com/laurentenhoor/devclaw/issues/443) (dependency gating)
+**Context:** [WORKFLOW-ALTERNATIVES.md](exploratory/WORKFLOW-ALTERNATIVES.md) (approach comparison), [STEP-BASED-TASKS.md](exploratory/STEP-BASED-TASKS.md) (early exploratory), #443 (dependency gating)
 
 ---
 

--- a/docs/devclaw-self-hosting.md
+++ b/docs/devclaw-self-hosting.md
@@ -103,7 +103,7 @@ This gives you four checks:
 - the branch name of the intended worktree
 - the exact commit of that worktree
 
-For example, if you intend to run from a `devclaw-local-stable` worktree, these checks should agree on both the path and the branch identity before you treat the switch as complete.
+For example, if you intend to run from a `feature/self-hosting-fix` worktree, these checks should agree on both the path and the branch identity before you treat the switch as complete.
 
 ## Avoid duplicate plugin-source collisions
 

--- a/docs/exploratory/STEP-BASED-TASKS.md
+++ b/docs/exploratory/STEP-BASED-TASKS.md
@@ -2,7 +2,7 @@
 
 Design for hierarchical issue → step layering with sequential execution and stacked PRs.
 
-**Related:** [#443 — Dependency gating](https://github.com/laurentenhoor/devclaw/issues/443)
+**Related:** #443 — Dependency gating
 
 ---
 
@@ -363,4 +363,4 @@ Full-blown PR stacking tools that rewrite commit history. Rejected because:
 
 - [GitHub Sub-Issues announcement](https://github.blog/engineering/architecture-optimization/introducing-sub-issues-enhancing-issue-management-on-github/)
 - [GitHub Sub-Issues API (GraphQL)](https://docs.github.com/en/graphql/reference/mutations#addsubissue) — requires `GraphQL-Features: sub_issues` header
-- [Issue #443 — Dependency gating](https://github.com/laurentenhoor/devclaw/issues/443)
+- Issue #443 — Dependency gating

--- a/lib/dispatch/pr-context.test.ts
+++ b/lib/dispatch/pr-context.test.ts
@@ -4,7 +4,7 @@ import { formatPrFeedback, type PrFeedback } from "./pr-context.js";
 describe("formatPrFeedback", () => {
   it("returns empty array when no comments", () => {
     const feedback: PrFeedback = {
-      url: "https://github.com/user/repo/pull/123",
+      url: "https://github.com/example-owner/example-repo/pull/123",
       branchName: "feature/123-test",
       reason: "merge_conflict",
       comments: [],
@@ -15,7 +15,7 @@ describe("formatPrFeedback", () => {
 
   it("includes branch name in conflict resolution instructions", () => {
     const feedback: PrFeedback = {
-      url: "https://github.com/user/repo/pull/123",
+      url: "https://github.com/example-owner/example-repo/pull/123",
       branchName: "feature/456-test",
       reason: "merge_conflict",
       comments: [
@@ -38,7 +38,7 @@ describe("formatPrFeedback", () => {
 
   it("uses fallback branch name when not provided", () => {
     const feedback: PrFeedback = {
-      url: "https://github.com/user/repo/pull/123",
+      url: "https://github.com/example-owner/example-repo/pull/123",
       reason: "merge_conflict",
       comments: [
         {
@@ -58,7 +58,7 @@ describe("formatPrFeedback", () => {
 
   it("includes step-by-step instructions for conflict resolution", () => {
     const feedback: PrFeedback = {
-      url: "https://github.com/user/repo/pull/123",
+      url: "https://github.com/example-owner/example-repo/pull/123",
       branchName: "feature/123-fix",
       reason: "merge_conflict",
       comments: [
@@ -88,7 +88,7 @@ describe("formatPrFeedback", () => {
 
   it("correctly formats changes_requested feedback", () => {
     const feedback: PrFeedback = {
-      url: "https://github.com/user/repo/pull/456",
+      url: "https://github.com/example-owner/example-repo/pull/456",
       branchName: "feature/789-feature",
       reason: "changes_requested",
       comments: [
@@ -111,7 +111,7 @@ describe("formatPrFeedback", () => {
 
   it("includes comment location information when available", () => {
     const feedback: PrFeedback = {
-      url: "https://github.com/user/repo/pull/123",
+      url: "https://github.com/example-owner/example-repo/pull/123",
       branchName: "feature/456-test",
       reason: "changes_requested",
       comments: [
@@ -133,7 +133,7 @@ describe("formatPrFeedback", () => {
 
   it("uses correct base branch in rebase command", () => {
     const feedback: PrFeedback = {
-      url: "https://github.com/user/repo/pull/123",
+      url: "https://github.com/example-owner/example-repo/pull/123",
       branchName: "feature/test",
       reason: "merge_conflict",
       comments: [

--- a/lib/providers/provider-pr-status.test.ts
+++ b/lib/providers/provider-pr-status.test.ts
@@ -51,7 +51,7 @@ describe("GitHubProvider.getPrStatus — closed PR handling", () => {
   it("returns url:closedPrUrl when a closed-without-merge PR exists", async () => {
     const provider = new GitHubProvider({ repoPath: "/fake", runCommand: mockRunCommand });
 
-    const closedPrUrl = "https://github.com/owner/repo/pull/7";
+    const closedPrUrl = "https://github.com/example-owner/example-repo/pull/7";
 
     (provider as any).findPrsForIssue = async (_id: number, state: string) => {
       if (state === "open" || state === "merged") return [];
@@ -85,7 +85,7 @@ describe("GitHubProvider.getPrStatus — closed PR handling", () => {
   it("prefers open PR over closed PR", async () => {
     const provider = new GitHubProvider({ repoPath: "/fake", runCommand: mockRunCommand });
 
-    const openPrUrl = "https://github.com/owner/repo/pull/9";
+    const openPrUrl = "https://github.com/example-owner/example-repo/pull/9";
 
     (provider as any).findPrsForIssue = async (_id: number, state: string) => {
       if (state === "open") {
@@ -117,7 +117,7 @@ describe("GitHubProvider.getPrStatus — closed PR handling", () => {
   it("prefers merged PR over closed PR", async () => {
     const provider = new GitHubProvider({ repoPath: "/fake", runCommand: mockRunCommand });
 
-    const mergedPrUrl = "https://github.com/owner/repo/pull/5";
+    const mergedPrUrl = "https://github.com/example-owner/example-repo/pull/5";
 
     (provider as any).findPrsForIssue = async (_id: number, state: string) => {
       if (state === "open") return [];
@@ -149,7 +149,7 @@ describe("GitHubProvider.getPrStatus — closed PR handling", () => {
     // Timeline has only OPEN PRs — none should trigger closed-PR path
     (provider as any).findPrsViaTimeline = async (_id: number, state: string) => {
       if (state === "all") {
-        return [{ number: 10, title: "", body: "", headRefName: "", url: "https://github.com/owner/repo/pull/10", mergedAt: null, reviewDecision: null, state: "OPEN", mergeable: null }];
+        return [{ number: 10, title: "", body: "", headRefName: "", url: "https://github.com/example-owner/example-repo/pull/10", mergedAt: null, reviewDecision: null, state: "OPEN", mergeable: null }];
       }
       return [];
     };
@@ -165,7 +165,7 @@ describe("GitHubProvider.getPrStatus — closed PR handling", () => {
   it("detects merge conflicts via mergeable field", async () => {
     const provider = new GitHubProvider({ repoPath: "/fake", runCommand: mockRunCommand });
 
-    const conflictedPrUrl = "https://github.com/owner/repo/pull/11";
+    const conflictedPrUrl = "https://github.com/example-owner/example-repo/pull/11";
 
     (provider as any).findPrsForIssue = async (_id: number, state: string) => {
       if (state === "open") {
@@ -198,7 +198,7 @@ describe("GitHubProvider.getPrStatus — closed PR handling", () => {
   it("distinguishes mergeable states", async () => {
     const provider = new GitHubProvider({ repoPath: "/fake", runCommand: mockRunCommand });
 
-    const mergeablePrUrl = "https://github.com/owner/repo/pull/12";
+    const mergeablePrUrl = "https://github.com/example-owner/example-repo/pull/12";
 
     (provider as any).findPrsForIssue = async (_id: number, state: string) => {
       if (state === "open") {
@@ -230,7 +230,7 @@ describe("GitHubProvider.getPrStatus — closed PR handling", () => {
   it("handles unknown mergeable state", async () => {
     const provider = new GitHubProvider({ repoPath: "/fake", runCommand: mockRunCommand });
 
-    const unknownPrUrl = "https://github.com/owner/repo/pull/13";
+    const unknownPrUrl = "https://github.com/example-owner/example-repo/pull/13";
 
     (provider as any).findPrsForIssue = async (_id: number, state: string) => {
       if (state === "open") {
@@ -279,7 +279,7 @@ describe("GitLabProvider.getPrStatus — closed MR handling", () => {
   it("returns url:closedMrUrl when a closed-without-merge MR exists", async () => {
     const provider = new GitLabProvider({ repoPath: "/fake", runCommand: mockRunCommand });
 
-    const closedMrUrl = "https://gitlab.com/owner/repo/-/merge_requests/3";
+    const closedMrUrl = "https://gitlab.com/octo-org/octo-repo/-/merge_requests/3";
 
     (provider as any).getRelatedMRs = async () => [
       {
@@ -303,8 +303,8 @@ describe("GitLabProvider.getPrStatus — closed MR handling", () => {
   it("prefers open MR over closed MR", async () => {
     const provider = new GitLabProvider({ repoPath: "/fake", runCommand: mockRunCommand });
 
-    const openMrUrl = "https://gitlab.com/owner/repo/-/merge_requests/4";
-    const closedMrUrl = "https://gitlab.com/owner/repo/-/merge_requests/2";
+    const openMrUrl = "https://gitlab.com/octo-org/octo-repo/-/merge_requests/4";
+    const closedMrUrl = "https://gitlab.com/octo-org/octo-repo/-/merge_requests/2";
 
     (provider as any).getRelatedMRs = async () => [
       { iid: 4, title: "open MR", description: "", web_url: openMrUrl, state: "opened", source_branch: "feature/4", merged_at: null },
@@ -324,8 +324,8 @@ describe("GitLabProvider.getPrStatus — closed MR handling", () => {
   it("prefers merged MR over closed MR", async () => {
     const provider = new GitLabProvider({ repoPath: "/fake", runCommand: mockRunCommand });
 
-    const mergedMrUrl = "https://gitlab.com/owner/repo/-/merge_requests/5";
-    const closedMrUrl = "https://gitlab.com/owner/repo/-/merge_requests/1";
+    const mergedMrUrl = "https://gitlab.com/octo-org/octo-repo/-/merge_requests/5";
+    const closedMrUrl = "https://gitlab.com/octo-org/octo-repo/-/merge_requests/1";
 
     (provider as any).getRelatedMRs = async () => [
       { iid: 5, title: "merged", description: "", web_url: mergedMrUrl, state: "merged", source_branch: "feature/5", merged_at: "2026-01-01T00:00:00Z" },
@@ -341,8 +341,8 @@ describe("GitLabProvider.getPrStatus — closed MR handling", () => {
   it("handles multiple closed MRs — returns the first found", async () => {
     const provider = new GitLabProvider({ repoPath: "/fake", runCommand: mockRunCommand });
 
-    const closedMrUrl1 = "https://gitlab.com/owner/repo/-/merge_requests/10";
-    const closedMrUrl2 = "https://gitlab.com/owner/repo/-/merge_requests/11";
+    const closedMrUrl1 = "https://gitlab.com/octo-org/octo-repo/-/merge_requests/10";
+    const closedMrUrl2 = "https://gitlab.com/octo-org/octo-repo/-/merge_requests/11";
 
     (provider as any).getRelatedMRs = async () => [
       { iid: 10, title: "closed 1", description: "", web_url: closedMrUrl1, state: "closed", source_branch: "feature/10", merged_at: null },

--- a/lib/regression/fork-identifiers.test.ts
+++ b/lib/regression/fork-identifiers.test.ts
@@ -1,0 +1,70 @@
+/**
+ * Regression guard for issue #108.
+ *
+ * Generic-facing code, tests, and docs must not hardcode local fork identifiers.
+ * Local-only runbooks/config may document environment-specific details separately.
+ *
+ * Run with: npx tsx --test lib/regression/fork-identifiers.test.ts
+ */
+import { describe, it } from "node:test";
+import assert from "node:assert";
+import fs from "node:fs/promises";
+import path from "node:path";
+
+const repoRoot = path.resolve(path.dirname(new URL(import.meta.url).pathname), "../..");
+
+const forbiddenIdentifiers = [
+  ["yaqub0r", "devclaw"].join("/"),
+  ["github.com", "yaqub0r", "devclaw"].join("/"),
+  `@${["yaqub0r", "devclaw"].join("/")}`,
+];
+
+const includeExtensions = new Set([".md", ".ts", ".js", ".json", ".yml", ".yaml"]);
+const excludedDirs = new Set([
+  ".git",
+  "dist",
+  "node_modules",
+  ".openclaw",
+]);
+
+async function walk(dir: string): Promise<string[]> {
+  const entries = await fs.readdir(dir, { withFileTypes: true });
+  const files: string[] = [];
+
+  for (const entry of entries) {
+    if (excludedDirs.has(entry.name)) continue;
+    const fullPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...await walk(fullPath));
+      continue;
+    }
+    if (!includeExtensions.has(path.extname(entry.name))) continue;
+    files.push(fullPath);
+  }
+
+  return files;
+}
+
+describe("regression guard: local fork identifiers stay out of generic-facing sources", () => {
+  it("should not contain known local fork repo identifiers outside local-only surfaces", async () => {
+    const files = await walk(repoRoot);
+    const offenders: string[] = [];
+
+    for (const file of files) {
+      const rel = path.relative(repoRoot, file);
+      if (rel === "lib/regression/fork-identifiers.test.ts") continue;
+      if (rel.startsWith("dev/runbooks/")) continue;
+      if (rel.startsWith("dev/regression/issues/")) continue;
+
+      const content = await fs.readFile(file, "utf-8");
+      const hits = forbiddenIdentifiers.filter(identifier => content.includes(identifier));
+      if (hits.length > 0) offenders.push(`${rel}: ${hits.join(", ")}`);
+    }
+
+    assert.deepStrictEqual(
+      offenders,
+      [],
+      `Found forbidden local fork identifiers in generic-facing files:\n${offenders.join("\n")}`,
+    );
+  });
+});

--- a/lib/tools/worker/work-finish.test.ts
+++ b/lib/tools/worker/work-finish.test.ts
@@ -174,7 +174,7 @@ describe("work_finish: PR validation and conflict resolution", () => {
       const errorMessage = 
         `Cannot complete work_finish(done) while PR still shows merge conflicts.\n\n` +
         `✗ PR status: CONFLICTING\n` +
-        `✗ PR URL: https://github.com/test/repo/pull/42\n` +
+        `✗ PR URL: https://github.com/example-owner/example-repo/pull/42\n` +
         `✗ Branch: feature/test\n\n` +
         `Your local rebase may have succeeded, but changes must be pushed to the remote.\n\n` +
         `Verify your changes were pushed:\n` +
@@ -210,7 +210,7 @@ describe("work_finish: PR validation and conflict resolution", () => {
       const errorMessage = 
         `Cannot complete work_finish(done) while PR still shows merge conflicts.\n\n` +
         `✗ PR status: CONFLICTING\n` +
-        `✗ PR URL: https://github.com/test/repo/pull/42\n` +
+        `✗ PR URL: https://github.com/example-owner/example-repo/pull/42\n` +
         `✗ Branch: ${branchName}`;
       
       assert.ok(
@@ -261,7 +261,7 @@ describe("work_finish: PR validation and conflict resolution", () => {
         project: "devclaw",
         issue: 123,
         reason: "pr_still_conflicting",
-        prUrl: "https://github.com/test/repo/pull/123",
+        prUrl: "https://github.com/example-owner/example-repo/pull/123",
         mergeable: false,
       };
       
@@ -275,7 +275,7 @@ describe("work_finish: PR validation and conflict resolution", () => {
         event: "conflict_resolution_verified",
         project: "devclaw",
         issue: 123,
-        prUrl: "https://github.com/test/repo/pull/123",
+        prUrl: "https://github.com/example-owner/example-repo/pull/123",
         mergeable: true,
       };
       


### PR DESCRIPTION
## Summary
- neutralize generic repo fixtures and repo-specific issue links
- replace a local worktree example with a neutral one in self-hosting docs
- add a regression guard plus issue-linked regression note for #108

## Testing
- npx tsx --test lib/regression/fork-identifiers.test.ts

## Notes
- rebuilt from devclaw-local-current to comply with local branch policy
