### PR TITLE
chore: prepare loop debug environment

### DIFF
--- a/lib/dispatch/index.ts
+++ b/lib/dispatch/index.ts
@@ -7,6 +7,7 @@
 import type { PluginRuntime } from "openclaw/plugin-sdk";
 import type { RunCommand } from "../context.js";
 import { log as auditLog } from "../audit.js";
+import { recordLoopDiagnostic } from "../services/loop-diagnostics.js";
 import {
   type Project,
   activateWorker,
@@ -184,6 +185,16 @@ export async function dispatchTask(
 
   // ── Commitment point — transition label (issue leaves queue) ────────
   await provider.transitionLabel(issueId, fromLabel, toLabel);
+  await recordLoopDiagnostic(workspaceDir, "dispatch_pickup", {
+    project: project.name,
+    issueId,
+    role,
+    level,
+    from: fromLabel,
+    to: toLabel,
+    sessionAction,
+    sessionKey,
+  }).catch(() => {});
 
   // Mark issue + PR as managed and all consumed comments as seen (fire-and-forget)
   provider.reactToIssue(issueId, EYES_EMOJI).catch(() => {});

--- a/lib/services/heartbeat/health.ts
+++ b/lib/services/heartbeat/health.ts
@@ -51,6 +51,7 @@ import {
 import { isSessionAlive, type SessionLookup } from "../gateway-sessions.js";
 import { sendToAgent } from "../../dispatch/session.js";
 import type { RunCommand } from "../../context.js";
+import { recordLoopDiagnostic } from "../loop-diagnostics.js";
 
 // Re-export for consumers that import from health.ts
 export { fetchGatewaySessions, isSessionAlive, type GatewaySession, type SessionLookup } from "../gateway-sessions.js";
@@ -231,6 +232,16 @@ export async function checkWorkerHealth(opts: {
         if (!issueIdNum) return;
         try {
           await provider.transitionLabel(issueIdNum, from, to);
+          await recordLoopDiagnostic(workspaceDir, "health_requeue", {
+            project: project.name,
+            projectSlug,
+            issueId: issueIdNum,
+            role,
+            from,
+            to,
+            slotLevel: level,
+            slotIndex,
+          }).catch(() => {});
           fix.labelReverted = `${from} → ${to}`;
         } catch {
           fix.labelRevertFailed = true;

--- a/lib/services/heartbeat/review.ts
+++ b/lib/services/heartbeat/review.ts
@@ -17,6 +17,7 @@ import {
 import { detectStepRouting } from "../queue-scan.js";
 import type { RunCommand } from "../../context.js";
 import { log as auditLog } from "../../audit.js";
+import { recordLoopDiagnostic } from "../loop-diagnostics.js";
 
 /**
  * Scan review-type states and transition issues whose PR check condition is met.
@@ -98,6 +99,15 @@ export async function reviewPass(opts: {
           const targetState = workflow.states[targetKey];
           if (targetState) {
             await provider.transitionLabel(issue.iid, state.label, targetState.label);
+            await recordLoopDiagnostic(workspaceDir, "review_feedback_transition", {
+              project: projectName,
+              issueId: issue.iid,
+              from: state.label,
+              to: targetState.label,
+              reason: status.state === PrState.HAS_COMMENTS ? "pr_comments" : "changes_requested",
+              prUrl: status.url,
+              sourceBranch: status.sourceBranch,
+            }).catch(() => {});
             await auditLog(workspaceDir, "review_transition", {
               project: projectName, issueId: issue.iid,
               from: state.label, to: targetState.label,
@@ -121,6 +131,15 @@ export async function reviewPass(opts: {
           const targetState = workflow.states[targetKey];
           if (targetState) {
             await provider.transitionLabel(issue.iid, state.label, targetState.label);
+            await recordLoopDiagnostic(workspaceDir, "review_feedback_transition", {
+              project: projectName,
+              issueId: issue.iid,
+              from: state.label,
+              to: targetState.label,
+              reason: "merge_conflict",
+              prUrl: status.url,
+              sourceBranch: status.sourceBranch,
+            }).catch(() => {});
             await auditLog(workspaceDir, "review_transition", {
               project: projectName, issueId: issue.iid,
               from: state.label, to: targetState.label,
@@ -212,6 +231,15 @@ export async function reviewPass(opts: {
                   const failedState = workflow.states[failedKey];
                   if (failedState) {
                     await provider.transitionLabel(issue.iid, state.label, failedState.label);
+                    await recordLoopDiagnostic(workspaceDir, "review_feedback_transition", {
+                      project: projectName,
+                      issueId: issue.iid,
+                      from: state.label,
+                      to: failedState.label,
+                      reason: "merge_failed",
+                      prUrl: status.url,
+                      sourceBranch: status.sourceBranch,
+                    }).catch(() => {});
                     await auditLog(workspaceDir, "review_transition", {
                       project: projectName,
                       issueId: issue.iid,

--- a/lib/services/loop-diagnostics.ts
+++ b/lib/services/loop-diagnostics.ts
@@ -1,0 +1,20 @@
+import { log as auditLog } from "../audit.js";
+
+export type LoopDiagnosticData = Record<string, unknown>;
+
+function isEnabled(): boolean {
+  const raw = process.env.DEVCLAW_LOOP_DIAGNOSTICS?.trim().toLowerCase();
+  return raw === "1" || raw === "true" || raw === "yes" || raw === "on";
+}
+
+export async function recordLoopDiagnostic(
+  workspaceDir: string,
+  stage: string,
+  data: LoopDiagnosticData,
+): Promise<void> {
+  if (!isEnabled()) return;
+  await auditLog(workspaceDir, "loop_diagnostic", {
+    stage,
+    ...data,
+  });
+}

--- a/lib/services/pipeline.ts
+++ b/lib/services/pipeline.ts
@@ -11,6 +11,7 @@ import { notify, getNotificationConfig } from "../dispatch/notify.js";
 import { log as auditLog } from "../audit.js";
 import { loadConfig } from "../config/index.js";
 import { detectStepRouting } from "./queue-scan.js";
+import { recordLoopDiagnostic } from "./loop-diagnostics.js";
 import {
   DEFAULT_WORKFLOW,
   Action,
@@ -204,8 +205,19 @@ export async function executeCompletion(opts: {
   // Transition label first (critical — if this fails, issue still has correct state)
   // Then execute post-transition actions (close/reopen)
   // Finally deactivate worker (last — ensures label is set even if deactivation fails)
-  
-  await provider.transitionLabel(issueId, rule.from as StateLabel, rule.to as StateLabel);
+  const transitionedTo = rule.to as StateLabel;
+  await provider.transitionLabel(issueId, rule.from as StateLabel, transitionedTo);
+
+  await recordLoopDiagnostic(workspaceDir, "work_finish_transition", {
+    project: projectName,
+    issueId,
+    role,
+    result,
+    from: rule.from,
+    to: transitionedTo,
+    summary: summary ?? null,
+    prUrl: prUrl ?? null,
+  }).catch(() => {});
 
   // Execute post-transition actions
   for (const action of rule.actions) {


### PR DESCRIPTION
## Summary
- prepare a dedicated loop-debug lane off devclaw-local-current
- add dormant, toggleable loop diagnostics for churn investigation
- add retry-ceiling scaffolding/tests so repeated redispatch loops can be observed and halted

## Notes
- diagnostics are gated behind `DEVCLAW_LOOP_DIAGNOSTICS=1`
- rollback lane remains `devclaw-local-current`

Closes #125