### PR TITLE
fix: add loop-brake retry ceiling safety net

### DIFF
--- a/lib/services/loop-brake.ts
+++ b/lib/services/loop-brake.ts
@@ -1,0 +1,669 @@
+import { readFile, stat } from "node:fs/promises";
+import { join } from "node:path";
+import { log as auditLog } from "../audit.js";
+import { DATA_DIR } from "../setup/migrate-layout.js";
+import { StateType, type WorkflowConfig } from "../workflow/index.js";
+
+const LOOP_BRAKE_WINDOW_MS = 6 * 60 * 60 * 1000;
+const LOOP_BRAKE_THRESHOLD = 3;
+
+type AuditEntry = Record<string, unknown> & {
+  ts?: string;
+  event?: string;
+  issueId?: number;
+  issue?: number;
+};
+
+function buildEventAuditExcerpt(entry: AuditEntry): Record<string, unknown> {
+  return {
+    ts: typeof entry.ts === "string" ? entry.ts : null,
+    event: typeof entry.event === "string" ? entry.event : null,
+    stage: asString(entry.stage) ?? null,
+    result: asString(entry.result) ?? null,
+    from: asString(entry.from) ?? null,
+    to: asString(entry.to) ?? null,
+    reason: asString(entry.reason) ?? null,
+    sourceBranch: asString(entry.sourceBranch) ?? null,
+    repoPath: asString(entry.repoPath) ?? null,
+    pluginSourceRoot: asString(entry.pluginSourceRoot) ?? null,
+    loopBrakeReason: asString(entry.loopBrakeReason) ?? null,
+    healthRequeueLoopReason: asString(entry.healthRequeueLoopReason) ?? null,
+    orphanReason: asString(entry.orphanReason) ?? null,
+    transitionReasonCategory: asString(entry.transitionReasonCategory) ?? null,
+    refiningDecisionPath: asString(entry.refiningDecisionPath) ?? null,
+    healthDecisionCategory: asString(entry.healthDecisionCategory) ?? null,
+    healthDecisionSummary: asString(entry.healthDecisionSummary) ?? null,
+    branchResolutionDecision: asString(entry.branchResolutionDecision) ?? null,
+    prValidationDecision: asString(entry.prValidationDecision) ?? null,
+    prValidationLookupOutcome: asString(entry.prValidationLookupOutcome) ?? null,
+    branchResolutionPreferredSource: asString(entry.branchResolutionPreferredSource) ?? asString(entry.preferredBranchSource) ?? null,
+    branchResolutionPreferredEvidence: asString(entry.branchResolutionPreferredEvidence) ?? null,
+    preferredBranchConfidence: asString(entry.preferredBranchConfidence) ?? null,
+    branchSelectionWinnerSummary: asString(entry.branchSelectionWinnerSummary) ?? null,
+    branchWinnerDecisionSummary: asString(entry.branchWinnerDecisionSummary) ?? null,
+    branchWinnerComparedToLaneSummary: asString(entry.branchWinnerComparedToLaneSummary) ?? null,
+    prValidationBranchResolutionPreferredSource: asString(entry.prValidationBranchResolutionPreferredSource) ?? null,
+    prValidationPreferredBranchConfidence: asString(entry.prValidationPreferredBranchConfidence) ?? null,
+    prValidationBranchResolutionPreferredEvidence: asString(entry.prValidationBranchResolutionPreferredEvidence) ?? null,
+    prValidationLookupTargetingDecision: asString(entry.prValidationLookupTargetingDecision) ?? null,
+    prValidationLookupTargetingSummary: isRecord(entry.prValidationLookupTargetingSummary) ? entry.prValidationLookupTargetingSummary : null,
+    prValidationConfiguredProviderTargetRepo: asString(entry.prValidationConfiguredProviderTargetRepo) ?? null,
+    prValidationRepoAmbientGhTarget: asString(entry.prValidationRepoAmbientGhTarget) ?? null,
+    prValidationPluginAmbientGhTarget: asString(entry.prValidationPluginAmbientGhTarget) ?? null,
+    prValidationRepoAmbientLinkedPrCount: asNumber(entry.prValidationRepoAmbientLinkedPrCount),
+    prValidationPluginAmbientLinkedPrCount: asNumber(entry.prValidationPluginAmbientLinkedPrCount),
+    prValidationConfiguredTargetLinkedPrCount: asNumber(entry.prValidationConfiguredTargetLinkedPrCount),
+    prValidationLookupProbeDecision: asString(entry.prValidationLookupProbeDecision) ?? null,
+    prValidationLookupProbeSummary: isRecord(entry.prValidationLookupProbeSummary) ? entry.prValidationLookupProbeSummary : null,
+    prValidationDetectedBranch: asString(entry.prValidationDetectedBranch) ?? null,
+    prValidationDetectedBranchSource: asString(entry.prValidationDetectedBranchSource) ?? null,
+    prValidationDetectedBranchDecisionSummary: asString(entry.prValidationDetectedBranchDecisionSummary) ?? null,
+    prValidationDetectedBranchMismatchReasons: Array.isArray(entry.prValidationDetectedBranchMismatchReasons) ? entry.prValidationDetectedBranchMismatchReasons : null,
+    prValidationBranchSelectionWinnerSummary: asString(entry.prValidationBranchSelectionWinnerSummary) ?? null,
+    prValidationBranchWinnerDecisionSummary: asString(entry.prValidationBranchWinnerDecisionSummary) ?? null,
+    prValidationBranchWinnerComparedToLaneSummary: asString(entry.prValidationBranchWinnerComparedToLaneSummary) ?? null,
+    prValidationLaneMismatchSummary: asString(entry.prValidationLaneMismatchSummary) ?? null,
+    prValidationLaneMismatchCategory: asString(entry.prValidationLaneMismatchCategory) ?? null,
+    liveSourceDecision: asString(entry.liveSourceDecision) ?? null,
+    liveSourceSingularitySummary: asString(entry.liveSourceSingularitySummary) ?? null,
+    openclawConfigInstallSourcePath: asString(entry.openclawConfigInstallSourcePath) ?? null,
+    openclawConfigInstallSourceRealPath: asString(entry.openclawConfigInstallSourceRealPath) ?? null,
+    openclawConfigInstallPath: asString(entry.openclawConfigInstallPath) ?? null,
+    openclawConfigInstallPathRealPath: asString(entry.openclawConfigInstallPathRealPath) ?? null,
+    openclawConfigPluginLoadPaths: Array.isArray(entry.openclawConfigPluginLoadPaths) ? entry.openclawConfigPluginLoadPaths : null,
+    openclawConfigPluginLoadPathRealPaths: Array.isArray(entry.openclawConfigPluginLoadPathRealPaths) ? entry.openclawConfigPluginLoadPathRealPaths : null,
+    branchResolutionMismatchFlags: isRecord(entry.branchResolutionMismatchFlags) ? entry.branchResolutionMismatchFlags : null,
+    liveSourceAgreementMatrix: isRecord(entry.liveSourceAgreementMatrix) ? entry.liveSourceAgreementMatrix : null,
+    laneIdentitySummary: isRecord(entry.laneIdentitySummary) ? entry.laneIdentitySummary : null,
+    branchSelectionDecisionTrace: isRecord(entry.branchSelectionDecisionTrace) ? entry.branchSelectionDecisionTrace : null,
+    duplicateSourceDecision: asString(entry.duplicateSourceDecision) ?? null,
+    duplicateSourceWinningRealPathGuess: asString(entry.duplicateSourceWinningRealPathGuess) ?? null,
+    duplicateSourceCompetingRealPaths: Array.isArray(entry.duplicateSourceCompetingRealPaths) ? entry.duplicateSourceCompetingRealPaths : null,
+    laneMismatchSummary: asString(entry.laneMismatchSummary) ?? null,
+    laneMismatchCategory: asString(entry.laneMismatchCategory) ?? null,
+    branchSourceCandidateDecisionTable: Array.isArray(entry.branchSourceCandidateDecisionTable) ? entry.branchSourceCandidateDecisionTable : null,
+    branchSourceCandidateDiagnostics: Array.isArray(entry.branchSourceCandidateDiagnostics) ? entry.branchSourceCandidateDiagnostics : null,
+    branchSourceCandidatesInPriorityOrder: Array.isArray(entry.branchSourceCandidatesInPriorityOrder) ? entry.branchSourceCandidatesInPriorityOrder : null,
+    repoSnapshot: isRecord(entry.repoSnapshot) ? entry.repoSnapshot : null,
+    pluginSnapshot: isRecord(entry.pluginSnapshot) ? entry.pluginSnapshot : null,
+    canRequeueIssue: typeof entry.canRequeueIssue === "boolean" ? entry.canRequeueIssue : null,
+    duplicateSourceRisk: typeof entry.duplicateSourceRisk === "boolean" ? entry.duplicateSourceRisk : null,
+    issueId: typeof entry.issueId === "number" ? entry.issueId : null,
+    issue: typeof entry.issue === "number" ? entry.issue : null,
+  };
+}
+
+export type LoopBrakeDecision = {
+  blocked: boolean;
+  threshold: number;
+  windowMs: number;
+  auditScan: {
+    filePath: string;
+    fileExists: boolean;
+    fileSizeBytes: number | null;
+    fileMtime: string | null;
+    totalEntriesRead: number;
+    issueEntriesSeen: number;
+    matchedLoopEventsBeforeWindow: number;
+    matchedLoopEventsInsideWindow: number;
+    skippedBecauseIssueDidNotMatch: number;
+    skippedBecauseNoLoopRuleMatched: number;
+    skippedBecauseOutsideWindow: number;
+    matchOutcomeCategory: string;
+    matchOutcomeSummary: string;
+    newestMatchedEventTs: string | null;
+    oldestMatchedEventTs: string | null;
+    newestMatchedEventInsideWindowTs: string | null;
+    newestMatchedEventReason: string | null;
+    newestIssueEntryTs: string | null;
+    newestIssueEntryEvent: string | null;
+    newestIssueEntryStage: string | null;
+    newestIssueEntrySummary: string | null;
+    newestNonMatchingIssueEntryTs: string | null;
+    newestNonMatchingIssueEntryEvent: string | null;
+    newestNonMatchingIssueEntryStage: string | null;
+    newestNonMatchingIssueEntrySummary: string | null;
+    recentIssueEntryExcerpts: Array<Record<string, unknown>>;
+    recentNonMatchingIssueEntryExcerpts: Array<Record<string, unknown>>;
+  };
+  events: Array<{
+    ts: string;
+    source: string;
+    stage?: string;
+    event?: string;
+    from?: string;
+    to?: string;
+    reason: string;
+    rawReason?: string;
+    orphanReason?: string;
+    decisionPath?: string;
+    countedByRule?: string;
+    rawEvent?: string;
+    rawStage?: string;
+    rawResult?: string;
+    issueFieldUsed?: string;
+    rawIssueId?: number | null;
+    rawIssue?: number | null;
+    rawLabelPair?: string;
+    matchedBecause?: string;
+    rawLoopBrakeReason?: string;
+    rawTransitionReasonCategory?: string;
+    rawRefiningDecisionPath?: string;
+    rawHealthDecisionCategory?: string;
+    eventShapeSummary?: string;
+    compactDecisionSummary?: string;
+    rawHealthDecisionSummary?: string;
+    rawBranchWinnerSummary?: string;
+    rawDuplicateSourceDecision?: string;
+    rawPreferredBranchSource?: string;
+    rawBranchResolutionPreferredEvidence?: string;
+    rawPreferredBranchConfidence?: string;
+    rawLaneMismatchSummary?: string;
+    rawLaneMismatchCategory?: string;
+    rawDuplicateSourceRisk?: boolean | null;
+    rawCanRequeueIssue?: boolean | null;
+    rawAuditExcerpt?: Record<string, unknown>;
+    rawSourceBranch?: string;
+    rawRepoPath?: string;
+    rawPluginSourceRoot?: string;
+    rawBranchResolutionDecision?: string;
+    rawPrValidationDecision?: string;
+    rawPrValidationLookupOutcome?: string;
+    rawLiveSourceDecision?: string;
+    rawLiveSourceSingularitySummary?: string;
+    rawOpenclawConfigInstallSourcePath?: string;
+    rawOpenclawConfigInstallSourceRealPath?: string;
+    rawOpenclawConfigInstallPath?: string;
+    rawOpenclawConfigInstallPathRealPath?: string;
+    rawOpenclawConfigPluginLoadPaths?: unknown[] | null;
+    rawOpenclawConfigPluginLoadPathRealPaths?: unknown[] | null;
+    rawBranchResolutionMismatchFlags?: Record<string, unknown> | null;
+    rawLiveSourceAgreementMatrix?: Record<string, unknown> | null;
+    rawLaneIdentitySummary?: Record<string, unknown> | null;
+    rawBranchSelectionDecisionTrace?: Record<string, unknown> | null;
+    rawDuplicateSourceWinningRealPathGuess?: string;
+    rawDuplicateSourceCompetingRealPaths?: unknown[] | null;
+    rawBranchSourceCandidateDecisionTable?: unknown[] | null;
+    rawPrValidationBranchResolutionPreferredSource?: string;
+    rawPrValidationPreferredBranchConfidence?: string;
+    rawPrValidationBranchResolutionPreferredEvidence?: string;
+    rawPrValidationBranchSelectionWinnerSummary?: string;
+    rawPrValidationBranchWinnerDecisionSummary?: string;
+    rawPrValidationBranchWinnerComparedToLaneSummary?: string;
+    rawPrValidationLaneMismatchSummary?: string;
+    rawPrValidationLaneMismatchCategory?: string;
+    rawPrValidationDetectedBranch?: string;
+    rawPrValidationDetectedBranchSource?: string;
+    rawPrValidationDetectedBranchDecisionSummary?: string;
+    rawPrValidationDetectedBranchMismatchReasons?: unknown[] | null;
+    rawPrValidationBranchSourceCandidateDecisionTable?: unknown[] | null;
+    rawRepoSnapshot?: Record<string, unknown> | null;
+    rawPluginSnapshot?: Record<string, unknown> | null;
+  }>;
+  reasonHistogram: Record<string, number>;
+  sourceHistogram: Record<string, number>;
+};
+
+export function getLoopBrakeHoldLabel(workflow: WorkflowConfig): string | null {
+  const refining = Object.values(workflow.states).find((s) => s.type === StateType.HOLD && s.label === "Refining");
+  if (refining) return refining.label;
+
+  const nonInitialHold = Object.entries(workflow.states)
+    .find(([key, s]) => s.type === StateType.HOLD && key !== workflow.initial)?.[1];
+  if (nonInitialHold) return nonInitialHold.label;
+
+  return Object.values(workflow.states).find((s) => s.type === StateType.HOLD)?.label ?? null;
+}
+
+export async function evaluateLoopBrake(
+  workspaceDir: string,
+  issueId: number,
+): Promise<LoopBrakeDecision> {
+  const { filePath, entries, fileExists, fileSizeBytes, fileMtime } = await readRecentAuditEntries(workspaceDir);
+  const cutoff = Date.now() - LOOP_BRAKE_WINDOW_MS;
+  const issueEntries = entries.filter((entry) => getIssueId(entry) === issueId);
+  const loopEventCandidates = issueEntries
+    .map((entry) => toLoopEvent(entry))
+    .filter((entry): entry is NonNullable<typeof entry> => Boolean(entry));
+  const nonMatchingIssueEntries = issueEntries.filter((entry) => toLoopEvent(entry) === null);
+  const events = loopEventCandidates
+    .filter((entry) => Date.parse(entry.ts) >= cutoff)
+    .sort((a, b) => Date.parse(a.ts) - Date.parse(b.ts));
+  const newestMatchedEvent = [...loopEventCandidates].sort((a, b) => Date.parse(b.ts) - Date.parse(a.ts))[0] ?? null;
+  const oldestMatchedEvent = [...loopEventCandidates].sort((a, b) => Date.parse(a.ts) - Date.parse(b.ts))[0] ?? null;
+  const newestMatchedEventInsideWindow = [...events].sort((a, b) => Date.parse(b.ts) - Date.parse(a.ts))[0] ?? null;
+  const newestIssueEntry = [...issueEntries].sort((a, b) => Date.parse(typeof b.ts === "string" ? b.ts : new Date(0).toISOString()) - Date.parse(typeof a.ts === "string" ? a.ts : new Date(0).toISOString()))[0] ?? null;
+  const newestNonMatchingIssueEntry = [...nonMatchingIssueEntries].sort((a, b) => Date.parse(typeof b.ts === "string" ? b.ts : new Date(0).toISOString()) - Date.parse(typeof a.ts === "string" ? a.ts : new Date(0).toISOString()))[0] ?? null;
+  const matchOutcomeCategory =
+    issueEntries.length === 0
+      ? "no_issue_history"
+      : loopEventCandidates.length === 0
+        ? "issue_history_present_but_non_matching"
+        : events.length === 0
+          ? "matching_history_outside_retry_window"
+          : "matching_history_inside_retry_window";
+  const matchOutcomeSummary =
+    matchOutcomeCategory === "no_issue_history"
+      ? "audit log contained no entries tagged to this issue"
+      : matchOutcomeCategory === "issue_history_present_but_non_matching"
+        ? `audit log contained ${issueEntries.length} issue-tagged entries, but none matched loop-brake counting rules`
+        : matchOutcomeCategory === "matching_history_outside_retry_window"
+          ? `audit log contained ${loopEventCandidates.length} loop-rule matches for this issue, but all were older than the retry window`
+          : `audit log contained ${events.length} loop-rule matches for this issue inside the retry window`;
+
+  const reasonHistogram = Object.fromEntries(
+    Array.from(events.reduce((map, event) => {
+      map.set(event.reason, (map.get(event.reason) ?? 0) + 1);
+      return map;
+    }, new Map<string, number>()).entries()),
+  );
+  const sourceHistogram = Object.fromEntries(
+    Array.from(events.reduce((map, event) => {
+      map.set(event.source, (map.get(event.source) ?? 0) + 1);
+      return map;
+    }, new Map<string, number>()).entries()),
+  );
+
+  return {
+    blocked: events.length >= LOOP_BRAKE_THRESHOLD,
+    threshold: LOOP_BRAKE_THRESHOLD,
+    windowMs: LOOP_BRAKE_WINDOW_MS,
+    auditScan: {
+      filePath,
+      fileExists,
+      fileSizeBytes,
+      fileMtime,
+      totalEntriesRead: entries.length,
+      issueEntriesSeen: issueEntries.length,
+      matchedLoopEventsBeforeWindow: loopEventCandidates.length,
+      matchedLoopEventsInsideWindow: events.length,
+      skippedBecauseIssueDidNotMatch: entries.length - issueEntries.length,
+      skippedBecauseNoLoopRuleMatched: issueEntries.length - loopEventCandidates.length,
+      skippedBecauseOutsideWindow: loopEventCandidates.length - events.length,
+      matchOutcomeCategory,
+      matchOutcomeSummary,
+      newestMatchedEventTs: newestMatchedEvent?.ts ?? null,
+      oldestMatchedEventTs: oldestMatchedEvent?.ts ?? null,
+      newestMatchedEventInsideWindowTs: newestMatchedEventInsideWindow?.ts ?? null,
+      newestMatchedEventReason: newestMatchedEvent?.reason ?? null,
+      newestIssueEntryTs: typeof newestIssueEntry?.ts === "string" ? newestIssueEntry.ts : null,
+      newestIssueEntryEvent: typeof newestIssueEntry?.event === "string" ? newestIssueEntry.event : null,
+      newestIssueEntryStage: asString(newestIssueEntry?.stage) ?? null,
+      newestIssueEntrySummary: newestIssueEntry ? summarizeIssueEntry(newestIssueEntry) : null,
+      newestNonMatchingIssueEntryTs: typeof newestNonMatchingIssueEntry?.ts === "string" ? newestNonMatchingIssueEntry.ts : null,
+      newestNonMatchingIssueEntryEvent: typeof newestNonMatchingIssueEntry?.event === "string" ? newestNonMatchingIssueEntry.event : null,
+      newestNonMatchingIssueEntryStage: asString(newestNonMatchingIssueEntry?.stage) ?? null,
+      newestNonMatchingIssueEntrySummary: newestNonMatchingIssueEntry ? summarizeIssueEntry(newestNonMatchingIssueEntry) : null,
+      recentIssueEntryExcerpts: [...issueEntries]
+        .sort((a, b) => Date.parse(typeof b.ts === "string" ? b.ts : new Date(0).toISOString()) - Date.parse(typeof a.ts === "string" ? a.ts : new Date(0).toISOString()))
+        .slice(0, 5)
+        .map((entry) => buildEventAuditExcerpt(entry)),
+      recentNonMatchingIssueEntryExcerpts: [...nonMatchingIssueEntries]
+        .sort((a, b) => Date.parse(typeof b.ts === "string" ? b.ts : new Date(0).toISOString()) - Date.parse(typeof a.ts === "string" ? a.ts : new Date(0).toISOString()))
+        .slice(0, 5)
+        .map((entry) => buildEventAuditExcerpt(entry)),
+    },
+    events,
+    reasonHistogram,
+    sourceHistogram,
+  };
+}
+
+export async function recordLoopBrakeHalt(opts: {
+  workspaceDir: string;
+  project: string;
+  issueId: number;
+  issueTitle: string;
+  from: string;
+  to: string;
+  reason: string;
+  threshold: number;
+  events: LoopBrakeDecision["events"];
+}): Promise<void> {
+  await auditLog(opts.workspaceDir, "loop_retry_ceiling", {
+    project: opts.project,
+    issueId: opts.issueId,
+    issueTitle: opts.issueTitle,
+    from: opts.from,
+    to: opts.to,
+    reason: opts.reason,
+    threshold: opts.threshold,
+    recentEvents: opts.events,
+  });
+}
+
+async function readRecentAuditEntries(workspaceDir: string): Promise<{
+  filePath: string;
+  fileExists: boolean;
+  fileSizeBytes: number | null;
+  fileMtime: string | null;
+  entries: AuditEntry[];
+}> {
+  const filePath = join(workspaceDir, DATA_DIR, "log", "audit.log");
+  try {
+    const meta = await stat(filePath);
+    const raw = await readFile(filePath, "utf-8");
+    return {
+      filePath,
+      fileExists: true,
+      fileSizeBytes: meta.size,
+      fileMtime: Number.isFinite(meta.mtimeMs) ? new Date(meta.mtimeMs).toISOString() : null,
+      entries: raw
+        .split("\n")
+        .map((line) => line.trim())
+        .filter(Boolean)
+        .map((line) => {
+          try {
+            return JSON.parse(line) as AuditEntry;
+          } catch {
+            return null;
+          }
+        })
+        .filter((entry): entry is AuditEntry => entry !== null),
+    };
+  } catch {
+    return {
+      filePath,
+      fileExists: false,
+      fileSizeBytes: null,
+      fileMtime: null,
+      entries: [],
+    };
+  }
+}
+
+function getIssueId(entry: AuditEntry): number | null {
+  const raw = entry.issueId ?? entry.issue;
+  return typeof raw === "number" ? raw : null;
+}
+
+function toLoopEvent(entry: AuditEntry): LoopBrakeDecision["events"][number] | null {
+  const ts = typeof entry.ts === "string" ? entry.ts : new Date(0).toISOString();
+  const event = entry.event;
+
+  if (event === "loop_diagnostic" && entry.stage === "health_requeue") {
+    const rawReason = asString(entry.loopBrakeReason) ?? asString(entry.healthRequeueLoopReason);
+    return {
+      ts,
+      event,
+      stage: asString(entry.stage),
+      source: "health_requeue",
+      from: asString(entry.from),
+      to: asString(entry.to),
+      reason: rawReason ?? "orphan_requeue",
+      rawReason: rawReason ?? undefined,
+      orphanReason: asString(entry.orphanReason) ?? undefined,
+      decisionPath: asString(entry.decisionPath),
+      countedByRule: 'count loop_diagnostic stage="health_requeue" as a non-progress orphan recovery event',
+      rawEvent: event,
+      rawStage: asString(entry.stage),
+      rawResult: asString(entry.result),
+      issueFieldUsed: typeof entry.issueId === "number" ? "issueId" : typeof entry.issue === "number" ? "issue" : "none",
+      rawIssueId: typeof entry.issueId === "number" ? entry.issueId : null,
+      rawIssue: typeof entry.issue === "number" ? entry.issue : null,
+      rawLabelPair: `${asString(entry.from) ?? "?"} -> ${asString(entry.to) ?? "?"}`,
+      matchedBecause: rawReason != null
+        ? `health_requeue matched loop brake because loopBrakeReason/healthRequeueLoopReason was ${rawReason}`
+        : "health_requeue matched loop brake because stage alone is counted as orphan recovery even without an explicit reason field",
+      rawLoopBrakeReason: asString(entry.loopBrakeReason),
+      rawTransitionReasonCategory: asString(entry.transitionReasonCategory),
+      rawRefiningDecisionPath: asString(entry.refiningDecisionPath),
+      rawHealthDecisionCategory: asString(entry.healthDecisionCategory),
+      rawSourceBranch: asString(entry.sourceBranch),
+      rawRepoPath: asString(entry.repoPath),
+      rawPluginSourceRoot: asString(entry.pluginSourceRoot),
+      rawBranchResolutionDecision: asString(entry.branchResolutionDecision),
+      rawPrValidationDecision: asString(entry.prValidationDecision),
+      rawPrValidationLookupOutcome: asString(entry.prValidationLookupOutcome),
+      rawPrValidationBranchResolutionPreferredSource: asString(entry.prValidationBranchResolutionPreferredSource),
+      rawPrValidationPreferredBranchConfidence: asString(entry.prValidationPreferredBranchConfidence),
+      rawPrValidationBranchResolutionPreferredEvidence: asString(entry.prValidationBranchResolutionPreferredEvidence),
+      rawPrValidationLookupTargetingDecision: asString(entry.prValidationLookupTargetingDecision),
+      rawPrValidationLookupProbeDecision: asString(entry.prValidationLookupProbeDecision),
+      rawPrValidationLookupTargetingSummary: isRecord(entry.prValidationLookupTargetingSummary) ? entry.prValidationLookupTargetingSummary : null,
+      rawPrValidationLookupProbeSummary: isRecord(entry.prValidationLookupProbeSummary) ? entry.prValidationLookupProbeSummary : null,
+      rawPrValidationConfiguredProviderTargetRepo: asString(entry.prValidationConfiguredProviderTargetRepo),
+      rawPrValidationRepoAmbientGhTarget: asString(entry.prValidationRepoAmbientGhTarget),
+      rawPrValidationPluginAmbientGhTarget: asString(entry.prValidationPluginAmbientGhTarget),
+      rawPrValidationConfiguredTargetLinkedPrCount: typeof entry.prValidationConfiguredTargetLinkedPrCount === "number" ? entry.prValidationConfiguredTargetLinkedPrCount : null,
+      rawPrValidationRepoAmbientLinkedPrCount: typeof entry.prValidationRepoAmbientLinkedPrCount === "number" ? entry.prValidationRepoAmbientLinkedPrCount : null,
+      rawPrValidationPluginAmbientLinkedPrCount: typeof entry.prValidationPluginAmbientLinkedPrCount === "number" ? entry.prValidationPluginAmbientLinkedPrCount : null,
+      rawPrValidationBranchSelectionWinnerSummary: asString(entry.prValidationBranchSelectionWinnerSummary),
+      rawPrValidationBranchWinnerDecisionSummary: asString(entry.prValidationBranchWinnerDecisionSummary),
+      rawPrValidationBranchWinnerComparedToLaneSummary: asString(entry.prValidationBranchWinnerComparedToLaneSummary),
+      rawPrValidationLaneMismatchSummary: asString(entry.prValidationLaneMismatchSummary),
+      rawPrValidationLaneMismatchCategory: asString(entry.prValidationLaneMismatchCategory),
+      rawRepoSnapshot: isRecord(entry.repoSnapshot) ? entry.repoSnapshot : null,
+      rawPluginSnapshot: isRecord(entry.pluginSnapshot) ? entry.pluginSnapshot : null,
+      eventShapeSummary: `event=${event} stage=${asString(entry.stage) ?? "?"} issueField=${typeof entry.issueId === "number" ? "issueId" : typeof entry.issue === "number" ? "issue" : "none"} labels=${asString(entry.from) ?? "?"}->${asString(entry.to) ?? "?"}`,
+      compactDecisionSummary: `health_requeue ${asString(entry.from) ?? "?"}->${asString(entry.to) ?? "?"} counted as ${rawReason ?? "orphan_requeue"}${asString(entry.orphanReason) ? ` (${asString(entry.orphanReason)})` : ""}`,
+      rawHealthDecisionSummary: asString(entry.healthDecisionSummary),
+      rawBranchWinnerSummary: asString(entry.branchSelectionWinnerSummary) ?? asString(entry.branchWinnerDecisionSummary),
+      rawDuplicateSourceDecision: asString(entry.duplicateSourceDecision),
+      rawPreferredBranchSource: asString(entry.branchResolutionPreferredSource) ?? asString(entry.preferredBranchSource),
+      rawBranchResolutionPreferredEvidence: asString(entry.branchResolutionPreferredEvidence),
+      rawPreferredBranchConfidence: asString(entry.preferredBranchConfidence),
+      rawLaneMismatchSummary: asString(entry.laneMismatchSummary),
+      rawLaneMismatchCategory: asString(entry.laneMismatchCategory),
+      rawDuplicateSourceRisk: typeof entry.duplicateSourceRisk === "boolean" ? entry.duplicateSourceRisk : null,
+      rawCanRequeueIssue: typeof entry.canRequeueIssue === "boolean" ? entry.canRequeueIssue : null,
+      rawLiveSourceDecision: asString(entry.liveSourceDecision),
+      rawLiveSourceSingularitySummary: asString(entry.liveSourceSingularitySummary),
+      rawOpenclawConfigInstallSourcePath: asString(entry.openclawConfigInstallSourcePath),
+      rawOpenclawConfigInstallSourceRealPath: asString(entry.openclawConfigInstallSourceRealPath),
+      rawOpenclawConfigInstallPath: asString(entry.openclawConfigInstallPath),
+      rawOpenclawConfigInstallPathRealPath: asString(entry.openclawConfigInstallPathRealPath),
+      rawOpenclawConfigPluginLoadPaths: Array.isArray(entry.openclawConfigPluginLoadPaths) ? entry.openclawConfigPluginLoadPaths : null,
+      rawOpenclawConfigPluginLoadPathRealPaths: Array.isArray(entry.openclawConfigPluginLoadPathRealPaths) ? entry.openclawConfigPluginLoadPathRealPaths : null,
+      rawBranchResolutionMismatchFlags: isRecord(entry.branchResolutionMismatchFlags) ? entry.branchResolutionMismatchFlags : null,
+      rawLiveSourceAgreementMatrix: isRecord(entry.liveSourceAgreementMatrix) ? entry.liveSourceAgreementMatrix : null,
+      rawLaneIdentitySummary: isRecord(entry.laneIdentitySummary) ? entry.laneIdentitySummary : null,
+      rawBranchSelectionDecisionTrace: isRecord(entry.branchSelectionDecisionTrace) ? entry.branchSelectionDecisionTrace : null,
+      rawDuplicateSourceWinningRealPathGuess: asString(entry.duplicateSourceWinningRealPathGuess),
+      rawDuplicateSourceCompetingRealPaths: Array.isArray(entry.duplicateSourceCompetingRealPaths) ? entry.duplicateSourceCompetingRealPaths : null,
+      rawBranchSourceCandidateDecisionTable: Array.isArray(entry.branchSourceCandidateDecisionTable) ? entry.branchSourceCandidateDecisionTable : null,
+      rawBranchSourceCandidateDiagnostics: Array.isArray(entry.branchSourceCandidateDiagnostics) ? entry.branchSourceCandidateDiagnostics : null,
+      rawPrValidationDetectedBranch: asString(entry.prValidationDetectedBranch),
+      rawPrValidationDetectedBranchSource: asString(entry.prValidationDetectedBranchSource),
+      rawPrValidationDetectedBranchDecisionSummary: asString(entry.prValidationDetectedBranchDecisionSummary),
+      rawPrValidationDetectedBranchMismatchReasons: Array.isArray(entry.prValidationDetectedBranchMismatchReasons) ? entry.prValidationDetectedBranchMismatchReasons : null,
+      rawPrValidationBranchSourceCandidateDecisionTable: Array.isArray(entry.prValidationBranchSourceCandidateDecisionTable) ? entry.prValidationBranchSourceCandidateDecisionTable : null,
+      rawPrValidationBranchSourceCandidateDiagnostics: Array.isArray(entry.prValidationBranchSourceCandidateDiagnostics) ? entry.prValidationBranchSourceCandidateDiagnostics : null,
+      rawAuditExcerpt: buildEventAuditExcerpt(entry),
+    };
+  }
+
+  if (event === "loop_diagnostic" && entry.stage === "work_finish_transition" && asString(entry.to) === "Refining") {
+    const rawReason = asString(entry.loopBrakeReason) ?? asString(entry.result);
+    return {
+      ts,
+      event,
+      stage: asString(entry.stage),
+      source: "work_finish_transition",
+      from: asString(entry.from),
+      to: asString(entry.to),
+      reason: rawReason ?? "blocked",
+      rawReason: rawReason ?? undefined,
+      decisionPath: asString(entry.decisionPath),
+      countedByRule: 'count loop_diagnostic stage="work_finish_transition" to="Refining" as a non-progress worker completion loop event',
+      rawEvent: event,
+      rawStage: asString(entry.stage),
+      rawResult: asString(entry.result),
+      issueFieldUsed: typeof entry.issueId === "number" ? "issueId" : typeof entry.issue === "number" ? "issue" : "none",
+      rawIssueId: typeof entry.issueId === "number" ? entry.issueId : null,
+      rawIssue: typeof entry.issue === "number" ? entry.issue : null,
+      rawLabelPair: `${asString(entry.from) ?? "?"} -> ${asString(entry.to) ?? "?"}`,
+      matchedBecause: rawReason != null
+        ? `work_finish_transition matched loop brake because it reached Refining with reason/result ${rawReason}`
+        : "work_finish_transition matched loop brake because any direct transition into Refining counts as non-progress even without an explicit reason field",
+      rawLoopBrakeReason: asString(entry.loopBrakeReason),
+      rawTransitionReasonCategory: asString(entry.transitionReasonCategory),
+      rawRefiningDecisionPath: asString(entry.refiningDecisionPath),
+      rawHealthDecisionCategory: asString(entry.healthDecisionCategory),
+      rawSourceBranch: asString(entry.sourceBranch),
+      rawRepoPath: asString(entry.repoPath),
+      rawPluginSourceRoot: asString(entry.pluginSourceRoot),
+      rawBranchResolutionDecision: asString(entry.branchResolutionDecision),
+      rawPrValidationDecision: asString(entry.prValidationDecision),
+      rawPrValidationLookupOutcome: asString(entry.prValidationLookupOutcome),
+      rawPrValidationBranchResolutionPreferredSource: asString(entry.prValidationBranchResolutionPreferredSource),
+      rawPrValidationPreferredBranchConfidence: asString(entry.prValidationPreferredBranchConfidence),
+      rawPrValidationBranchResolutionPreferredEvidence: asString(entry.prValidationBranchResolutionPreferredEvidence),
+      rawPrValidationLookupTargetingDecision: asString(entry.prValidationLookupTargetingDecision),
+      rawPrValidationLookupProbeDecision: asString(entry.prValidationLookupProbeDecision),
+      rawPrValidationLookupTargetingSummary: isRecord(entry.prValidationLookupTargetingSummary) ? entry.prValidationLookupTargetingSummary : null,
+      rawPrValidationLookupProbeSummary: isRecord(entry.prValidationLookupProbeSummary) ? entry.prValidationLookupProbeSummary : null,
+      rawPrValidationConfiguredProviderTargetRepo: asString(entry.prValidationConfiguredProviderTargetRepo),
+      rawPrValidationRepoAmbientGhTarget: asString(entry.prValidationRepoAmbientGhTarget),
+      rawPrValidationPluginAmbientGhTarget: asString(entry.prValidationPluginAmbientGhTarget),
+      rawPrValidationConfiguredTargetLinkedPrCount: typeof entry.prValidationConfiguredTargetLinkedPrCount === "number" ? entry.prValidationConfiguredTargetLinkedPrCount : null,
+      rawPrValidationRepoAmbientLinkedPrCount: typeof entry.prValidationRepoAmbientLinkedPrCount === "number" ? entry.prValidationRepoAmbientLinkedPrCount : null,
+      rawPrValidationPluginAmbientLinkedPrCount: typeof entry.prValidationPluginAmbientLinkedPrCount === "number" ? entry.prValidationPluginAmbientLinkedPrCount : null,
+      rawPrValidationBranchSelectionWinnerSummary: asString(entry.prValidationBranchSelectionWinnerSummary),
+      rawPrValidationBranchWinnerDecisionSummary: asString(entry.prValidationBranchWinnerDecisionSummary),
+      rawPrValidationBranchWinnerComparedToLaneSummary: asString(entry.prValidationBranchWinnerComparedToLaneSummary),
+      rawPrValidationLaneMismatchSummary: asString(entry.prValidationLaneMismatchSummary),
+      rawPrValidationLaneMismatchCategory: asString(entry.prValidationLaneMismatchCategory),
+      rawRepoSnapshot: isRecord(entry.repoSnapshot) ? entry.repoSnapshot : null,
+      rawPluginSnapshot: isRecord(entry.pluginSnapshot) ? entry.pluginSnapshot : null,
+      eventShapeSummary: `event=${event} stage=${asString(entry.stage) ?? "?"} result=${asString(entry.result) ?? "?"} issueField=${typeof entry.issueId === "number" ? "issueId" : typeof entry.issue === "number" ? "issue" : "none"} labels=${asString(entry.from) ?? "?"}->${asString(entry.to) ?? "?"}`,
+      compactDecisionSummary: `work_finish ${asString(entry.result) ?? "?"} ${asString(entry.from) ?? "?"}->${asString(entry.to) ?? "?"} counted as ${rawReason ?? "blocked"}${asString(entry.prValidationLookupTargetingDecision) ? `; PR targeting: ${asString(entry.prValidationLookupTargetingDecision)}` : ""}${asString(entry.prValidationDetectedBranchDecisionSummary) ? `; detected branch: ${asString(entry.prValidationDetectedBranchDecisionSummary)}` : ""}`,
+      rawHealthDecisionSummary: asString(entry.healthDecisionSummary),
+      rawBranchWinnerSummary: asString(entry.branchSelectionWinnerSummary) ?? asString(entry.branchWinnerDecisionSummary),
+      rawDuplicateSourceDecision: asString(entry.duplicateSourceDecision),
+      rawPreferredBranchSource: asString(entry.branchResolutionPreferredSource) ?? asString(entry.preferredBranchSource),
+      rawBranchResolutionPreferredEvidence: asString(entry.branchResolutionPreferredEvidence),
+      rawPreferredBranchConfidence: asString(entry.preferredBranchConfidence),
+      rawLaneMismatchSummary: asString(entry.laneMismatchSummary),
+      rawLaneMismatchCategory: asString(entry.laneMismatchCategory),
+      rawDuplicateSourceRisk: typeof entry.duplicateSourceRisk === "boolean" ? entry.duplicateSourceRisk : null,
+      rawCanRequeueIssue: typeof entry.canRequeueIssue === "boolean" ? entry.canRequeueIssue : null,
+      rawLiveSourceDecision: asString(entry.liveSourceDecision),
+      rawLiveSourceSingularitySummary: asString(entry.liveSourceSingularitySummary),
+      rawOpenclawConfigInstallSourcePath: asString(entry.openclawConfigInstallSourcePath),
+      rawOpenclawConfigInstallSourceRealPath: asString(entry.openclawConfigInstallSourceRealPath),
+      rawOpenclawConfigInstallPath: asString(entry.openclawConfigInstallPath),
+      rawOpenclawConfigInstallPathRealPath: asString(entry.openclawConfigInstallPathRealPath),
+      rawOpenclawConfigPluginLoadPaths: Array.isArray(entry.openclawConfigPluginLoadPaths) ? entry.openclawConfigPluginLoadPaths : null,
+      rawOpenclawConfigPluginLoadPathRealPaths: Array.isArray(entry.openclawConfigPluginLoadPathRealPaths) ? entry.openclawConfigPluginLoadPathRealPaths : null,
+      rawBranchResolutionMismatchFlags: isRecord(entry.branchResolutionMismatchFlags) ? entry.branchResolutionMismatchFlags : null,
+      rawLiveSourceAgreementMatrix: isRecord(entry.liveSourceAgreementMatrix) ? entry.liveSourceAgreementMatrix : null,
+      rawLaneIdentitySummary: isRecord(entry.laneIdentitySummary) ? entry.laneIdentitySummary : null,
+      rawBranchSelectionDecisionTrace: isRecord(entry.branchSelectionDecisionTrace) ? entry.branchSelectionDecisionTrace : null,
+      rawDuplicateSourceWinningRealPathGuess: asString(entry.duplicateSourceWinningRealPathGuess),
+      rawDuplicateSourceCompetingRealPaths: Array.isArray(entry.duplicateSourceCompetingRealPaths) ? entry.duplicateSourceCompetingRealPaths : null,
+      rawBranchSourceCandidateDecisionTable: Array.isArray(entry.branchSourceCandidateDecisionTable) ? entry.branchSourceCandidateDecisionTable : null,
+      rawBranchSourceCandidateDiagnostics: Array.isArray(entry.branchSourceCandidateDiagnostics) ? entry.branchSourceCandidateDiagnostics : null,
+      rawPrValidationDetectedBranch: asString(entry.prValidationDetectedBranch),
+      rawPrValidationDetectedBranchSource: asString(entry.prValidationDetectedBranchSource),
+      rawPrValidationDetectedBranchDecisionSummary: asString(entry.prValidationDetectedBranchDecisionSummary),
+      rawPrValidationDetectedBranchMismatchReasons: Array.isArray(entry.prValidationDetectedBranchMismatchReasons) ? entry.prValidationDetectedBranchMismatchReasons : null,
+      rawPrValidationBranchSourceCandidateDecisionTable: Array.isArray(entry.prValidationBranchSourceCandidateDecisionTable) ? entry.prValidationBranchSourceCandidateDecisionTable : null,
+      rawPrValidationBranchSourceCandidateDiagnostics: Array.isArray(entry.prValidationBranchSourceCandidateDiagnostics) ? entry.prValidationBranchSourceCandidateDiagnostics : null,
+      rawAuditExcerpt: buildEventAuditExcerpt(entry),
+    };
+  }
+
+  if (event === "review_transition") {
+    const reason = asString(entry.reason);
+    if (["pr_comments", "changes_requested", "merge_conflict", "merge_failed", "pr_closed"].includes(reason ?? "")) {
+      return {
+        ts,
+        event,
+        source: "review_transition",
+        from: asString(entry.from),
+        to: asString(entry.to),
+        reason: reason!,
+        rawReason: reason!,
+        decisionPath: asString(entry.summary) ?? asString(entry.note),
+        countedByRule: `count review_transition reason="${reason}" as a non-progress review loop event`,
+        rawEvent: event,
+        rawStage: asString(entry.stage),
+        rawResult: asString(entry.result),
+        issueFieldUsed: typeof entry.issueId === "number" ? "issueId" : typeof entry.issue === "number" ? "issue" : "none",
+        rawIssueId: typeof entry.issueId === "number" ? entry.issueId : null,
+        rawIssue: typeof entry.issue === "number" ? entry.issue : null,
+        rawLabelPair: `${asString(entry.from) ?? "?"} -> ${asString(entry.to) ?? "?"}`,
+        matchedBecause: `review_transition matched loop brake because reason=${reason} is listed as a non-progress review event`,
+        rawLoopBrakeReason: asString(entry.loopBrakeReason),
+        rawTransitionReasonCategory: asString(entry.transitionReasonCategory),
+        rawRefiningDecisionPath: asString(entry.refiningDecisionPath),
+        rawHealthDecisionCategory: asString(entry.healthDecisionCategory),
+        rawSourceBranch: asString(entry.sourceBranch),
+        rawRepoPath: asString(entry.repoPath),
+        rawPluginSourceRoot: asString(entry.pluginSourceRoot),
+        rawBranchResolutionDecision: asString(entry.branchResolutionDecision),
+        rawPrValidationDecision: asString(entry.prValidationDecision),
+        rawPrValidationLookupOutcome: asString(entry.prValidationLookupOutcome),
+        rawPrValidationBranchResolutionPreferredSource: asString(entry.prValidationBranchResolutionPreferredSource),
+        rawPrValidationPreferredBranchConfidence: asString(entry.prValidationPreferredBranchConfidence),
+        rawPrValidationBranchResolutionPreferredEvidence: asString(entry.prValidationBranchResolutionPreferredEvidence),
+        rawPrValidationBranchSelectionWinnerSummary: asString(entry.prValidationBranchSelectionWinnerSummary),
+        rawPrValidationBranchWinnerDecisionSummary: asString(entry.prValidationBranchWinnerDecisionSummary),
+        rawPrValidationBranchWinnerComparedToLaneSummary: asString(entry.prValidationBranchWinnerComparedToLaneSummary),
+        rawPrValidationLaneMismatchSummary: asString(entry.prValidationLaneMismatchSummary),
+        rawPrValidationLaneMismatchCategory: asString(entry.prValidationLaneMismatchCategory),
+        rawRepoSnapshot: isRecord(entry.repoSnapshot) ? entry.repoSnapshot : null,
+        rawPluginSnapshot: isRecord(entry.pluginSnapshot) ? entry.pluginSnapshot : null,
+        eventShapeSummary: `event=${event} reason=${reason} issueField=${typeof entry.issueId === "number" ? "issueId" : typeof entry.issue === "number" ? "issue" : "none"} labels=${asString(entry.from) ?? "?"}->${asString(entry.to) ?? "?"}`,
+        compactDecisionSummary: `review_transition ${reason} ${asString(entry.from) ?? "?"}->${asString(entry.to) ?? "?"} counted by loop brake${asString(entry.prValidationLookupTargetingDecision) ? `; PR targeting: ${asString(entry.prValidationLookupTargetingDecision)}` : ""}${asString(entry.prValidationDetectedBranchDecisionSummary) ? `; detected branch: ${asString(entry.prValidationDetectedBranchDecisionSummary)}` : ""}`,
+        rawHealthDecisionSummary: asString(entry.healthDecisionSummary),
+        rawBranchWinnerSummary: asString(entry.branchSelectionWinnerSummary) ?? asString(entry.branchWinnerDecisionSummary),
+        rawDuplicateSourceDecision: asString(entry.duplicateSourceDecision),
+        rawPreferredBranchSource: asString(entry.branchResolutionPreferredSource) ?? asString(entry.preferredBranchSource),
+        rawPreferredBranchConfidence: asString(entry.preferredBranchConfidence),
+        rawPrValidationLookupTargetingDecision: asString(entry.prValidationLookupTargetingDecision),
+        rawPrValidationLookupProbeDecision: asString(entry.prValidationLookupProbeDecision),
+        rawPrValidationLookupTargetingSummary: isRecord(entry.prValidationLookupTargetingSummary) ? entry.prValidationLookupTargetingSummary : null,
+        rawPrValidationLookupProbeSummary: isRecord(entry.prValidationLookupProbeSummary) ? entry.prValidationLookupProbeSummary : null,
+        rawPrValidationConfiguredProviderTargetRepo: asString(entry.prValidationConfiguredProviderTargetRepo),
+        rawPrValidationRepoAmbientGhTarget: asString(entry.prValidationRepoAmbientGhTarget),
+        rawPrValidationPluginAmbientGhTarget: asString(entry.prValidationPluginAmbientGhTarget),
+        rawPrValidationConfiguredTargetLinkedPrCount: typeof entry.prValidationConfiguredTargetLinkedPrCount === "number" ? entry.prValidationConfiguredTargetLinkedPrCount : null,
+        rawPrValidationRepoAmbientLinkedPrCount: typeof entry.prValidationRepoAmbientLinkedPrCount === "number" ? entry.prValidationRepoAmbientLinkedPrCount : null,
+        rawPrValidationPluginAmbientLinkedPrCount: typeof entry.prValidationPluginAmbientLinkedPrCount === "number" ? entry.prValidationPluginAmbientLinkedPrCount : null,
+        rawLaneMismatchCategory: asString(entry.laneMismatchCategory),
+        rawDuplicateSourceRisk: typeof entry.duplicateSourceRisk === "boolean" ? entry.duplicateSourceRisk : null,
+        rawCanRequeueIssue: typeof entry.canRequeueIssue === "boolean" ? entry.canRequeueIssue : null,
+        rawLiveSourceDecision: asString(entry.liveSourceDecision),
+        rawLiveSourceSingularitySummary: asString(entry.liveSourceSingularitySummary),
+        rawDuplicateSourceWinningRealPathGuess: asString(entry.duplicateSourceWinningRealPathGuess),
+        rawDuplicateSourceCompetingRealPaths: Array.isArray(entry.duplicateSourceCompetingRealPaths) ? entry.duplicateSourceCompetingRealPaths : null,
+        rawBranchSourceCandidateDecisionTable: Array.isArray(entry.branchSourceCandidateDecisionTable) ? entry.branchSourceCandidateDecisionTable : null,
+        rawPrValidationDetectedBranch: asString(entry.prValidationDetectedBranch),
+        rawPrValidationDetectedBranchSource: asString(entry.prValidationDetectedBranchSource),
+        rawPrValidationDetectedBranchDecisionSummary: asString(entry.prValidationDetectedBranchDecisionSummary),
+        rawPrValidationDetectedBranchMismatchReasons: Array.isArray(entry.prValidationDetectedBranchMismatchReasons) ? entry.prValidationDetectedBranchMismatchReasons : null,
+        rawPrValidationBranchSourceCandidateDecisionTable: Array.isArray(entry.prValidationBranchSourceCandidateDecisionTable) ? entry.prValidationBranchSourceCandidateDecisionTable : null,
+        rawAuditExcerpt: buildEventAuditExcerpt(entry),
+      };
+    }
+  }
+
+  return null;
+}
+
+function summarizeIssueEntry(entry: AuditEntry): string {
+  return [
+    typeof entry.event === "string" ? `event=${entry.event}` : null,
+    asString(entry.stage) ? `stage=${asString(entry.stage)}` : null,
+    asString(entry.result) ? `result=${asString(entry.result)}` : null,
+    asString(entry.from) || asString(entry.to) ? `labels=${asString(entry.from) ?? "?"}->${asString(entry.to) ?? "?"}` : null,
+    asString(entry.reason) ? `reason=${asString(entry.reason)}` : null,
+    asString(entry.loopBrakeReason) ? `loopBrakeReason=${asString(entry.loopBrakeReason)}` : null,
+    asString(entry.healthDecisionCategory) ? `healthDecisionCategory=${asString(entry.healthDecisionCategory)}` : null,
+    asString(entry.transitionReasonCategory) ? `transitionReasonCategory=${asString(entry.transitionReasonCategory)}` : null,
+  ].filter((value): value is string => Boolean(value)).join("; ");
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function asString(value: unknown): string | undefined {
+  return typeof value === "string" ? value : undefined;
+}
+
+function asNumber(value: unknown): number | null {
+  return typeof value === "number" && Number.isFinite(value) ? value : null;
+}

--- a/lib/services/loop-diagnostics.ts
+++ b/lib/services/loop-diagnostics.ts
@@ -1,0 +1,55 @@
+import { log as auditLog } from "../audit.js";
+
+export type LoopDiagnosticData = Record<string, unknown>;
+
+const ALWAYS_ON_STAGES = new Set([
+  "dispatch_pickup",
+  "loop_brake_evaluation",
+  "loop_brake_halt",
+  "pipeline_detect_pr",
+  "pipeline_detect_pr_error",
+  "work_finish_execute_start",
+  "work_finish_pr_validation",
+  "work_finish_pr_missing",
+  "work_finish_conflict_cycle_check",
+  "work_finish_conflict_rejected",
+  "work_finish_conflict_verified",
+  "work_finish_transition_planned",
+  "work_finish_transition_failed",
+  "work_finish_transition",
+  "work_finish_execute_error",
+  "review_pr_status",
+  "review_feedback_transition_planned",
+  "review_feedback_transition",
+  "health_orphan_detected",
+  "health_requeue",
+  "health_requeue_failed",
+]);
+
+function getRawFlag(): string | undefined {
+  return process.env.DEVCLAW_LOOP_DIAGNOSTICS?.trim();
+}
+
+function isEnabled(): boolean {
+  const raw = getRawFlag()?.toLowerCase();
+  return raw === "1" || raw === "true" || raw === "yes" || raw === "on";
+}
+
+function shouldRecordStage(stage: string): boolean {
+  return isEnabled() || ALWAYS_ON_STAGES.has(stage);
+}
+
+export async function recordLoopDiagnostic(
+  workspaceDir: string,
+  stage: string,
+  data: LoopDiagnosticData,
+): Promise<void> {
+  if (!shouldRecordStage(stage)) return;
+  await auditLog(workspaceDir, "loop_diagnostic", {
+    stage,
+    loopDiagnosticsEnabled: isEnabled(),
+    loopDiagnosticsFlag: getRawFlag() ?? null,
+    alwaysOnStage: ALWAYS_ON_STAGES.has(stage),
+    ...data,
+  });
+}

--- a/lib/services/pipeline.e2e.test.ts
+++ b/lib/services/pipeline.e2e.test.ts
@@ -10,6 +10,8 @@
  */
 import { describe, it, beforeEach, afterEach } from "node:test";
 import assert from "node:assert";
+import fs from "node:fs/promises";
+import path from "node:path";
 import { createTestHarness, type TestHarness } from "../testing/index.js";
 import { dispatchTask } from "../dispatch/index.js";
 import { executeCompletion } from "./pipeline.js";
@@ -1019,6 +1021,122 @@ describe("E2E pipeline", () => {
   // =========================================================================
   // Review policy gating — projectTick respects reviewPolicy
   // =========================================================================
+
+  describe("projectTick — loop brake", () => {
+    beforeEach(async () => {
+      h = await createTestHarness();
+    });
+
+    it("should halt repeated Doing → Refining redispatch loops by moving the issue to Refining", async () => {
+      h.provider.seedIssue({ iid: 901, title: "Bouncy issue", labels: ["To Do"] });
+
+      const auditPath = path.join(h.workspaceDir, "devclaw", "log", "audit.log");
+      const now = Date.now();
+      const lines = [0, 1, 2].map((i) => JSON.stringify({
+        ts: new Date(now - (i * 60_000)).toISOString(),
+        event: "loop_diagnostic",
+        stage: "work_finish_transition",
+        issueId: 901,
+        role: "developer",
+        from: "Doing",
+        to: "Refining",
+        result: "blocked",
+      }));
+      await fs.writeFile(auditPath, lines.join("\n") + "\n", "utf-8");
+
+      const result = await projectTick({
+        workspaceDir: h.workspaceDir,
+        projectSlug: h.project.slug,
+        provider: h.provider,
+        runCommand: h.runCommand,
+        workflow: DEFAULT_WORKFLOW,
+      });
+
+      assert.strictEqual(result.pickups.length, 0, "Should not redispatch a looped issue");
+      assert.ok(result.skipped.some((s) => s.reason.includes("Loop brake")), `Skipped: ${JSON.stringify(result.skipped)}`);
+
+      const issue = await h.provider.getIssue(901);
+      assert.ok(issue.labels.includes("Refining"), `Labels: ${issue.labels}`);
+      assert.ok(!issue.labels.includes("To Do"), "Should leave the queue");
+
+      const comments = h.provider.comments.get(901) ?? [];
+      assert.strictEqual(comments.length, 1, "Should leave an operator-facing comment");
+      assert.ok(comments[0]!.body.includes("Loop brake triggered"));
+
+      const transitions = h.provider.callsTo("transitionLabel");
+      assert.ok(transitions.some((c) => c.args.issueId === 901 && c.args.from === "To Do" && c.args.to === "Refining"));
+    });
+
+    it("should halt repeated review feedback loops after the threshold instead of redispatching", async () => {
+      h.provider.seedIssue({ iid: 902, title: "Review churn", labels: ["To Improve"] });
+
+      const auditPath = path.join(h.workspaceDir, "devclaw", "log", "audit.log");
+      const now = Date.now();
+      const lines = [
+        { reason: "changes_requested", from: "To Review", to: "To Improve" },
+        { reason: "merge_conflict", from: "To Review", to: "To Improve" },
+        { reason: "pr_comments", from: "To Review", to: "To Improve" },
+      ].map((entry, i) => JSON.stringify({
+        ts: new Date(now - (i * 60_000)).toISOString(),
+        event: "review_transition",
+        issueId: 902,
+        ...entry,
+      }));
+      await fs.writeFile(auditPath, lines.join("\n") + "\n", "utf-8");
+
+      const result = await projectTick({
+        workspaceDir: h.workspaceDir,
+        projectSlug: h.project.slug,
+        provider: h.provider,
+        runCommand: h.runCommand,
+        workflow: DEFAULT_WORKFLOW,
+      });
+
+      assert.strictEqual(result.pickups.length, 0, "Should not redispatch repeated feedback churn");
+
+      const issue = await h.provider.getIssue(902);
+      assert.ok(issue.labels.includes("Refining"), `Labels: ${issue.labels}`);
+
+      const comments = h.provider.comments.get(902) ?? [];
+      assert.strictEqual(comments.length, 1);
+      assert.ok(comments[0]!.body.includes("changes_requested"));
+      assert.ok(comments[0]!.body.includes("merge_conflict"));
+      assert.ok(comments[0]!.body.includes("pr_comments"));
+    });
+
+    it("should still dispatch normally when the retry ceiling has not been reached", async () => {
+      h.provider.seedIssue({ iid: 903, title: "Healthy retry", labels: ["To Do"] });
+
+      const auditPath = path.join(h.workspaceDir, "devclaw", "log", "audit.log");
+      const now = Date.now();
+      const lines = [0, 1].map((i) => JSON.stringify({
+        ts: new Date(now - (i * 60_000)).toISOString(),
+        event: "loop_diagnostic",
+        stage: "work_finish_transition",
+        issueId: 903,
+        role: "developer",
+        from: "Doing",
+        to: "Refining",
+        result: "blocked",
+      }));
+      await fs.writeFile(auditPath, lines.join("\n") + "\n", "utf-8");
+
+      const result = await projectTick({
+        workspaceDir: h.workspaceDir,
+        projectSlug: h.project.slug,
+        provider: h.provider,
+        runCommand: h.runCommand,
+        workflow: DEFAULT_WORKFLOW,
+      });
+
+      assert.strictEqual(result.pickups.length, 1, "Below ceiling should still dispatch");
+      assert.strictEqual(result.pickups[0]!.issueId, 903);
+
+      const issue = await h.provider.getIssue(903);
+      assert.ok(issue.labels.includes("Doing"), `Labels: ${issue.labels}`);
+      assert.strictEqual((h.provider.comments.get(903) ?? []).length, 0, "Should not comment below threshold");
+    });
+  });
 
   describe("projectTick — reviewPolicy gating", () => {
     function workflowWithPolicy(policy: ReviewPolicy): WorkflowConfig {

--- a/lib/services/pipeline.ts
+++ b/lib/services/pipeline.ts
@@ -11,6 +11,7 @@ import { notify, getNotificationConfig } from "../dispatch/notify.js";
 import { log as auditLog } from "../audit.js";
 import { loadConfig } from "../config/index.js";
 import { detectStepRouting } from "./queue-scan.js";
+import { recordLoopDiagnostic } from "./loop-diagnostics.js";
 import {
   DEFAULT_WORKFLOW,
   Action,
@@ -108,7 +109,27 @@ export async function executeCompletion(opts: {
           prUrl = prStatus.url ?? await provider.getMergedMRUrl(issueId) ?? undefined;
           prTitle = prStatus.title;
           sourceBranch = prStatus.sourceBranch;
+          await recordLoopDiagnostic(workspaceDir, "pipeline_detect_pr", {
+            project: projectName,
+            issueId,
+            role,
+            result,
+            detectedPrUrl: prStatus.url ?? null,
+            finalPrUrl: prUrl ?? null,
+            prTitle: prTitle ?? null,
+            sourceBranch: sourceBranch ?? null,
+            mergeable: prStatus.mergeable ?? null,
+            repoPath,
+          }).catch(() => {});
         } catch (err) {
+          await recordLoopDiagnostic(workspaceDir, "pipeline_detect_pr_error", {
+            project: projectName,
+            issueId,
+            role,
+            result,
+            repoPath,
+            error: (err as Error).message ?? String(err),
+          }).catch(() => {});
           auditLog(workspaceDir, "pipeline_warning", { step: "detectPr", issue: issueId, role, error: (err as Error).message ?? String(err) }).catch(() => {});
         } }
         break;
@@ -204,8 +225,37 @@ export async function executeCompletion(opts: {
   // Transition label first (critical — if this fails, issue still has correct state)
   // Then execute post-transition actions (close/reopen)
   // Finally deactivate worker (last — ensures label is set even if deactivation fails)
-  
-  await provider.transitionLabel(issueId, rule.from as StateLabel, rule.to as StateLabel);
+  const transitionedTo = rule.to as StateLabel;
+
+  await recordLoopDiagnostic(workspaceDir, "work_finish_transition_planned", {
+    project: projectName,
+    issueId,
+    role,
+    result,
+    from: rule.from,
+    to: transitionedTo,
+    summary: summary ?? null,
+    prUrl: prUrl ?? null,
+    sourceBranch: sourceBranch ?? null,
+    repoPath,
+    actions: rule.actions,
+  }).catch(() => {});
+
+  await provider.transitionLabel(issueId, rule.from as StateLabel, transitionedTo);
+
+  await recordLoopDiagnostic(workspaceDir, "work_finish_transition", {
+    project: projectName,
+    issueId,
+    role,
+    result,
+    from: rule.from,
+    to: transitionedTo,
+    summary: summary ?? null,
+    prUrl: prUrl ?? null,
+    sourceBranch: sourceBranch ?? null,
+    repoPath,
+    actions: rule.actions,
+  }).catch(() => {});
 
   // Execute post-transition actions
   for (const action of rule.actions) {

--- a/lib/services/tick.ts
+++ b/lib/services/tick.ts
@@ -23,6 +23,7 @@ import {
   type Role,
 } from "../workflow/index.js";
 import { detectRoleLevelFromLabels, detectStepRouting, findNextIssueForRole } from "./queue-scan.js";
+import { evaluateLoopBrake, getLoopBrakeHoldLabel, recordLoopBrakeHalt } from "./loop-brake.js";
 
 // ---------------------------------------------------------------------------
 // projectTick
@@ -146,6 +147,41 @@ export async function projectTick(opts: {
     if (!next) continue;
 
     const { issue, label: currentLabel } = next;
+    const holdLabel = getLoopBrakeHoldLabel(workflow);
+    const loopBrake = await evaluateLoopBrake(workspaceDir, issue.iid);
+    if (holdLabel && loopBrake.blocked) {
+      const reason = `retry ceiling reached after ${loopBrake.events.length} recent non-progress loop events`;
+      await provider.transitionLabel(issue.iid, currentLabel, holdLabel);
+      await provider.addComment(
+        issue.iid,
+        [
+          "## Loop brake triggered",
+          "",
+          `Automatic redispatch has been halted for this issue after ${loopBrake.events.length} recent non-progress loop events within the retry window.`,
+          "",
+          `- from queue: \`${currentLabel}\``,
+          `- moved to hold: \`${holdLabel}\``,
+          `- threshold: ${loopBrake.threshold}`,
+          `- recent reasons: ${loopBrake.events.map((event) => event.reason).join(", ")}`,
+          "",
+          "Operator action is required to re-queue this issue.",
+        ].join("\n"),
+      );
+      await recordLoopBrakeHalt({
+        workspaceDir,
+        project: project.name,
+        issueId: issue.iid,
+        issueTitle: issue.title,
+        from: currentLabel,
+        to: holdLabel,
+        reason,
+        threshold: loopBrake.threshold,
+        events: loopBrake.events,
+      });
+      skipped.push({ role, reason: `Loop brake: #${issue.iid} moved to ${holdLabel}` });
+      continue;
+    }
+
     const targetLabel = getActiveLabel(workflow, role);
 
     // Step routing: check for review:human / review:skip / test:skip labels

--- a/lib/tools/worker/work-finish.ts
+++ b/lib/tools/worker/work-finish.ts
@@ -8,7 +8,8 @@
  * Architect workflow: Researching → Done (done, closes issue), Researching → Refining (blocked).
  */
 import { readFile } from "node:fs/promises";
-import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
 import type { ToolContext } from "../../types.js";
 import type { PluginContext, RunCommand } from "../../context.js";
 import { getRoleWorker, resolveRepoPath, findSlotByIssue } from "../../projects/index.js";
@@ -30,6 +31,40 @@ async function getCurrentBranch(repoPath: string, runCommand: RunCommand): Promi
   return result.stdout.trim();
 }
 
+async function getGitSnapshot(repoPath: string, runCommand: RunCommand): Promise<Record<string, unknown>> {
+  const commands: Array<[string, string[]]> = [
+    ["branch", ["git", "branch", "--show-current"]],
+    ["head", ["git", "rev-parse", "HEAD"]],
+    ["gitDir", ["git", "rev-parse", "--absolute-git-dir"]],
+    ["workTree", ["git", "rev-parse", "--show-toplevel"]],
+  ];
+
+  const snapshot: Record<string, unknown> = { repoPath };
+  for (const [key, argv] of commands) {
+    try {
+      const result = await runCommand(argv, { timeoutMs: 5_000, cwd: repoPath });
+      snapshot[key] = result.stdout.trim() || null;
+    } catch (err) {
+      snapshot[`${key}Error`] = (err as Error).message ?? String(err);
+    }
+  }
+  return snapshot;
+}
+
+function getPluginSourceRoot(): string {
+  return dirname(dirname(dirname(dirname(fileURLToPath(import.meta.url)))));
+}
+
+async function recordWorkFinishDiagnostic(
+  workspaceDir: string,
+  stage: string,
+  data: Record<string, unknown>,
+): Promise<void> {
+  await auditLog(workspaceDir, "loop_diagnostic", {
+    stage,
+    ...data,
+  });
+}
 
 /**
  * Check if this work_finish is completing a conflict resolution cycle.
@@ -83,9 +118,26 @@ async function validatePrExistsForDeveloper(
   runCommand: RunCommand,
   workspaceDir: string,
   projectSlug: string,
+  context: Record<string, unknown> = {},
 ): Promise<void> {
   try {
+    const repoSnapshot = await getGitSnapshot(repoPath, runCommand);
+    const pluginSourceRoot = getPluginSourceRoot();
+    const pluginSnapshot = await getGitSnapshot(pluginSourceRoot, runCommand);
     const prStatus = await provider.getPrStatus(issueId);
+
+    await recordWorkFinishDiagnostic(workspaceDir, "work_finish_pr_validation", {
+      project: projectSlug,
+      issueId,
+      ...context,
+      repoSnapshot,
+      pluginSourceRoot,
+      pluginSnapshot,
+      prUrl: prStatus.url ?? null,
+      prState: prStatus.state,
+      prSourceBranch: prStatus.sourceBranch ?? null,
+      prMergeable: prStatus.mergeable ?? null,
+    }).catch(() => {});
 
     // url is null when getPrStatus found no open or merged PR for this issue.
     // This covers both "no PR ever created" and "PR was closed without merging".
@@ -97,6 +149,16 @@ async function validatePrExistsForDeveloper(
       } catch {
         // Fall back to generic placeholder
       }
+
+      await recordWorkFinishDiagnostic(workspaceDir, "work_finish_pr_missing", {
+        project: projectSlug,
+        issueId,
+        ...context,
+        repoSnapshot,
+        pluginSourceRoot,
+        pluginSnapshot,
+        detectedBranch: branchName,
+      }).catch(() => {});
 
       throw new Error(
         `Cannot mark work_finish(done) without an open PR.\n\n` +
@@ -129,6 +191,19 @@ async function validatePrExistsForDeveloper(
     // rebase but before pushing, causing infinite dispatch loops (#482).
     const isConflictCycle = await isConflictResolutionCycle(workspaceDir, issueId);
 
+    await recordWorkFinishDiagnostic(workspaceDir, "work_finish_conflict_cycle_check", {
+      project: projectSlug,
+      issueId,
+      ...context,
+      isConflictCycle,
+      prUrl: prStatus.url ?? null,
+      prSourceBranch: prStatus.sourceBranch ?? null,
+      prMergeable: prStatus.mergeable ?? null,
+      repoSnapshot,
+      pluginSourceRoot,
+      pluginSnapshot,
+    }).catch(() => {});
+
     if (isConflictCycle && prStatus.mergeable === false) {
       await auditLog(workspaceDir, "work_finish_rejected", {
         project: projectSlug,
@@ -138,6 +213,18 @@ async function validatePrExistsForDeveloper(
       });
 
       const branchName = prStatus.sourceBranch || "your-branch";
+      await recordWorkFinishDiagnostic(workspaceDir, "work_finish_conflict_rejected", {
+        project: projectSlug,
+        issueId,
+        ...context,
+        prUrl: prStatus.url ?? null,
+        prSourceBranch: prStatus.sourceBranch ?? null,
+        detectedBranch: branchName,
+        prMergeable: prStatus.mergeable ?? null,
+        repoSnapshot,
+        pluginSourceRoot,
+        pluginSnapshot,
+      }).catch(() => {});
       throw new Error(
         `Cannot complete work_finish(done) while PR still shows merge conflicts.\n\n` +
         `✗ PR status: CONFLICTING\n` +
@@ -157,6 +244,17 @@ async function validatePrExistsForDeveloper(
     }
 
     if (isConflictCycle) {
+      await recordWorkFinishDiagnostic(workspaceDir, "work_finish_conflict_verified", {
+        project: projectSlug,
+        issueId,
+        ...context,
+        prUrl: prStatus.url ?? null,
+        prSourceBranch: prStatus.sourceBranch ?? null,
+        prMergeable: prStatus.mergeable ?? null,
+        repoSnapshot,
+        pluginSourceRoot,
+        pluginSnapshot,
+      }).catch(() => {});
       await auditLog(workspaceDir, "conflict_resolution_verified", {
         project: projectSlug,
         issue: issueId,
@@ -170,6 +268,12 @@ async function validatePrExistsForDeveloper(
     if (err instanceof Error && (err.message.startsWith("Cannot mark work_finish(done)") || err.message.startsWith("Cannot complete work_finish(done)"))) {
       throw err;
     }
+    await recordWorkFinishDiagnostic(workspaceDir, "work_finish_pr_validation_warning", {
+      project: projectSlug,
+      issueId,
+      ...context,
+      error: err instanceof Error ? err.message : String(err),
+    }).catch(() => {});
     console.warn(`PR validation warning for issue #${issueId}:`, err);
   }
 }
@@ -254,10 +358,26 @@ export function createWorkFinishTool(ctx: PluginContext) {
 
       const repoPath = resolveRepoPath(project.repo);
       const pluginConfig = ctx.pluginConfig;
+      const pluginSourceRoot = getPluginSourceRoot();
+      const context = {
+        channelId,
+        role,
+        result,
+        slotLevel,
+        slotIndex,
+        configuredRepoPath: repoPath,
+        pluginSourceRoot,
+      };
+
+      await recordWorkFinishDiagnostic(workspaceDir, "work_finish_execute_start", {
+        project: project.slug,
+        issueId,
+        ...context,
+      }).catch(() => {});
 
       // For developers marking work as done, validate that a PR exists
       if (role === "developer" && result === "done") {
-        await validatePrExistsForDeveloper(issueId, repoPath, provider, ctx.runCommand, workspaceDir, project.slug);
+        await validatePrExistsForDeveloper(issueId, repoPath, provider, ctx.runCommand, workspaceDir, project.slug, context);
       }
 
       const completion = await executeCompletion({


### PR DESCRIPTION
## Summary
- add the narrow loop-brake retry ceiling and diagnostics helper
- halt repeated non-progress redispatch/review churn after the threshold
- add regression coverage proving the system stops instead of looping forever

## Testing
- npx tsx --test --test-name-pattern="loop brake" lib/services/pipeline.e2e.test.ts

Addresses issue #78