### PR TITLE
revert: roll back failed #123 local-truth release

### DIFF
--- a/lib/setup/workspace.test.ts
+++ b/lib/setup/workspace.test.ts
@@ -27,10 +27,6 @@ afterEach(async () => {
   if (tmpDir) await fs.rm(tmpDir, { recursive: true, force: true });
 });
 
-function escapeRegexForTest(value: string): string {
-  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-}
-
 describe("ensureDefaultFiles — managed root-block behavior", () => {
   it("should create workflow.yaml when missing", async () => {
     const ws = await makeTmpDir();
@@ -115,29 +111,23 @@ describe("ensureDefaultFiles — managed root-block behavior", () => {
     assert.match(content, /<!-- DEVCLAW:END agents -->/);
   });
 
-  it("should insert a managed notice and block into an existing AGENTS.md without destroying user content", async () => {
+  it("should insert a managed block into an existing AGENTS.md without destroying user content", async () => {
     const ws = await makeTmpDir();
     const agentsPath = path.join(ws, "AGENTS.md");
     const before = "# My workspace rules\n\nKeep this.\n\n## After\nStill mine.\n";
     await fs.writeFile(agentsPath, before, "utf-8");
 
     await ensureDefaultFiles(ws);
-    await ensureDefaultFiles(ws);
 
     const afterContent = await fs.readFile(agentsPath, "utf-8");
-    const blockCount = (afterContent.match(/<!-- DEVCLAW:START agents -->/g) ?? []).length;
-    const noticeCount = (afterContent.match(/<!-- DEVCLAW:NOTICE:START agents -->/g) ?? []).length;
-    assert.strictEqual(blockCount, 1, "managed block should not be duplicated");
-    assert.strictEqual(noticeCount, 1, "managed notice should not be duplicated");
     assert.match(afterContent, /^# My workspace rules/m);
     assert.match(afterContent, /Keep this\./);
     assert.match(afterContent, /^## After$/m);
     assert.match(afterContent, /Still mine\./);
-    assert.match(afterContent, /<!-- DEVCLAW:NOTICE:START agents -->[\s\S]*may replace those changes the next time it refreshes defaults\.[\s\S]*<!-- DEVCLAW:NOTICE:END agents -->/);
     assert.match(afterContent, /<!-- DEVCLAW:START agents -->[\s\S]*<!-- DEVCLAW:END agents -->/);
   });
 
-  it("should update an existing managed block, seed its notice, and avoid duplication", async () => {
+  it("should update an existing managed block without duplicating it", async () => {
     const ws = await makeTmpDir();
     const toolsPath = path.join(ws, "TOOLS.md");
     await fs.writeFile(
@@ -151,126 +141,29 @@ describe("ensureDefaultFiles — managed root-block behavior", () => {
 
     const afterContent = await fs.readFile(toolsPath, "utf-8");
     const blockCount = (afterContent.match(/<!-- DEVCLAW:START tools -->/g) ?? []).length;
-    const noticeCount = (afterContent.match(/<!-- DEVCLAW:NOTICE:START tools -->/g) ?? []).length;
     assert.strictEqual(blockCount, 1, "managed block should not be duplicated");
-    assert.strictEqual(noticeCount, 1, "managed notice should not be duplicated");
     assert.match(afterContent, /^Intro/m);
     assert.match(afterContent, /^Outro/m);
-    assert.match(afterContent, /Add workspace-specific tool notes outside the managed block\./);
     assert.ok(!afterContent.includes("old block"), "managed block should be refreshed");
   });
 
-  it("should append only the missing block when the managed notice already exists", async () => {
-    const ws = await makeTmpDir();
-    const toolsPath = path.join(ws, "TOOLS.md");
-    await fs.writeFile(
-      toolsPath,
-      [
-        "Intro",
-        "",
-        "<!-- DEVCLAW:NOTICE:START tools -->",
-        "stale notice",
-        "<!-- DEVCLAW:NOTICE:END tools -->",
-        "",
-        "Outro",
-        "",
-      ].join("\n"),
-      "utf-8",
-    );
-
-    await ensureDefaultFiles(ws);
-    await ensureDefaultFiles(ws);
-
-    const afterContent = await fs.readFile(toolsPath, "utf-8");
-    const blockCount = (afterContent.match(/<!-- DEVCLAW:START tools -->/g) ?? []).length;
-    const noticeCount = (afterContent.match(/<!-- DEVCLAW:NOTICE:START tools -->/g) ?? []).length;
-
-    assert.strictEqual(blockCount, 1, "should insert exactly one managed block");
-    assert.strictEqual(noticeCount, 1, "should not duplicate the managed notice");
-    assert.match(afterContent, /^Intro/m);
-    assert.match(afterContent, /^Outro$/m);
-    assert.match(afterContent, /Add workspace-specific tool notes outside the managed block\./);
-    assert.ok(!afterContent.includes("stale notice"), "existing notice should be refreshed");
-  });
-
-  it("should normalize legacy full-file DevClaw root docs into a single managed block without duplication", async () => {
-    const ws = await makeTmpDir();
-    const legacyFiles = [
-      {
-        fileName: "AGENTS.md",
-        sectionId: "agents",
-        template: (await import("./templates.js")).AGENTS_MD_TEMPLATE,
-      },
-      {
-        fileName: "HEARTBEAT.md",
-        sectionId: "heartbeat",
-        template: (await import("./templates.js")).HEARTBEAT_MD_TEMPLATE,
-      },
-      {
-        fileName: "TOOLS.md",
-        sectionId: "tools",
-        template: (await import("./templates.js")).TOOLS_MD_TEMPLATE,
-      },
-    ];
-
-    for (const { fileName, sectionId, template } of legacyFiles) {
-      const filePath = path.join(ws, fileName);
-      const legacyContent = template.replace(/\n/g, "\r\n");
-      await fs.writeFile(filePath, legacyContent, "utf-8");
-
-      await ensureDefaultFiles(ws);
-      await ensureDefaultFiles(ws);
-
-      const afterContent = await fs.readFile(filePath, "utf-8");
-      const noticeCount = (afterContent.match(new RegExp(`<!-- DEVCLAW:NOTICE:START ${sectionId} -->`, "g")) ?? []).length;
-      const blockCount = (afterContent.match(new RegExp(`<!-- DEVCLAW:START ${sectionId} -->`, "g")) ?? []).length;
-
-      assert.strictEqual(noticeCount, 1, `${fileName} notice should be normalized exactly once`);
-      assert.strictEqual(blockCount, 1, `${fileName} block should be normalized exactly once`);
-      assert.doesNotMatch(afterContent, new RegExp(`${escapeRegexForTest(template.trim())}\\s*<!-- DEVCLAW:START ${sectionId} -->`), `${fileName} should not retain the legacy full-file template above the managed block`);
-    }
-  });
-
-  it("should preserve customized HEARTBEAT.md content outside managed sections across restarts", async () => {
+  it("should preserve customized HEARTBEAT.md and TOOLS.md content outside managed blocks", async () => {
     const ws = await makeTmpDir();
     const heartbeatPath = path.join(ws, "HEARTBEAT.md");
-    const customHeartbeat = "Before\n\nAfter heartbeat\n";
-    await fs.writeFile(heartbeatPath, customHeartbeat, "utf-8");
+    const toolsPath = path.join(ws, "TOOLS.md");
+    await fs.writeFile(heartbeatPath, "Before\n\nAfter heartbeat\n", "utf-8");
+    await fs.writeFile(toolsPath, "Before tools\n\nAfter tools\n", "utf-8");
 
-    await ensureDefaultFiles(ws);
     await ensureDefaultFiles(ws);
 
     const heartbeat = await fs.readFile(heartbeatPath, "utf-8");
-    const noticeCount = (heartbeat.match(/<!-- DEVCLAW:NOTICE:START heartbeat -->/g) ?? []).length;
-    const blockCount = (heartbeat.match(/<!-- DEVCLAW:START heartbeat -->/g) ?? []).length;
-    assert.strictEqual(noticeCount, 1, "managed notice should not be duplicated");
-    assert.strictEqual(blockCount, 1, "managed block should not be duplicated");
+    const tools = await fs.readFile(toolsPath, "utf-8");
     assert.match(heartbeat, /^Before/m);
     assert.match(heartbeat, /^After heartbeat$/m);
-    assert.match(heartbeat, /<!-- DEVCLAW:NOTICE:START heartbeat -->/);
     assert.match(heartbeat, /<!-- DEVCLAW:START heartbeat -->/);
-    assert.ok(heartbeat.includes("Before\n\nAfter heartbeat"), "custom heartbeat content should survive restart");
-  });
-
-  it("should preserve customized TOOLS.md content outside managed sections across restarts", async () => {
-    const ws = await makeTmpDir();
-    const toolsPath = path.join(ws, "TOOLS.md");
-    const customTools = "Before tools\n\nAfter tools\n";
-    await fs.writeFile(toolsPath, customTools, "utf-8");
-
-    await ensureDefaultFiles(ws);
-    await ensureDefaultFiles(ws);
-
-    const tools = await fs.readFile(toolsPath, "utf-8");
-    const noticeCount = (tools.match(/<!-- DEVCLAW:NOTICE:START tools -->/g) ?? []).length;
-    const blockCount = (tools.match(/<!-- DEVCLAW:START tools -->/g) ?? []).length;
-    assert.strictEqual(noticeCount, 1, "managed notice should not be duplicated");
-    assert.strictEqual(blockCount, 1, "managed block should not be duplicated");
     assert.match(tools, /^Before tools/m);
     assert.match(tools, /^After tools$/m);
-    assert.match(tools, /<!-- DEVCLAW:NOTICE:START tools -->/);
     assert.match(tools, /<!-- DEVCLAW:START tools -->/);
-    assert.ok(tools.includes("Before tools\n\nAfter tools"), "custom tools content should survive restart");
   });
 
   it("should let explicit reset/default-writing flows overwrite intentionally", async () => {

--- a/lib/setup/workspace.ts
+++ b/lib/setup/workspace.ts
@@ -60,7 +60,13 @@ const MANAGED_BLOCKS = {
  *   - Runtime state (projects.json): create-only
  */
 export async function ensureDefaultFiles(workspacePath: string): Promise<void> {
-  await ensureWorkspaceDataFiles(workspacePath);
+  const dataDir = path.join(workspacePath, DATA_DIR);
+  await fs.mkdir(dataDir, { recursive: true });
+
+  // Ensure directories exist
+  await fs.mkdir(path.join(dataDir, "projects"), { recursive: true });
+  await fs.mkdir(path.join(dataDir, "prompts"), { recursive: true });
+  await fs.mkdir(path.join(dataDir, "log"), { recursive: true });
 
   // --- Workspace-root guidance files — manage tagged DevClaw blocks only ---
   for (const [fileName, config] of Object.entries(MANAGED_BLOCKS)) {
@@ -77,20 +83,6 @@ export async function ensureDefaultFiles(workspacePath: string): Promise<void> {
 
   // Remove BOOTSTRAP.md — one-time onboarding file, not needed after setup
   try { await fs.unlink(path.join(workspacePath, "BOOTSTRAP.md")); } catch { /* already gone */ }
-}
-
-/**
- * Ensure DevClaw-owned data files exist without touching workspace-root guidance files.
- * Safe for generic runtime code paths like project reads.
- */
-export async function ensureWorkspaceDataFiles(workspacePath: string): Promise<void> {
-  const dataDir = path.join(workspacePath, DATA_DIR);
-  await fs.mkdir(dataDir, { recursive: true });
-
-  // Ensure directories exist
-  await fs.mkdir(path.join(dataDir, "projects"), { recursive: true });
-  await fs.mkdir(path.join(dataDir, "prompts"), { recursive: true });
-  await fs.mkdir(path.join(dataDir, "log"), { recursive: true });
 
   // devclaw/workflow.yaml — create-only (three-layer merge handles defaults for missing keys)
   const workflowPath = path.join(dataDir, "workflow.yaml");
@@ -227,81 +219,28 @@ function buildManagedBlock(sectionId: string, content: string): string {
   return `${start}\n${content.trimEnd()}\n${end}`;
 }
 
-function buildManagedNotice(sectionId: string, intro: string): string {
-  return [
-    `<!-- DEVCLAW:NOTICE:START ${sectionId} -->`,
-    intro,
-    `<!-- DEVCLAW:NOTICE:END ${sectionId} -->`,
-  ].join("\n");
-}
-
-function buildManagedSection(sectionId: string, content: string, intro: string): string {
-  return `${buildManagedNotice(sectionId, intro)}\n\n${buildManagedBlock(sectionId, content)}`;
-}
-
 function buildManagedFile(sectionId: string, content: string, intro: string): string {
-  return `${buildManagedSection(sectionId, content, intro)}\n`;
-}
-
-function normalizeForManagedComparison(content: string): string {
-  return content
-    .replace(/^\uFEFF/, "")
-    .replace(/\r\n?/g, "\n")
-    .trim();
-}
-
-function isLegacyManagedFullFile(originalContent: string, template: string): boolean {
-  return normalizeForManagedComparison(originalContent) === normalizeForManagedComparison(template);
+  return `${intro}\n\n${buildManagedBlock(sectionId, content)}\n`;
 }
 
 function upsertManagedContent(originalContent: string, sectionId: string, content: string, intro: string): string {
   const managedBlock = buildManagedBlock(sectionId, content);
-  const managedNotice = buildManagedNotice(sectionId, intro);
-  const managedSection = buildManagedSection(sectionId, content, intro);
   const blockPattern = new RegExp(
     `<!-- DEVCLAW:START ${escapeRegExp(sectionId)} -->[\\s\\S]*?<!-- DEVCLAW:END ${escapeRegExp(sectionId)} -->`,
     "m",
   );
-  const noticePattern = new RegExp(
-    `<!-- DEVCLAW:NOTICE:START ${escapeRegExp(sectionId)} -->[\\s\\S]*?<!-- DEVCLAW:NOTICE:END ${escapeRegExp(sectionId)} -->\\n*`,
-    "m",
-  );
 
-  if (!originalContent.trim() || isLegacyManagedFullFile(originalContent, content)) {
+  if (!originalContent.trim()) {
     return buildManagedFile(sectionId, content, intro);
   }
 
-  const hasNotice = noticePattern.test(originalContent);
-  const hasBlock = blockPattern.test(originalContent);
-
-  // Step 1: seed or refresh the explanatory notice independently from block insertion.
-  let nextContent = hasNotice
-    ? originalContent.replace(noticePattern, `${managedNotice}\n\n`)
-    : originalContent;
-
-  if (!hasNotice && hasBlock) {
-    const blockMatch = nextContent.match(blockPattern);
-    if (!blockMatch || typeof blockMatch.index !== "number") {
-      return nextContent.endsWith("\n") ? nextContent : `${nextContent}\n`;
-    }
-
-    const beforeBlock = nextContent.slice(0, blockMatch.index).replace(/\n+$/, "");
-    const afterBlock = nextContent.slice(blockMatch.index);
-    nextContent = beforeBlock
-      ? `${beforeBlock}\n\n${managedNotice}\n\n${afterBlock}`
-      : `${managedNotice}\n\n${afterBlock}`;
+  if (blockPattern.test(originalContent)) {
+    const updated = originalContent.replace(blockPattern, managedBlock);
+    return updated.endsWith("\n") ? updated : `${updated}\n`;
   }
 
-  // Step 2: replace or append the managed block, preserving user-owned content.
-  if (hasBlock) {
-    nextContent = nextContent.replace(blockPattern, managedBlock);
-    return nextContent.endsWith("\n") ? nextContent : `${nextContent}\n`;
-  }
-
-  const baseContent = nextContent.replace(/\n+$/, "");
-  const separator = baseContent.endsWith("\n") ? "\n" : "\n\n";
-  const insertedContent = hasNotice ? managedBlock : managedSection;
-  return `${baseContent}${separator}${insertedContent}\n`;
+  const separator = originalContent.endsWith("\n") ? "\n" : "\n\n";
+  return `${originalContent}${separator}${managedBlock}\n`;
 }
 
 async function upsertManagedBlock(filePath: string, sectionId: string, content: string, intro: string): Promise<void> {


### PR DESCRIPTION
## Summary
- revert `dc20b47` from `devclaw-local-current`
- send #123 back to development after failed real live validation
- preserve the rollback as a visible review step instead of silently rewriting local truth

## Failure evidence
- live commit under validation: `dc20b47eec32086d60b5e08022ed76c55aa82b2c`
- real workspace check still showed duplicated AGENTS instructions
- `grep "You are a development orchestrator" ~/.openclaw/workspace/AGENTS.md` returned two matches

## Why this rollback is needed
Focused tests passed, but the actual self-hosted workspace still retained legacy top-level DevClaw content plus the managed block. That means this promotion was not valid on the real local-truth lane and should be reverted before redoing the fix properly.

Closes none. Follow-up work remains on #123.
