### PR TITLE
Re-add self-contained live runtime provenance

### DIFF
--- a/build.mjs
+++ b/build.mjs
@@ -6,8 +6,32 @@
  */
 import esbuild from "esbuild";
 import { readFileSync } from "node:fs";
+import { execSync } from "node:child_process";
 
 const pkg = JSON.parse(readFileSync("package.json", "utf-8"));
+
+function git(args) {
+  try {
+    return execSync(`git ${args}`, { stdio: ["ignore", "pipe", "ignore"] }).toString().trim();
+  } catch {
+    return null;
+  }
+}
+
+const commitSha = git("rev-parse HEAD");
+const shortCommitSha = git("rev-parse --short HEAD");
+const branch = git("rev-parse --abbrev-ref HEAD");
+const dirty = git("status --porcelain=v1") ? true : false;
+const buildTimestamp = new Date().toISOString();
+const buildProvenance = {
+  packageName: pkg.name,
+  packageVersion: pkg.version,
+  commitSha,
+  shortCommitSha,
+  branch,
+  dirty: commitSha ? dirty : null,
+  buildTimestamp,
+};
 
 await esbuild.build({
   entryPoints: ["index.ts"],
@@ -21,7 +45,9 @@ await esbuild.build({
   define: {
     __PLUGIN_VERSION__: JSON.stringify(pkg.version),
     __PACKAGE_NAME__: JSON.stringify(pkg.name),
+    __BUILD_PROVENANCE__: JSON.stringify(JSON.stringify(buildProvenance)),
   },
 });
 
 console.log(`Built dist/index.js (${pkg.name}@${pkg.version})`);
+console.log(`Embedded build provenance: ${JSON.stringify(buildProvenance)}`);

--- a/docs/TOOLS.md
+++ b/docs/TOOLS.md
@@ -551,7 +551,7 @@ List channels for a project or all projects. Shows channel type, ID, name, and e
 
 ### `config`
 
-Manage DevClaw workspace configuration. Supports three actions: reset config files to defaults, diff against defaults, and show version info.
+Manage DevClaw workspace configuration. Supports four actions: reset config files to defaults, diff against defaults, show version info, and inspect live build provenance.
 
 **Source:** [`lib/tools/admin/config.ts`](../lib/tools/admin/config.ts)
 
@@ -559,7 +559,7 @@ Manage DevClaw workspace configuration. Supports three actions: reset config fil
 
 | Parameter | Type | Required | Description |
 |---|---|---|---|
-| `action` | `"reset"` \| `"diff"` \| `"version"` | Yes | Action to perform |
+| `action` | `"reset"` \| `"diff"` \| `"version"` \| `"provenance"` | Yes | Action to perform |
 | `scope` | `"prompts"` \| `"workflow"` \| `"all"` | No | Reset scope (only for `action: "reset"`) |
 
 **Actions:**
@@ -569,3 +569,4 @@ Manage DevClaw workspace configuration. Supports three actions: reset config fil
 | `reset` | Reset config files to package defaults. Creates `.bak` backups. Use `scope` to target: `prompts` (role prompts only), `workflow` (workflow.yaml only), `all` (everything). |
 | `diff` | Show differences between current `workflow.yaml` and the built-in default template. Helps identify customizations and see what changed in new versions. |
 | `version` | Show DevClaw package version and workspace tracked version. |
+| `provenance` | Show embedded live runtime build provenance: package version, commit SHA, short SHA, branch, dirty flag, build timestamp, and metadata source. |

--- a/docs/devclaw-self-hosting.md
+++ b/docs/devclaw-self-hosting.md
@@ -72,11 +72,23 @@ Use `openclaw plugins inspect devclaw` to answer:
 Important distinction:
 
 - `inspect` tells you **what path is live**
-- git tells you **what commit that path contains**
+- runtime provenance tells you **what embedded build is live**
+- git tells you **what commit a still-present source tree contains**
 
-## Verify the exact live commit
+## Verify the exact live build without the repo
 
-Once you know the live source path, resolve that path back to the checkout or worktree root and verify the commit directly:
+Use the embedded provenance first. It survives even if the linked source worktree is gone:
+
+```bash
+openclaw agent --agent <agent-id> --message 'Call config with action "provenance" and reply with the result only.' --json
+openclaw devclaw provenance
+```
+
+This reports the live package version, commit SHA, short SHA, branch, dirty flag, and build timestamp from the built artifact itself.
+
+## Verify the exact live commit from source path inspection
+
+If the source tree still exists, you can also resolve the live source path back to the checkout or worktree root and verify the commit directly:
 
 ```bash
 openclaw plugins inspect devclaw

--- a/index.ts
+++ b/index.ts
@@ -39,6 +39,7 @@ import { registerCli } from "./lib/setup/cli.js";
 import { registerHeartbeatService } from "./lib/services/heartbeat/index.js";
 import { registerBootstrapHook } from "./lib/dispatch/bootstrap-hook.js";
 import { registerAttachmentHook } from "./lib/dispatch/attachment-hook.js";
+import { getBuildProvenance, formatBuildProvenanceSummary } from "./lib/build-provenance.js";
 
 const plugin = {
   id: "devclaw",
@@ -91,6 +92,7 @@ const plugin = {
 
   register(api: OpenClawPluginApi) {
     const ctx = createPluginContext(api);
+    const provenance = getBuildProvenance();
 
     // Worker lifecycle
     api.registerTool(createTaskStartTool(ctx), { names: ["task_start"] });
@@ -134,7 +136,7 @@ const plugin = {
     registerAttachmentHook(api, ctx);
 
     api.logger.info(
-      "DevClaw plugin registered (23 tools, 1 CLI command group, 1 service, 3 hooks)",
+      `DevClaw plugin registered (23 tools, 1 CLI command group, 1 service, 3 hooks) | build=${formatBuildProvenanceSummary(provenance)} | provenance=${JSON.stringify(provenance)}`,
     );
   },
 };

--- a/lib/build-provenance.ts
+++ b/lib/build-provenance.ts
@@ -1,0 +1,79 @@
+/**
+ * build-provenance.ts — Embedded live runtime provenance for built DevClaw installs.
+ *
+ * Build-time metadata is injected by esbuild so live installs remain self-describing
+ * even if the original source checkout/worktree is no longer available.
+ */
+import fsSync from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+/** Injected at build time by esbuild (see build.mjs). */
+declare const __PLUGIN_VERSION__: string | undefined;
+declare const __PACKAGE_NAME__: string | undefined;
+declare const __BUILD_PROVENANCE__: string | undefined;
+
+const THIS_DIR = path.dirname(fileURLToPath(import.meta.url));
+
+export type BuildProvenance = {
+  packageName: string;
+  packageVersion: string;
+  commitSha: string | null;
+  shortCommitSha: string | null;
+  branch: string | null;
+  dirty: boolean | null;
+  buildTimestamp: string | null;
+  source: "embedded" | "fallback";
+};
+
+function readPackageFallback(): { packageName: string; packageVersion: string } {
+  try {
+    const pkgPath = path.join(THIS_DIR, "..", "..", "package.json");
+    const pkg = JSON.parse(fsSync.readFileSync(pkgPath, "utf-8"));
+    return {
+      packageName: pkg.name ?? "devclaw",
+      packageVersion: pkg.version ?? "0.0.0",
+    };
+  } catch {
+    return {
+      packageName: typeof __PACKAGE_NAME__ !== "undefined" && __PACKAGE_NAME__ ? __PACKAGE_NAME__ : "devclaw",
+      packageVersion: typeof __PLUGIN_VERSION__ !== "undefined" && __PLUGIN_VERSION__ ? __PLUGIN_VERSION__ : "0.0.0",
+    };
+  }
+}
+
+export function getBuildProvenance(): BuildProvenance {
+  const fallbackPkg = readPackageFallback();
+
+  if (typeof __BUILD_PROVENANCE__ !== "undefined" && __BUILD_PROVENANCE__) {
+    try {
+      const parsed = JSON.parse(__BUILD_PROVENANCE__) as Omit<BuildProvenance, "source">;
+      return {
+        ...parsed,
+        source: "embedded",
+      };
+    } catch {
+      // Fall through to safe fallback.
+    }
+  }
+
+  return {
+    packageName: fallbackPkg.packageName,
+    packageVersion: fallbackPkg.packageVersion,
+    commitSha: null,
+    shortCommitSha: null,
+    branch: null,
+    dirty: null,
+    buildTimestamp: null,
+    source: "fallback",
+  };
+}
+
+export function formatBuildProvenanceSummary(provenance = getBuildProvenance()): string {
+  const dirtyText = provenance.dirty === null ? "unknown" : provenance.dirty ? "dirty" : "clean";
+  const commitText = provenance.commitSha ?? "unknown commit";
+  const branchText = provenance.branch ?? "unknown branch";
+  const builtAtText = provenance.buildTimestamp ?? "unknown build time";
+
+  return `${provenance.packageName}@${provenance.packageVersion} (${commitText}, ${branchText}, ${dirtyText}, built ${builtAtText})`;
+}

--- a/lib/setup/cli.ts
+++ b/lib/setup/cli.ts
@@ -10,6 +10,7 @@ import { runSetup } from "./index.js";
 import { getAllDefaultModels, getAllRoleIds, getLevelsForRole } from "../roles/index.js";
 import { readProjects, writeProjects, type Channel } from "../projects/index.js";
 import { log as auditLog } from "../audit.js";
+import { getBuildProvenance } from "../build-provenance.js";
 
 /**
  * Get the default workspace directory from the OpenClaw config.
@@ -99,6 +100,13 @@ export function registerCli(program: Command, ctx: PluginContext): void {
     });
 
   // Channel management commands
+  devclaw
+    .command("provenance")
+    .description("Show embedded live runtime build provenance")
+    .action(() => {
+      console.log(JSON.stringify(getBuildProvenance(), null, 2));
+    });
+
   const channel = devclaw
     .command("channel")
     .description("Manage project channels (register, deregister, list)");

--- a/lib/tools/admin/config.ts
+++ b/lib/tools/admin/config.ts
@@ -5,6 +5,7 @@
  * - reset: Reset config files to package defaults (with .bak backups)
  * - diff: Show differences between current workflow.yaml and package default
  * - version: Show current and workspace DevClaw versions
+ * - provenance: Show embedded live runtime build provenance
  */
 import fs from "node:fs/promises";
 import path from "node:path";
@@ -15,6 +16,7 @@ import { writeAllDefaults, backupAndWrite, fileExists } from "../../setup/worksp
 import { WORKFLOW_YAML_TEMPLATE, DEFAULT_ROLE_INSTRUCTIONS } from "../../setup/templates.js";
 import { DATA_DIR } from "../../setup/migrate-layout.js";
 import { getCurrentVersion, readVersionFile } from "../../setup/version.js";
+import { getBuildProvenance, formatBuildProvenanceSummary } from "../../build-provenance.js";
 
 export function createConfigTool(ctx: PluginContext) {
   return (toolCtx: ToolContext) => ({
@@ -27,19 +29,21 @@ Actions:
   Scope: --prompts (prompts only), --workflow (workflow.yaml only), --all (everything).
 - **diff**: Show differences between current workflow.yaml and the package default template.
 - **version**: Show DevClaw package version and workspace tracked version.
+- **provenance**: Show embedded live runtime build provenance.
 
 Examples:
   config({ action: "reset", scope: "workflow" })
   config({ action: "reset", scope: "all" })
   config({ action: "diff" })
-  config({ action: "version" })`,
+  config({ action: "version" })
+  config({ action: "provenance" })`,
     parameters: {
       type: "object",
       required: ["action"],
       properties: {
         action: {
           type: "string",
-          enum: ["reset", "diff", "version"],
+          enum: ["reset", "diff", "version", "provenance"],
           description: "Config action to perform.",
         },
         scope: {
@@ -62,6 +66,8 @@ Examples:
           return await handleDiff(workspacePath);
         case "version":
           return await handleVersion(workspacePath);
+        case "provenance":
+          return handleProvenance();
         default:
           throw new Error(`Unknown config action: ${action}`);
       }
@@ -174,5 +180,24 @@ async function handleVersion(workspacePath: string) {
       : workspaceVersion
         ? `DevClaw v${packageVersion} (workspace tracked: v${workspaceVersion}) — version mismatch.`
         : `DevClaw v${packageVersion} — workspace version not yet tracked.`,
+  });
+}
+
+function handleProvenance() {
+  const provenance = getBuildProvenance();
+
+  return jsonResult({
+    success: true,
+    action: "provenance",
+    packageVersion: provenance.packageVersion,
+    provenance,
+    summary:
+      `Live runtime provenance: ${formatBuildProvenanceSummary(provenance)}\n` +
+      `commit=${provenance.commitSha ?? "unknown"}\n` +
+      `short=${provenance.shortCommitSha ?? "unknown"}\n` +
+      `branch=${provenance.branch ?? "unknown"}\n` +
+      `dirty=${provenance.dirty === null ? "unknown" : provenance.dirty ? "true" : "false"}\n` +
+      `built=${provenance.buildTimestamp ?? "unknown"}\n` +
+      `source=${provenance.source}`,
   });
 }


### PR DESCRIPTION
## Summary
- embed live runtime provenance into the built artifact at build time
- expose a durable runtime inspection surface via `config({ action: "provenance" })` and `openclaw devclaw provenance`
- log structured provenance on plugin registration and document the self-hosting flow

## Testing
- `npm run build`
- verified the built `dist/index.js` contains the embedded commit SHA and provenance fields

Closes #148
