### PR TITLE
fix: visible Refining hold comments on local truth (#152)

### DIFF
--- a/lib/services/pipeline.e2e.test.ts
+++ b/lib/services/pipeline.e2e.test.ts
@@ -297,6 +297,17 @@ describe("E2E pipeline", () => {
       assert.strictEqual(output.labelTransition, "Reviewing → Refining");
       const issue = await h.provider.getIssue(25);
       assert.ok(issue.labels.includes("Refining"), `Labels: ${issue.labels}`);
+
+      const comments = h.provider.comments.get(25) ?? [];
+      assert.strictEqual(comments.length, 1);
+      assert.ok(comments[0]!.body.startsWith("👁️ **REVIEWER**: Refining hold reason"));
+      assert.ok(comments[0]!.body.includes("### Why this is on hold"));
+      assert.ok(comments[0]!.body.includes("- from: `Reviewing`"));
+      assert.ok(comments[0]!.body.includes("- to: `Refining`"));
+      assert.ok(comments[0]!.body.includes("- category: `work_finish_blocked`"));
+      assert.ok(comments[0]!.body.includes("- source: `worker`"));
+      assert.ok(comments[0]!.body.includes("- role: `reviewer`"));
+      assert.ok(comments[0]!.body.includes("- result: `blocked`"));
     });
   });
 
@@ -419,6 +430,21 @@ describe("E2E pipeline", () => {
 
       const issue = await h.provider.getIssue(50);
       assert.ok(issue.labels.includes("Refining"));
+
+      const comments = h.provider.comments.get(50) ?? [];
+      assert.strictEqual(comments.length, 1, "Should leave the canonical Refining hold reason");
+      const addCommentCall = h.provider.callsTo("addComment")[0];
+      const transitionCall = h.provider.callsTo("transitionLabel")[0];
+      assert.ok(addCommentCall && transitionCall, "Should record both comment and transition");
+      assert.ok(h.provider.calls.indexOf(addCommentCall) < h.provider.calls.indexOf(transitionCall), "Should comment before entering Refining");
+      assert.ok(comments[0]!.body.startsWith("🔧 **DEVELOPER**: Refining hold reason"));
+      assert.ok(comments[0]!.body.includes("DevClaw is moving this issue from `Doing` to `Refining` because work cannot continue yet."));
+      assert.ok(comments[0]!.body.includes("### Why this is on hold"));
+      assert.ok(comments[0]!.body.includes("- Need design decision"));
+      assert.ok(comments[0]!.body.includes("### Transition details"));
+      assert.ok(comments[0]!.body.includes("- category: `work_finish_blocked`"));
+      assert.ok(comments[0]!.body.includes("### Context"));
+      assert.ok(comments[0]!.body.includes("Please review this hold reason and update the issue before re-queueing it."));
     });
   });
 

--- a/lib/services/pipeline.ts
+++ b/lib/services/pipeline.ts
@@ -36,6 +36,65 @@ export type CompletionOutput = {
   issueReopened?: boolean;
 };
 
+function getRefiningCommentPrefix(role: string): string {
+  switch (role) {
+    case "developer":
+      return "🔧 **DEVELOPER**";
+    case "tester":
+      return "🧪 **TESTER**";
+    case "reviewer":
+      return "👁️ **REVIEWER**";
+    case "architect":
+      return "🏗️ **ARCHITECT**";
+    default:
+      return "🎛️ **ORCHESTRATOR**";
+  }
+}
+
+export function buildRefiningHoldComment(opts: {
+  role: string;
+  result: string;
+  from: string;
+  to: string;
+  summary?: string;
+  source?: "worker" | "system";
+}): string {
+  const {
+    role,
+    result,
+    from,
+    to,
+    summary,
+    source = "worker",
+  } = opts;
+
+  const lines = [
+    `${getRefiningCommentPrefix(role)}: Refining hold reason`,
+    "",
+    `DevClaw is moving this issue from \`${from}\` to \`${to}\` because work cannot continue yet.`,
+    "",
+    "### Why this is on hold",
+    "",
+    `- ${summary?.trim() || "Work stopped without a summary, and operator follow-up is required before this issue can continue."}`,
+    "",
+    "### Transition details",
+    "",
+    `- from: \`${from}\``,
+    `- to: \`${to}\``,
+    `- category: \`work_finish_${result}\``,
+    `- source: \`${source}\``,
+    "",
+    "### Context",
+    "",
+    `- role: \`${role}\``,
+    `- result: \`${result}\``,
+    "",
+    "Please review this hold reason and update the issue before re-queueing it.",
+  ];
+
+  return lines.join("\n");
+}
+
 /**
  * Get completion rule for a role:result pair.
  * Uses workflow config when available.
@@ -207,6 +266,16 @@ export async function executeCompletion(opts: {
   // Then execute post-transition actions (close/reopen)
   // Finally deactivate worker (last — ensures label is set even if deactivation fails)
   const transitionedTo = rule.to as StateLabel;
+  if (transitionedTo === "Refining") {
+    await provider.addComment(issueId, buildRefiningHoldComment({
+      role,
+      result,
+      from: rule.from,
+      to: transitionedTo,
+      summary,
+      source: "worker",
+    }));
+  }
   await provider.transitionLabel(issueId, rule.from as StateLabel, transitionedTo);
 
   await recordLoopDiagnostic(workspaceDir, "work_finish_transition", {


### PR DESCRIPTION
## Summary
- require a visible hold-reason comment before any completion transition into Refining
- cover reviewer blocked and developer blocked paths in pipeline e2e tests
- keep this branch scoped to the silent-Refining family on top of devclaw-local-current

## Traceability
- prerequisite #125 slice already exists on devclaw-local-current
- this PR adds the recoverable visible-Refining fix family slice for #152

## Testing
- attempted TypeScript verification, but current branch line still has unrelated baseline typecheck failures outside this two-file slice