### PR TITLE
fix: visible Refining hold comments (#152)

### DIFF
--- a/lib/dispatch/index.ts
+++ b/lib/dispatch/index.ts
@@ -7,6 +7,7 @@
 import type { PluginRuntime } from "openclaw/plugin-sdk";
 import type { RunCommand } from "../context.js";
 import { log as auditLog } from "../audit.js";
+import { recordLoopDiagnostic } from "../services/loop-diagnostics.js";
 import {
   type Project,
   activateWorker,
@@ -184,6 +185,16 @@ export async function dispatchTask(
 
   // ── Commitment point — transition label (issue leaves queue) ────────
   await provider.transitionLabel(issueId, fromLabel, toLabel);
+  await recordLoopDiagnostic(workspaceDir, "dispatch_pickup", {
+    project: project.name,
+    issueId,
+    role,
+    level,
+    from: fromLabel,
+    to: toLabel,
+    sessionAction,
+    sessionKey,
+  }).catch(() => {});
 
   // Mark issue + PR as managed and all consumed comments as seen (fire-and-forget)
   provider.reactToIssue(issueId, EYES_EMOJI).catch(() => {});

--- a/lib/services/heartbeat/health.ts
+++ b/lib/services/heartbeat/health.ts
@@ -51,6 +51,7 @@ import {
 import { isSessionAlive, type SessionLookup } from "../gateway-sessions.js";
 import { sendToAgent } from "../../dispatch/session.js";
 import type { RunCommand } from "../../context.js";
+import { recordLoopDiagnostic } from "../loop-diagnostics.js";
 
 // Re-export for consumers that import from health.ts
 export { fetchGatewaySessions, isSessionAlive, type GatewaySession, type SessionLookup } from "../gateway-sessions.js";
@@ -231,6 +232,16 @@ export async function checkWorkerHealth(opts: {
         if (!issueIdNum) return;
         try {
           await provider.transitionLabel(issueIdNum, from, to);
+          await recordLoopDiagnostic(workspaceDir, "health_requeue", {
+            project: project.name,
+            projectSlug,
+            issueId: issueIdNum,
+            role,
+            from,
+            to,
+            slotLevel: level,
+            slotIndex,
+          }).catch(() => {});
           fix.labelReverted = `${from} → ${to}`;
         } catch {
           fix.labelRevertFailed = true;

--- a/lib/services/heartbeat/review.ts
+++ b/lib/services/heartbeat/review.ts
@@ -17,6 +17,7 @@ import {
 import { detectStepRouting } from "../queue-scan.js";
 import type { RunCommand } from "../../context.js";
 import { log as auditLog } from "../../audit.js";
+import { recordLoopDiagnostic } from "../loop-diagnostics.js";
 
 /**
  * Scan review-type states and transition issues whose PR check condition is met.
@@ -98,6 +99,15 @@ export async function reviewPass(opts: {
           const targetState = workflow.states[targetKey];
           if (targetState) {
             await provider.transitionLabel(issue.iid, state.label, targetState.label);
+            await recordLoopDiagnostic(workspaceDir, "review_feedback_transition", {
+              project: projectName,
+              issueId: issue.iid,
+              from: state.label,
+              to: targetState.label,
+              reason: status.state === PrState.HAS_COMMENTS ? "pr_comments" : "changes_requested",
+              prUrl: status.url,
+              sourceBranch: status.sourceBranch,
+            }).catch(() => {});
             await auditLog(workspaceDir, "review_transition", {
               project: projectName, issueId: issue.iid,
               from: state.label, to: targetState.label,
@@ -121,6 +131,15 @@ export async function reviewPass(opts: {
           const targetState = workflow.states[targetKey];
           if (targetState) {
             await provider.transitionLabel(issue.iid, state.label, targetState.label);
+            await recordLoopDiagnostic(workspaceDir, "review_feedback_transition", {
+              project: projectName,
+              issueId: issue.iid,
+              from: state.label,
+              to: targetState.label,
+              reason: "merge_conflict",
+              prUrl: status.url,
+              sourceBranch: status.sourceBranch,
+            }).catch(() => {});
             await auditLog(workspaceDir, "review_transition", {
               project: projectName, issueId: issue.iid,
               from: state.label, to: targetState.label,
@@ -212,6 +231,15 @@ export async function reviewPass(opts: {
                   const failedState = workflow.states[failedKey];
                   if (failedState) {
                     await provider.transitionLabel(issue.iid, state.label, failedState.label);
+                    await recordLoopDiagnostic(workspaceDir, "review_feedback_transition", {
+                      project: projectName,
+                      issueId: issue.iid,
+                      from: state.label,
+                      to: failedState.label,
+                      reason: "merge_failed",
+                      prUrl: status.url,
+                      sourceBranch: status.sourceBranch,
+                    }).catch(() => {});
                     await auditLog(workspaceDir, "review_transition", {
                       project: projectName,
                       issueId: issue.iid,

--- a/lib/services/loop-diagnostics.ts
+++ b/lib/services/loop-diagnostics.ts
@@ -1,0 +1,20 @@
+import { log as auditLog } from "../audit.js";
+
+export type LoopDiagnosticData = Record<string, unknown>;
+
+function isEnabled(): boolean {
+  const raw = process.env.DEVCLAW_LOOP_DIAGNOSTICS?.trim().toLowerCase();
+  return raw === "1" || raw === "true" || raw === "yes" || raw === "on";
+}
+
+export async function recordLoopDiagnostic(
+  workspaceDir: string,
+  stage: string,
+  data: LoopDiagnosticData,
+): Promise<void> {
+  if (!isEnabled()) return;
+  await auditLog(workspaceDir, "loop_diagnostic", {
+    stage,
+    ...data,
+  });
+}

--- a/lib/services/pipeline.e2e.test.ts
+++ b/lib/services/pipeline.e2e.test.ts
@@ -297,6 +297,17 @@ describe("E2E pipeline", () => {
       assert.strictEqual(output.labelTransition, "Reviewing → Refining");
       const issue = await h.provider.getIssue(25);
       assert.ok(issue.labels.includes("Refining"), `Labels: ${issue.labels}`);
+
+      const comments = h.provider.comments.get(25) ?? [];
+      assert.strictEqual(comments.length, 1);
+      assert.ok(comments[0]!.body.startsWith("👁️ **REVIEWER**: Refining hold reason"));
+      assert.ok(comments[0]!.body.includes("### Why this is on hold"));
+      assert.ok(comments[0]!.body.includes("- from: `Reviewing`"));
+      assert.ok(comments[0]!.body.includes("- to: `Refining`"));
+      assert.ok(comments[0]!.body.includes("- category: `work_finish_blocked`"));
+      assert.ok(comments[0]!.body.includes("- source: `worker`"));
+      assert.ok(comments[0]!.body.includes("- role: `reviewer`"));
+      assert.ok(comments[0]!.body.includes("- result: `blocked`"));
     });
   });
 
@@ -419,6 +430,21 @@ describe("E2E pipeline", () => {
 
       const issue = await h.provider.getIssue(50);
       assert.ok(issue.labels.includes("Refining"));
+
+      const comments = h.provider.comments.get(50) ?? [];
+      assert.strictEqual(comments.length, 1, "Should leave the canonical Refining hold reason");
+      const addCommentCall = h.provider.callsTo("addComment")[0];
+      const transitionCall = h.provider.callsTo("transitionLabel")[0];
+      assert.ok(addCommentCall && transitionCall, "Should record both comment and transition");
+      assert.ok(h.provider.calls.indexOf(addCommentCall) < h.provider.calls.indexOf(transitionCall), "Should comment before entering Refining");
+      assert.ok(comments[0]!.body.startsWith("🔧 **DEVELOPER**: Refining hold reason"));
+      assert.ok(comments[0]!.body.includes("DevClaw is moving this issue from `Doing` to `Refining` because work cannot continue yet."));
+      assert.ok(comments[0]!.body.includes("### Why this is on hold"));
+      assert.ok(comments[0]!.body.includes("- Need design decision"));
+      assert.ok(comments[0]!.body.includes("### Transition details"));
+      assert.ok(comments[0]!.body.includes("- category: `work_finish_blocked`"));
+      assert.ok(comments[0]!.body.includes("### Context"));
+      assert.ok(comments[0]!.body.includes("Please review this hold reason and update the issue before re-queueing it."));
     });
   });
 

--- a/lib/services/pipeline.ts
+++ b/lib/services/pipeline.ts
@@ -36,6 +36,65 @@ export type CompletionOutput = {
   issueReopened?: boolean;
 };
 
+function getRefiningCommentPrefix(role: string): string {
+  switch (role) {
+    case "developer":
+      return "🔧 **DEVELOPER**";
+    case "tester":
+      return "🧪 **TESTER**";
+    case "reviewer":
+      return "👁️ **REVIEWER**";
+    case "architect":
+      return "🏗️ **ARCHITECT**";
+    default:
+      return "🎛️ **ORCHESTRATOR**";
+  }
+}
+
+export function buildRefiningHoldComment(opts: {
+  role: string;
+  result: string;
+  from: string;
+  to: string;
+  summary?: string;
+  source?: "worker" | "system";
+}): string {
+  const {
+    role,
+    result,
+    from,
+    to,
+    summary,
+    source = "worker",
+  } = opts;
+
+  const lines = [
+    `${getRefiningCommentPrefix(role)}: Refining hold reason`,
+    "",
+    `DevClaw is moving this issue from \`${from}\` to \`${to}\` because work cannot continue yet.`,
+    "",
+    "### Why this is on hold",
+    "",
+    `- ${summary?.trim() || "Work stopped without a summary, and operator follow-up is required before this issue can continue."}`,
+    "",
+    "### Transition details",
+    "",
+    `- from: \`${from}\``,
+    `- to: \`${to}\``,
+    `- category: \`work_finish_${result}\``,
+    `- source: \`${source}\``,
+    "",
+    "### Context",
+    "",
+    `- role: \`${role}\``,
+    `- result: \`${result}\``,
+    "",
+    "Please review this hold reason and update the issue before re-queueing it.",
+  ];
+
+  return lines.join("\n");
+}
+
 /**
  * Get completion rule for a role:result pair.
  * Uses workflow config when available.
@@ -206,6 +265,16 @@ export async function executeCompletion(opts: {
   // Then execute post-transition actions (close/reopen)
   // Finally deactivate worker (last — ensures label is set even if deactivation fails)
   const transitionedTo = rule.to as StateLabel;
+  if (transitionedTo === "Refining") {
+    await provider.addComment(issueId, buildRefiningHoldComment({
+      role,
+      result,
+      from: rule.from,
+      to: transitionedTo,
+      summary,
+      source: "worker",
+    }));
+  }
   await provider.transitionLabel(issueId, rule.from as StateLabel, transitionedTo);
 
   await recordLoopDiagnostic(workspaceDir, "work_finish_transition", {

--- a/lib/services/pipeline.ts
+++ b/lib/services/pipeline.ts
@@ -11,6 +11,7 @@ import { notify, getNotificationConfig } from "../dispatch/notify.js";
 import { log as auditLog } from "../audit.js";
 import { loadConfig } from "../config/index.js";
 import { detectStepRouting } from "./queue-scan.js";
+import { recordLoopDiagnostic } from "./loop-diagnostics.js";
 import {
   DEFAULT_WORKFLOW,
   Action,
@@ -204,8 +205,19 @@ export async function executeCompletion(opts: {
   // Transition label first (critical — if this fails, issue still has correct state)
   // Then execute post-transition actions (close/reopen)
   // Finally deactivate worker (last — ensures label is set even if deactivation fails)
-  
-  await provider.transitionLabel(issueId, rule.from as StateLabel, rule.to as StateLabel);
+  const transitionedTo = rule.to as StateLabel;
+  await provider.transitionLabel(issueId, rule.from as StateLabel, transitionedTo);
+
+  await recordLoopDiagnostic(workspaceDir, "work_finish_transition", {
+    project: projectName,
+    issueId,
+    role,
+    result,
+    from: rule.from,
+    to: transitionedTo,
+    summary: summary ?? null,
+    prUrl: prUrl ?? null,
+  }).catch(() => {});
 
   // Execute post-transition actions
   for (const action of rule.actions) {


### PR DESCRIPTION
## Summary
- carry forward the verified #125 prerequisite diagnostics slice
- require a visible hold-reason comment before any completion transition into Refining
- cover reviewer blocked and developer blocked paths in pipeline e2e tests

## Traceability
- curated export for the silent-Refining family from issue-125-loop-debug-env
- intentionally excludes unrelated residual lane diagnostics

## Testing
- attempted TypeScript verification, but this line still has unrelated baseline typecheck failures outside this curated slice