### PR TITLE
revert: undo premature merge of #168 notification package

### DIFF
--- a/lib/dispatch/notify.test.ts
+++ b/lib/dispatch/notify.test.ts
@@ -121,57 +121,6 @@ describe("notify", () => {
     assert.match(auditLog, /"delivery":"cli-fallback"/);
   });
 
-  it("passes messageThreadId through the Telegram CLI fallback", async () => {
-    const calls: Array<{ args: string[]; timeoutMs?: number }> = [];
-
-    const ok = await notify(
-      {
-        type: "workerComplete",
-        project: "devclaw",
-        issueId: 7,
-        issueUrl: "https://example.com/issues/7",
-        role: "developer",
-        result: "refine",
-      },
-      {
-        workspaceDir: tempDir,
-        channelId: "-100123",
-        channel: "telegram",
-        runtime: {
-          channel: {
-            telegram: {
-              sendMessageTelegram: async () => {
-                throw new Error("telegram runtime unavailable");
-              },
-            },
-          },
-        } as any,
-        runCommand: async (args, opts): Promise<SpawnResult> => {
-          const options = typeof opts === "number" ? { timeoutMs: opts } : opts as CommandOptions;
-          calls.push({ args, timeoutMs: options?.timeoutMs });
-          return {
-            stdout: "",
-            stderr: "",
-            code: 0,
-            signal: null,
-            killed: false,
-            termination: "exit",
-          };
-        },
-        messageThreadId: 176,
-      },
-    );
-
-    assert.equal(ok, true);
-    assert.equal(calls.length, 1);
-    assert.ok(calls[0]?.args.includes("--thread-id"));
-    assert.ok(calls[0]?.args.includes("176"));
-
-    const auditLog = await readFile(join(tempDir, "devclaw", "log", "audit.log"), "utf-8");
-    assert.match(auditLog, /"delivery":"cli-fallback"/);
-    assert.match(auditLog, /"messageThreadId":176/);
-  });
-
   it("logs notify_error and returns false when no sender is available", async () => {
     const ok = await notify(
       {

--- a/lib/dispatch/notify.ts
+++ b/lib/dispatch/notify.ts
@@ -281,84 +281,60 @@ async function sendMessage(
   runCommand?: RunCommand,
   messageThreadId?: number,
 ): Promise<boolean> {
-  const runtimeChannel = runtime?.channel as Record<string, any> | undefined;
-  const runtimeSender =
-    channel === "telegram" ? runtimeChannel?.telegram?.sendMessageTelegram :
-    channel === "whatsapp" ? runtimeChannel?.whatsapp?.sendMessageWhatsApp :
-    channel === "discord" ? runtimeChannel?.discord?.sendMessageDiscord :
-    channel === "slack" ? runtimeChannel?.slack?.sendMessageSlack :
-    channel === "signal" ? runtimeChannel?.signal?.sendMessageSignal :
-    undefined;
-
-  if (runtimeSender) {
-    try {
+  try {
+    // Use runtime API when available (avoids CLI subprocess timeouts)
+    if (runtime) {
       if (channel === "telegram") {
+        // Cast to any to bypass TypeScript type limitation; disableWebPagePreview and messageThreadId are valid in Telegram API
         const telegramOpts: Record<string, unknown> = { silent: true, disableWebPagePreview: true, accountId };
         if (messageThreadId != null) telegramOpts.messageThreadId = messageThreadId;
-        await runtimeSender(target, message, telegramOpts as any);
-      } else if (channel === "whatsapp") {
-        await runtimeSender(target, message, { verbose: false, accountId });
-      } else {
-        await runtimeSender(target, message, { accountId });
+        await runtime.channel.telegram.sendMessageTelegram(target, message, telegramOpts as any);
+        return true;
       }
-
-      await auditLog(workspaceDir, "notify_delivery", {
-        target,
-        channel,
-        delivery: "runtime",
-      });
-      return true;
-    } catch (err) {
-      await auditLog(workspaceDir, "notify_runtime_error", {
-        target,
-        channel,
-        error: (err as Error).message,
-      });
+      if (channel === "whatsapp") {
+        await runtime.channel.whatsapp.sendMessageWhatsApp(target, message, { verbose: false, accountId });
+        return true;
+      }
+      if (channel === "discord") {
+        await runtime.channel.discord.sendMessageDiscord(target, message, { accountId });
+        return true;
+      }
+      if (channel === "slack") {
+        await runtime.channel.slack.sendMessageSlack(target, message, { accountId });
+        return true;
+      }
+      if (channel === "signal") {
+        await runtime.channel.signal.sendMessageSignal(target, message, { accountId });
+        return true;
+      }
     }
-  }
 
-  if (!runCommand) {
-    await auditLog(workspaceDir, "notify_error", {
-      target,
-      channel,
-      delivery: "failed",
-      error: `No runtime sender available for channel ${channel} and runCommand is not available`,
-    });
-    return false;
-  }
-
-  try {
+    // Fallback: use CLI (for unsupported channels or when runtime isn't available)
+    if (!runCommand) throw new Error("runCommand is required when runtime is not available");
     const rc = runCommand;
-    const argv = [
-      "openclaw",
-      "message",
-      "send",
-      "--channel",
-      channel,
-      "--target",
-      target,
-      "--message",
-      message,
-    ];
-    if (channel === "telegram" && messageThreadId != null) {
-      argv.push("--thread-id", String(messageThreadId));
-    }
-    argv.push("--json");
-
-    await rc(argv, { timeoutMs: 30_000 });
-
-    await auditLog(workspaceDir, "notify_delivery", {
-      target,
-      channel,
-      delivery: "cli-fallback",
-      ...(channel === "telegram" && messageThreadId != null ? { messageThreadId } : {}),
-    });
+    // Note: openclaw message send CLI doesn't expose disable_web_page_preview flag.
+    // The runtime API path (above) handles it; CLI fallback won't suppress previews.
+    await rc(
+      [
+        "openclaw",
+        "message",
+        "send",
+        "--channel",
+        channel,
+        "--target",
+        target,
+        "--message",
+        message,
+        "--json",
+      ],
+      { timeoutMs: 30_000 },
+    );
     return true;
   } catch (err) {
+    // Log but don't throw — notifications shouldn't break the main flow
     await auditLog(workspaceDir, "notify_error", {
       target,
       channel,
-      delivery: "failed",
       error: (err as Error).message,
     });
     return false;

--- a/lib/services/pipeline.e2e.test.ts
+++ b/lib/services/pipeline.e2e.test.ts
@@ -352,58 +352,6 @@ describe("E2E pipeline", () => {
       assert.strictEqual(closeCalls.length, 1);
       assert.strictEqual(closeCalls[0].args.issueId, 30);
     });
-
-    it("should use CLI fallback for completion notifications and preserve Telegram topic routing", async () => {
-      h.project.channels[0]!.messageThreadId = 176;
-
-      await executeCompletion({
-        workspaceDir: h.workspaceDir,
-        projectSlug: h.project.slug,
-        channels: h.project.channels,
-        role: "tester",
-        result: "pass",
-        issueId: 30,
-        summary: "All tests pass",
-        provider: h.provider,
-        repoPath: "/tmp/test-repo",
-        projectName: "test-project",
-        runCommand: h.runCommand,
-      });
-
-      const notifyCalls = h.commands.commands.filter(
-        (c) => c.argv[0] === "openclaw" && c.argv[1] === "message" && c.argv[2] === "send",
-      );
-      assert.ok(notifyCalls.length >= 2, "Expected workerComplete and issueComplete CLI fallback notifications");
-      assert.ok(notifyCalls.every((c) => c.argv.includes("--thread-id") && c.argv.includes("176")));
-    });
-
-    it("should await completion notification fallback delivery before returning", async () => {
-      h.project.channels[0]!.messageThreadId = 176;
-      const delayedRunCommand = async (argv: string[], opts: any) => {
-        if (argv[0] === "openclaw" && argv[1] === "message" && argv[2] === "send") {
-          await new Promise((resolve) => setTimeout(resolve, 25));
-        }
-        return h.runCommand(argv, opts);
-      };
-
-      const startedAt = Date.now();
-      await executeCompletion({
-        workspaceDir: h.workspaceDir,
-        projectSlug: h.project.slug,
-        channels: h.project.channels,
-        role: "tester",
-        result: "pass",
-        issueId: 30,
-        summary: "All tests pass",
-        provider: h.provider,
-        repoPath: "/tmp/test-repo",
-        projectName: "test-project",
-        runCommand: delayedRunCommand,
-      });
-      const elapsedMs = Date.now() - startedAt;
-
-      assert.ok(elapsedMs >= 50, `Expected executeCompletion to await both fallback sends, got ${elapsedMs}ms`);
-    });
   });
 
   // =========================================================================
@@ -497,58 +445,6 @@ describe("E2E pipeline", () => {
       assert.ok(comments[0]!.body.includes("- category: `work_finish_blocked`"));
       assert.ok(comments[0]!.body.includes("### Context"));
       assert.ok(comments[0]!.body.includes("Please review this hold reason and update the issue before re-queueing it."));
-    });
-
-    it("should use CLI fallback for Refining notifications and preserve Telegram topic routing", async () => {
-      h.project.channels[0]!.messageThreadId = 176;
-
-      await executeCompletion({
-        workspaceDir: h.workspaceDir,
-        projectSlug: h.project.slug,
-        channels: h.project.channels,
-        role: "developer",
-        result: "blocked",
-        issueId: 50,
-        summary: "Need design decision",
-        provider: h.provider,
-        repoPath: "/tmp/test-repo",
-        projectName: "test-project",
-        runCommand: h.runCommand,
-      });
-
-      const notifyCalls = h.commands.commands.filter(
-        (c) => c.argv[0] === "openclaw" && c.argv[1] === "message" && c.argv[2] === "send",
-      );
-      assert.ok(notifyCalls.length >= 1, "Expected CLI fallback notification call");
-      assert.ok(notifyCalls.some((c) => c.argv.includes("--thread-id") && c.argv.includes("176")));
-    });
-
-    it("should await Refining notification fallback delivery before returning", async () => {
-      h.project.channels[0]!.messageThreadId = 176;
-      const delayedRunCommand = async (argv: string[], opts: any) => {
-        if (argv[0] === "openclaw" && argv[1] === "message" && argv[2] === "send") {
-          await new Promise((resolve) => setTimeout(resolve, 25));
-        }
-        return h.runCommand(argv, opts);
-      };
-
-      const startedAt = Date.now();
-      await executeCompletion({
-        workspaceDir: h.workspaceDir,
-        projectSlug: h.project.slug,
-        channels: h.project.channels,
-        role: "developer",
-        result: "blocked",
-        issueId: 50,
-        summary: "Need design decision",
-        provider: h.provider,
-        repoPath: "/tmp/test-repo",
-        projectName: "test-project",
-        runCommand: delayedRunCommand,
-      });
-      const elapsedMs = Date.now() - startedAt;
-
-      assert.ok(elapsedMs >= 25, `Expected executeCompletion to await Refining fallback send, got ${elapsedMs}ms`);
     });
   });
 

--- a/lib/services/pipeline.ts
+++ b/lib/services/pipeline.ts
@@ -214,57 +214,52 @@ export async function executeCompletion(opts: {
 
   // Send notification early (before deactivation and label transition which can fail)
   const notifyConfig = getNotificationConfig(pluginConfig);
-  try {
-    await notify(
-      {
-        type: "workerComplete",
-        project: projectName,
-        issueId,
-        issueUrl: issue.web_url,
-        role,
-        level: opts.level,
-        name: workerName,
-        result: result as "done" | "pass" | "fail" | "refine" | "blocked",
-        summary,
-        nextState,
-        prUrl,
-        createdTasks,
-      },
-      {
-        workspaceDir,
-        config: notifyConfig,
-        channelId: notifyTarget?.channelId,
-        channel: notifyTarget?.channel ?? "telegram",
-        runtime,
-        accountId: notifyTarget?.accountId,
-        runCommand: rc,
-        messageThreadId: notifyTarget?.messageThreadId,
-      },
-    );
-  } catch (err) {
+  notify(
+    {
+      type: "workerComplete",
+      project: projectName,
+      issueId,
+      issueUrl: issue.web_url,
+      role,
+      level: opts.level,
+      name: workerName,
+      result: result as "done" | "pass" | "fail" | "refine" | "blocked",
+      summary,
+      nextState,
+      prUrl,
+      createdTasks,
+    },
+    {
+      workspaceDir,
+      config: notifyConfig,
+      channelId: notifyTarget?.channelId,
+      channel: notifyTarget?.channel ?? "telegram",
+      runtime,
+      accountId: notifyTarget?.accountId,
+      messageThreadId: notifyTarget?.messageThreadId,
+    },
+  ).catch((err) => {
     auditLog(workspaceDir, "pipeline_warning", { step: "notify", issue: issueId, role, error: (err as Error).message ?? String(err) }).catch(() => {});
-  }
+  });
 
   // Send merge notification when PR was merged during this completion
   if (mergedPr) {
-    try {
-      await notify(
-        {
-          type: "prMerged",
-          project: projectName,
-          issueId,
-          issueUrl: issue.web_url,
-          issueTitle: issue.title,
-          prUrl,
-          prTitle,
-          sourceBranch,
-          mergedBy: "pipeline",
-        },
-        { workspaceDir, config: notifyConfig, channelId: notifyTarget?.channelId, channel: notifyTarget?.channel ?? "telegram", runtime, accountId: notifyTarget?.accountId, runCommand: rc, messageThreadId: notifyTarget?.messageThreadId },
-      );
-    } catch (err) {
+    notify(
+      {
+        type: "prMerged",
+        project: projectName,
+        issueId,
+        issueUrl: issue.web_url,
+        issueTitle: issue.title,
+        prUrl,
+        prTitle,
+        sourceBranch,
+        mergedBy: "pipeline",
+      },
+      { workspaceDir, config: notifyConfig, channelId: notifyTarget?.channelId, channel: notifyTarget?.channel ?? "telegram", runtime, accountId: notifyTarget?.accountId, messageThreadId: notifyTarget?.messageThreadId },
+    ).catch((err) => {
       auditLog(workspaceDir, "pipeline_warning", { step: "mergeNotify", issue: issueId, role, error: (err as Error).message ?? String(err) }).catch(() => {});
-    }
+    });
   }
 
   // Transition label first (critical — if this fails, issue still has correct state)
@@ -300,30 +295,26 @@ export async function executeCompletion(opts: {
       case Action.CLOSE_ISSUE:
         await provider.closeIssue(issueId);
         // Notify that the issue has been fully completed and closed
-        try {
-          await notify(
-            {
-              type: "issueComplete",
-              project: projectName,
-              issueId,
-              issueUrl: issue.web_url,
-              issueTitle: issue.title,
-              prUrl,
-            },
-            {
-              workspaceDir,
-              config: notifyConfig,
-              channelId: notifyTarget?.channelId,
-              channel: notifyTarget?.channel ?? "telegram",
-              runtime,
-              accountId: notifyTarget?.accountId,
-              runCommand: rc,
-              messageThreadId: notifyTarget?.messageThreadId,
-            },
-          );
-        } catch (err) {
+        notify(
+          {
+            type: "issueComplete",
+            project: projectName,
+            issueId,
+            issueUrl: issue.web_url,
+            issueTitle: issue.title,
+            prUrl,
+          },
+          {
+            workspaceDir,
+            config: notifyConfig,
+            channelId: notifyTarget?.channelId,
+            channel: notifyTarget?.channel ?? "telegram",
+            runtime,
+            accountId: notifyTarget?.accountId,
+          },
+        ).catch((err) => {
           auditLog(workspaceDir, "pipeline_warning", { step: "issueCompleteNotify", issue: issueId, role, error: (err as Error).message ?? String(err) }).catch(() => {});
-        }
+        });
         break;
       case Action.REOPEN_ISSUE:
         await provider.reopenIssue(issueId);
@@ -340,31 +331,28 @@ export async function executeCompletion(opts: {
     const updated = await provider.getIssue(issueId);
     const routing = detectStepRouting(updated.labels, "review") as "human" | "agent" | null;
     if (routing === "human" || routing === "agent") {
-      try {
-        await notify(
-          {
-            type: "reviewNeeded",
-            project: projectName,
-            issueId,
-            issueUrl: updated.web_url,
-            issueTitle: updated.title,
-            routing,
-            prUrl,
-          },
-          {
-            workspaceDir,
-            config: notifyConfig,
-            channelId: notifyTarget?.channelId,
-            channel: notifyTarget?.channel ?? "telegram",
-            runtime,
-            accountId: notifyTarget?.accountId,
-            runCommand: rc,
-            messageThreadId: notifyTarget?.messageThreadId,
-          },
-        );
-      } catch (err) {
+      notify(
+        {
+          type: "reviewNeeded",
+          project: projectName,
+          issueId,
+          issueUrl: updated.web_url,
+          issueTitle: updated.title,
+          routing,
+          prUrl,
+        },
+        {
+          workspaceDir,
+          config: notifyConfig,
+          channelId: notifyTarget?.channelId,
+          channel: notifyTarget?.channel ?? "telegram",
+          runtime,
+          accountId: notifyTarget?.accountId,
+          messageThreadId: notifyTarget?.messageThreadId,
+        },
+      ).catch((err) => {
         auditLog(workspaceDir, "pipeline_warning", { step: "reviewNotify", issue: issueId, role, error: (err as Error).message ?? String(err) }).catch(() => {});
-      }
+      });
     }
   }
 


### PR DESCRIPTION
## Summary
- revert the premature merge of the #168 notification package from `devclaw-local-current`
- restore local truth to the pre-package state
- correct the release flow so the review branch can be tested live first

## Why
The branch-first process here is:
1. prepare the review/package branch
2. test that branch in the live environment
3. then continue the release process

PR #170 was merged into `devclaw-local-current` too early.
This rollback PR corrects that process mistake.

## Reverted merge
- merge commit: `59ecd44a8d1caabc3953de0b9b111ac44f87bbd9`
- original PR: #170

## Next step after this rollback
Switch the live environment to the review branch `review/168-telegram-completion-refining-notifications` and test that branch directly.
