### PR TITLE
docs: track local publication issue helper

### DIFF
--- a/dev/runbooks/developing-devclaw-with-openclaw.md
+++ b/dev/runbooks/developing-devclaw-with-openclaw.md
@@ -98,6 +98,14 @@ Do not promote code to DevClaw official without a local issue that covers the fu
 
 That issue is not just "prep". It owns the entire promotion workflow.
 
+For local upstream-publication tracking issues, use title format:
+
+- `UP: #<local-issue> <short topic>`
+
+When creating or renaming these local tracking issues from the repo, prefer:
+
+- `dev/scripts/upstream-publication-issue.sh`
+
 The promotion issue should document:
 
 - the exact local issue or fix being promoted

--- a/dev/scripts/upstream-publication-issue.sh
+++ b/dev/scripts/upstream-publication-issue.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Local helper for DevClaw upstream-publication tracking issues.
+
+Title format:
+  UP: #<local-issue> <short topic>
+
+Usage:
+  dev/scripts/upstream-publication-issue.sh title <local-issue> <short topic>
+  dev/scripts/upstream-publication-issue.sh create <local-issue> <short topic> [gh issue create args...]
+  dev/scripts/upstream-publication-issue.sh rename <tracking-issue> <local-issue> <short topic>
+
+Examples:
+  dev/scripts/upstream-publication-issue.sh title 117 no-PR developer operational tasks
+  dev/scripts/upstream-publication-issue.sh create 117 no-PR developer operational tasks --body-file /tmp/body.md
+  dev/scripts/upstream-publication-issue.sh rename 141 125/#130 silent-Refining fix family promotion prep
+
+Notes:
+- This is for local tracking in yaqub0r/devclaw, not upstream issue titles.
+- Additional arguments after create are passed through to gh issue create.
+EOF
+}
+
+if [ "$#" -lt 1 ]; then
+  usage
+  exit 1
+fi
+
+command="$1"
+shift
+
+build_title() {
+  local local_issue="$1"
+  shift
+  if [ "$#" -eq 0 ]; then
+    echo "error: short topic is required" >&2
+    exit 1
+  fi
+  printf 'UP: #%s %s\n' "$local_issue" "$*"
+}
+
+case "$command" in
+  title)
+    if [ "$#" -lt 2 ]; then
+      usage
+      exit 1
+    fi
+    build_title "$@"
+    ;;
+
+  create)
+    if [ "$#" -lt 2 ]; then
+      usage
+      exit 1
+    fi
+    local_issue="$1"
+    shift
+
+    topic_parts=()
+    passthrough=()
+    parsing_topic=1
+    for arg in "$@"; do
+      if [ "$parsing_topic" -eq 1 ] && [[ "$arg" == --* ]]; then
+        parsing_topic=0
+      fi
+      if [ "$parsing_topic" -eq 1 ]; then
+        topic_parts+=("$arg")
+      else
+        passthrough+=("$arg")
+      fi
+    done
+
+    if [ "${#topic_parts[@]}" -eq 0 ]; then
+      echo "error: short topic is required" >&2
+      exit 1
+    fi
+
+    title="$(build_title "$local_issue" "${topic_parts[@]}")"
+    gh issue create --title "$title" "${passthrough[@]}"
+    ;;
+
+  rename)
+    if [ "$#" -lt 3 ]; then
+      usage
+      exit 1
+    fi
+    tracking_issue="$1"
+    local_issue="$2"
+    shift 2
+    title="$(build_title "$local_issue" "$@")"
+    gh issue edit "$tracking_issue" --title "$title"
+    ;;
+
+  -h|--help|help)
+    usage
+    ;;
+
+  *)
+    echo "error: unknown command: $command" >&2
+    usage
+    exit 1
+    ;;
+esac


### PR DESCRIPTION
## Summary
- record the local `UP:` issue title convention in the dev runbook
- add the optional helper script for local publication-tracking issue title/create/rename flows
- intentionally land publication-guidance leftovers that were otherwise blocking a clean local-truth checkout

## Testing
- not run (docs/helper-script only)

## Issue
- refs #67