### PR TITLE
Add live orchestrator prompt loading

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ dist/
 !openclaw.plugin.json
 .openclaw
 node_modules
+.claude/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - **Critical:** work_finish now re-validates PR mergeable status during conflict resolution cycles, preventing infinite loops where developers claim "fixed" without pushing changes (#482, #480, #464, #483)
+- **Workspace root file ownership boundary** — Startup now updates only DevClaw-managed tagged sections inside `AGENTS.md`, `HEARTBEAT.md`, and `TOOLS.md`, preserving user content outside those blocks while keeping explicit reset flows able to rewrite full defaults (#88)
+- **Defaults loading in source/test runs** — Template resolution now finds `defaults/` correctly in both bundled and source layouts, restoring setup/workspace tests and local development flows
 
 ### Improved
 

--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ Then start onboarding by chatting with your agent in any channel:
 
 [Read more on onboarding &rarr;](#getting-started)
 
+For developing DevClaw while running it through OpenClaw, including a generic non-destructive smoke test, see [Developing DevClaw with OpenClaw](docs/devclaw-self-hosting.md).
+
 ---
 
 ## What it looks like

--- a/build.mjs
+++ b/build.mjs
@@ -6,8 +6,32 @@
  */
 import esbuild from "esbuild";
 import { readFileSync } from "node:fs";
+import { execSync } from "node:child_process";
 
 const pkg = JSON.parse(readFileSync("package.json", "utf-8"));
+
+function git(args) {
+  try {
+    return execSync(`git ${args}`, { stdio: ["ignore", "pipe", "ignore"] }).toString().trim();
+  } catch {
+    return null;
+  }
+}
+
+const commitSha = git("rev-parse HEAD");
+const shortCommitSha = git("rev-parse --short HEAD");
+const branch = git("rev-parse --abbrev-ref HEAD");
+const dirty = git("status --porcelain=v1") ? true : false;
+const buildTimestamp = new Date().toISOString();
+const buildProvenance = {
+  packageName: pkg.name,
+  packageVersion: pkg.version,
+  commitSha,
+  shortCommitSha,
+  branch,
+  dirty: commitSha ? dirty : null,
+  buildTimestamp,
+};
 
 await esbuild.build({
   entryPoints: ["index.ts"],
@@ -21,7 +45,9 @@ await esbuild.build({
   define: {
     __PLUGIN_VERSION__: JSON.stringify(pkg.version),
     __PACKAGE_NAME__: JSON.stringify(pkg.name),
+    __BUILD_PROVENANCE__: JSON.stringify(JSON.stringify(buildProvenance)),
   },
 });
 
 console.log(`Built dist/index.js (${pkg.name}@${pkg.version})`);
+console.log(`Embedded build provenance: ${JSON.stringify(buildProvenance)}`);

--- a/defaults/AGENTS.md
+++ b/defaults/AGENTS.md
@@ -135,7 +135,9 @@ If the test phase is enabled in workflow.yaml:
 
 ### Prompt Instructions
 
-Workers receive role-specific instructions appended to their task message. These are loaded from `devclaw/projects/<project-name>/prompts/<role>.md` in the workspace, falling back to `devclaw/prompts/<role>.md` if no project-specific file exists. `project_register` scaffolds these files automatically — edit them to customize worker behavior per project.
+Workers receive role-specific instructions appended to their task message. These are loaded from `devclaw/projects/<project-name>/prompts/<role>.md` in the workspace, falling back to `devclaw/prompts/<role>.md` if no project-specific file exists. `project_register` scaffolds the project override directory automatically.
+
+The main orchestrator session also supports live prompt layering. After the AGENTS.md baseline loads, DevClaw appends `devclaw/prompts/orchestrator.md`, then `devclaw/projects/<project-name>/prompts/orchestrator.md` when that project is known.
 
 ### Heartbeats
 

--- a/defaults/AGENTS.md
+++ b/defaults/AGENTS.md
@@ -35,8 +35,6 @@ You are a **development orchestrator** — a planner and dispatcher, not a coder
 
 **Always include issue URLs** in your responses when discussing tasks. Tool responses include an `announcement` field with properly formatted links — include it verbatim in your reply. The announcement already contains all relevant links; do **not** append separate URL lines on top of it.
 
-**Treat blocked developer updates as active follow-up.** When a developer reports `blocked`, do not just restate it and move on. First try to unblock it yourself if the blocker is actionable from orchestration.
-
 Examples:
 - "Picked up #42 for DEVELOPER (medior).\n[paste announcement here]" — announcement already has the link
 - "Created issue #42 about the login bug" — no URL at all (only acceptable when no announcement field)
@@ -132,28 +130,6 @@ If the test phase is enabled in workflow.yaml:
 - Tester "pass" → Done
 - Tester "fail" → "To Improve" → scheduler dispatches Developer
 - Tester "refine" / blocked → needs human input
-
-### Handling Blocked Developer Work
-
-When a developer reports `blocked`, treat it as an orchestration task, not a terminal status update.
-
-1. Check whether you can unblock it directly.
-2. If yes, do that first, then move the issue forward.
-3. If no, surface the blocker clearly with the smallest concrete operator action needed.
-
-**Blockers you should usually resolve yourself:**
-- clarifying requirements from existing context
-- fixing issue state or wrong workflow placement
-- creating or linking prerequisite issues
-- resolving obvious workflow mismatches
-- gathering a missing operator decision if you can get it immediately
-
-**Blockers that need operator input:**
-- product or scope decisions only the operator can make
-- conflicting requirements with no clear source of truth
-- external access, credentials, approvals, or environment changes you cannot perform
-
-Do not leave blocked work stalled when there is a reasonable orchestration path to unblock it.
 
 **Include the `announcement` verbatim** in your response — it already contains all relevant links. Do not append separate URL lines.
 

--- a/defaults/AGENTS.md
+++ b/defaults/AGENTS.md
@@ -35,6 +35,8 @@ You are a **development orchestrator** — a planner and dispatcher, not a coder
 
 **Always include issue URLs** in your responses when discussing tasks. Tool responses include an `announcement` field with properly formatted links — include it verbatim in your reply. The announcement already contains all relevant links; do **not** append separate URL lines on top of it.
 
+**Treat blocked developer updates as active follow-up.** When a developer reports `blocked`, do not just restate it and move on. First try to unblock it yourself if the blocker is actionable from orchestration.
+
 Examples:
 - "Picked up #42 for DEVELOPER (medior).\n[paste announcement here]" — announcement already has the link
 - "Created issue #42 about the login bug" — no URL at all (only acceptable when no announcement field)
@@ -130,6 +132,28 @@ If the test phase is enabled in workflow.yaml:
 - Tester "pass" → Done
 - Tester "fail" → "To Improve" → scheduler dispatches Developer
 - Tester "refine" / blocked → needs human input
+
+### Handling Blocked Developer Work
+
+When a developer reports `blocked`, treat it as an orchestration task, not a terminal status update.
+
+1. Check whether you can unblock it directly.
+2. If yes, do that first, then move the issue forward.
+3. If no, surface the blocker clearly with the smallest concrete operator action needed.
+
+**Blockers you should usually resolve yourself:**
+- clarifying requirements from existing context
+- fixing issue state or wrong workflow placement
+- creating or linking prerequisite issues
+- resolving obvious workflow mismatches
+- gathering a missing operator decision if you can get it immediately
+
+**Blockers that need operator input:**
+- product or scope decisions only the operator can make
+- conflicting requirements with no clear source of truth
+- external access, credentials, approvals, or environment changes you cannot perform
+
+Do not leave blocked work stalled when there is a reasonable orchestration path to unblock it.
 
 **Include the `announcement` verbatim** in your response — it already contains all relevant links. Do not append separate URL lines.
 

--- a/defaults/SOUL.md
+++ b/defaults/SOUL.md
@@ -12,6 +12,8 @@ You are a **development orchestrator** — you plan, prioritize, and dispatch. Y
 
 **Be resourceful.** Check status before asking. Read the issue before dispatching. Understand the codebase before planning. Come back with answers, not questions.
 
+**Be proactive with blockers.** If a developer reports `blocked`, first try to remove the blocker through orchestration. Only escalate when the blocker truly needs operator input.
+
 ## How You Work
 
 - You receive requests via chat (Telegram, WhatsApp, or web)

--- a/defaults/SOUL.md
+++ b/defaults/SOUL.md
@@ -12,8 +12,6 @@ You are a **development orchestrator** — you plan, prioritize, and dispatch. Y
 
 **Be resourceful.** Check status before asking. Read the issue before dispatching. Understand the codebase before planning. Come back with answers, not questions.
 
-**Be proactive with blockers.** If a developer reports `blocked`, first try to remove the blocker through orchestration. Only escalate when the blocker truly needs operator input.
-
 ## How You Work
 
 - You receive requests via chat (Telegram, WhatsApp, or web)

--- a/defaults/devclaw/prompts/orchestrator.md
+++ b/defaults/devclaw/prompts/orchestrator.md
@@ -1,0 +1,13 @@
+# Orchestrator Prompt Override
+
+This file is loaded into the main orchestrator session after the AGENTS.md baseline.
+
+Precedence inside the live orchestrator prompt stack:
+1. Runtime and system rules
+2. AGENTS.md baseline
+3. `devclaw/prompts/orchestrator.md`
+4. `devclaw/projects/<project>/prompts/orchestrator.md`
+5. Current chat, issue, and task context
+
+Use this file for workspace-wide orchestration policy that should not live in AGENTS.md.
+Examples: routing preferences, issue triage rules, notification style, and project management conventions.

--- a/dev/README.md
+++ b/dev/README.md
@@ -1,0 +1,39 @@
+# DevClaw developer tree
+
+This `dev/` tree is the canonical in-repo home for developer-only material.
+It is versioned with the repository so developer guidance and regression artifacts travel with the codebase, but it is not intended to be part of the end-user release payload.
+The tree should remain in git, while `package.json.files` should continue to exclude `dev/` so these artifacts are not shipped by default.
+
+## Required layout
+
+The intended top-level artifact layout under `/dev` is:
+
+- `dev/README.md`, the top-level guide to the developer-only tree
+- `dev/runbooks/`, for developer and operator runbooks, including self-hosting guidance
+- `dev/regression/tests/`, for executable regression coverage
+- `dev/regression/issues/`, for issue-linked notes, bug summaries, and validation rationale
+- `dev/regression/fixtures/`, or equivalent supporting fixture/helper material when tests need stable inputs
+
+At minimum, the developer tree should contain:
+
+- `dev/README.md`, the top-level guide to the developer-only tree
+- `dev/runbooks/`, for developer and operator runbooks
+- self-hosting documentation under `dev/runbooks/`
+- `dev/regression/tests/`, for executable regression coverage
+- `dev/regression/issues/`, for issue-linked notes, bug summaries, and validation rationale
+- `dev/regression/fixtures/`, or equivalent supporting fixture/helper material when tests need stable inputs
+
+Release-user documentation stays under `docs/`.
+Developer-only runbooks, issue-linked regression notes, and release-hardening checks belong under `dev/`.
+
+## Definition of Done for release-relevant fixes
+
+Do not consider an issue done until the regression story is addressed.
+
+When a bug fix is release-relevant or likely to regress, the issue is not done until the regression story is addressed:
+
+1. add or update executable regression coverage under `dev/regression/tests/`
+2. document the bug summary, triggering conditions, automated coverage, and any manual validation notes under `dev/regression/issues/`
+3. add fixtures or helpers under `dev/regression/fixtures/` when the regression needs stable inputs
+
+If a fix does not need a regression artifact, the developer handling the issue should be able to explain why.

--- a/dev/regression/fixtures/README.md
+++ b/dev/regression/fixtures/README.md
@@ -1,0 +1,3 @@
+# Regression fixtures
+
+Place sample configs, issue payloads, or tracker responses here when a regression test needs stable input data.

--- a/dev/regression/issues/dev-tree-cleanup-105.md
+++ b/dev/regression/issues/dev-tree-cleanup-105.md
@@ -1,0 +1,29 @@
+# Regression note: repo-local developer tree cleanup, issue #105
+
+- Related issue: #105
+- Scope: preserve repo-local developer guidance under `dev/` while keeping `dev/` out of the published package payload
+
+## Change summary
+
+This cleanup keeps the self-hosting runbook under `dev/runbooks/`, makes the `/dev` layout and Definition of Done expectations explicit in `dev/README.md`, and preserves the packaging boundary that keeps `dev/` versioned in git but excluded from `package.json.files`.
+
+## Triggering conditions
+
+- documentation or cleanup work moves developer-facing material out of release-user docs
+- a packaging change risks shipping the repo-local `dev/` tree in the published package
+- follow-up cleanup needs to confirm where regression artifacts and issue-linked notes belong
+
+## Automated coverage
+
+The repo checks for this cleanup are:
+
+1. `npm run regression:release`, to confirm the `dev/` tree layout, preserved runbook sections, DoD guidance, and regression script hook are all present
+2. `npm pack --dry-run`, to confirm the published package payload still excludes `dev/` while the tree remains versioned in git
+
+## Manual validation notes
+
+Manual validation should confirm that:
+
+- `dev/runbooks/developing-devclaw-with-openclaw.md` still contains the preserved self-hosting sections
+- `dev/README.md` explains the intended `/dev` layout and DoD expectations
+- `package.json.files` does not include `dev/`

--- a/dev/regression/tests/dev-tree-cleanup-105.sh
+++ b/dev/regression/tests/dev-tree-cleanup-105.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "$0")/../../.." && pwd)"
+cd "$repo_root"
+
+python3 - <<'PY'
+from pathlib import Path
+import json
+
+runbook = Path('dev/runbooks/developing-devclaw-with-openclaw.md').read_text()
+readme = Path('dev/README.md').read_text()
+pkg = json.loads(Path('package.json').read_text())
+
+for needle in [
+    '## Stronger proof for linked local installs',
+    '## Generic smoke test for a running environment',
+    '## Tracker routing verification for fork-based installs',
+]:
+    assert needle in runbook, f'missing preserved runbook section: {needle}'
+
+for needle in [
+    'Definition of Done',
+    'dev/regression/tests/',
+    'dev/regression/issues/',
+    'The tree should remain in git',
+    'exclude `dev/`',
+]:
+    assert needle in readme, f'missing dev README guidance: {needle}'
+
+files = pkg.get('files', [])
+assert 'dev/' not in files and 'dev' not in files, 'package.json.files should exclude dev/'
+assert pkg.get('scripts', {}).get('regression:release') == 'bash dev/regression/tests/run-all.sh', 'regression:release script missing or changed'
+
+print('dev tree cleanup regression checks passed')
+PY

--- a/dev/regression/tests/run-all.sh
+++ b/dev/regression/tests/run-all.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+root="$(cd "$(dirname "$0")" && pwd)"
+"$root/dev-tree-cleanup-105.sh"
+
+echo "All release regression checks passed"

--- a/dev/runbooks/developing-devclaw-with-openclaw.md
+++ b/dev/runbooks/developing-devclaw-with-openclaw.md
@@ -107,7 +107,8 @@ The promotion issue should document:
 - the target `pr/<issue-number>-<short-description>` branch name
 - the fork PR that will be opened against `devclaw-local-current` for human acceptance and testing
 - the compare or diff URL for the later DevClaw official PR
-- the proposed body for the later DevClaw official PR
+- after the operator reports testing is complete, the proposed title and body for the later DevClaw official PR
+- the upstream DevClaw issue link that the later PR should close or reference
 - any remaining human-only steps
 
 Use issue `#141` only as a rough shape reference, not as naming guidance. Avoid "start upstream promotion prep" style issue framing. The issue should describe the whole promotion, not just an initial prep stage.
@@ -129,8 +130,16 @@ The agent should **not** open the upstream DevClaw official PR itself.
 Instead, as part of the operator handoff, the agent should prepare:
 
 - the compare or diff URL for the `pr/*` branch against upstream `main`
-- the proposed PR title
-- the proposed PR body
+- after the operator confirms testing is complete, the proposed PR title
+- after the operator confirms testing is complete, the proposed PR body
+
+Before writing that final upstream PR title/body into the promotion issue, the orchestrator should:
+
+- check whether the fix already corresponds to an existing issue on `laurentenhoor/devclaw`
+- if an existing upstream issue exists, reference it in the proposed PR body and add or refresh an issue comment when the fix handoff should be visible there
+- if no upstream issue exists, open a new issue on `laurentenhoor/devclaw` that describes the problem as a discrete standalone record, without assuming the reader already knows the history
+- after opening that new issue, add a follow-up issue comment pointing to the prepared fix branch or compare URL when appropriate
+- include the resulting upstream issue link in the proposed PR body
 
 So the rule is:
 
@@ -139,12 +148,15 @@ So the rule is:
 
 After the relevant PR steps have succeeded, the orchestrator should not stop silently at "package prepared" or "PR merged".
 
-The orchestrator should:
+Before the operator reports testing complete, the orchestrator should limit the promotion issue handoff to branch heads, PR URLs, validation evidence, and the compare URL. Do not write the final upstream PR title/body yet.
+
+After the operator reports testing complete, the orchestrator should:
 
 - inform the operator of the concrete result
 - include the relevant PR URLs, merge or success status, and the exact branch or commit that is now considered local truth
 - state whether `devclaw-local-current` is now the validated lane to install from
 - explicitly offer to install or reload `devclaw-local-current` into the live self-hosted environment
+- then complete the upstream issue linkage step and write the final proposed upstream PR title/body into the promotion issue
 
 This handoff gives the operator a ready-to-submit upstream PR package while keeping only the final upstream PR opening step under operator control, while also making the live-install follow-up explicit instead of implicit.
 
@@ -164,9 +176,11 @@ The required rollback flow is:
 5. revert the bad merge or bad commit on that rollback branch, rather than silently rewriting history on `devclaw-local-current`
 6. push the rollback `review/*` branch and open a fork PR into `devclaw-local-current`
 7. merge the rollback PR, then rebuild, reinstall, restart, and verify the live self-hosted environment from the reverted `devclaw-local-current`
-8. after the rollback is safely landed and verified, delete the stale `review/*` and `pr/*` branches that represented the failed promotion
-9. only then recreate fresh development, review, and export branches for the corrected fix if the work will continue
-10. do not create a replacement `review/*` PR for that same family until step 7 has succeeded, unless the operator explicitly authorizes a different sequencing with an unlock code
+8. after the rollback is safely landed and verified, clean up the old failed-release artifacts so they no longer look current or reusable
+9. that cleanup should include, as applicable, stale local branches, stale remote branches, stale local PR/export worktrees, and stale temp packaging directories tied to the failed promotion family
+10. only after that cleanup, delete or retire the stale `review/*` and `pr/*` release branches that represented the failed promotion
+11. only then recreate fresh development, review, and export branches for the corrected fix if the work will continue
+12. do not create a replacement `review/*` PR for that same family until step 7 has succeeded, unless the operator explicitly authorizes a different sequencing with an unlock code
 
 Normal rollback should be done as a visible revert PR into `devclaw-local-current`.
 Do not force-reset, force-push, or rewrite local-truth history unless the operator explicitly authorizes that divergence with an unlock code.

--- a/dev/runbooks/developing-devclaw-with-openclaw.md
+++ b/dev/runbooks/developing-devclaw-with-openclaw.md
@@ -1,54 +1,85 @@
 # Developing DevClaw with OpenClaw
 
-This guide covers the generic workflow for developing DevClaw while running DevClaw through OpenClaw.
+This runbook is the local-first operator policy for working on DevClaw while DevClaw is your active orchestrator.
+It lives under `/dev` because these rules are first-class local operating docs and must be preserved on `devclaw-local-current`.
 
-It is intentionally environment-agnostic. If your machine or fork has local policy, branch names, or operator habits layered on top, keep those in local-only docs and link back here.
-This runbook lives under `dev/runbooks/` because it is self-hosting and developer-facing guidance, not release-user documentation.
+## Local-first branch policy
 
-## What this guide is for
+Treat these branch roles as the working contract:
 
-Use this when you are:
+- `devclaw-local-current`: local truth and day-to-day working lane
+- `devclaw-local-stable`: local fallback lane when `devclaw-local-current` is too noisy or risky
+- `issue/*`: local implementation branches for scoped work
+- `pr/*`: export branches prepared for upstream review
 
-- editing DevClaw source while DevClaw is your active orchestrator
-- switching the live plugin source between branches or worktrees
-- validating that a branch change actually became the runtime source
-- avoiding duplicate plugin-source loads during local development
+Upstream `main` is a reference point and export target. It is not the normal day-to-day base for local work.
 
-## Core idea
+## Operating model
+
+1. Keep local docs and operator runbooks on `devclaw-local-current`.
+2. Start implementation from `devclaw-local-current` into an `issue/*` branch when you need isolated task work.
+3. Land validated work back onto `devclaw-local-current` so local truth stays complete.
+4. When work needs to go upstream, export it onto a matching `pr/*` branch.
+5. Preserve the `/dev/` documentation changes on `devclaw-local-current` even when the upstream export omits local-only material.
+
+## Export policy
+
+Use `pr/*` for upstream-facing export branches, not `contrib/*`.
+
+Typical flow:
+
+1. implement and validate locally
+2. land the accepted result on `devclaw-local-current`
+3. create or refresh the corresponding `pr/*` branch for upstream review
+4. push the `pr/*` branch to the fork remote
+
+Upstream review material should be prepared from `pr/*`, while `devclaw-local-current` remains the complete local operating branch.
+
+## Traceability rule
+
+When exporting work upstream, keep matching exported commits on `devclaw-local-current`.
+
+That means:
+
+- the code or doc change sent upstream should also exist on `devclaw-local-current`
+- if the export needs cleanup, splitting, or local-doc omission, keep a clearly corresponding commit history or note the mapping in the handoff
+- do not treat the `pr/*` branch as the only canonical copy of the work
+
+The point of the export is to publish local truth, not replace it.
+
+## PR handoff policy
+
+The agent should not open the upstream PR itself.
+
+Instead, as part of the operator handoff, the agent should prepare:
+
+- the compare or diff URL for the `pr/*` branch against upstream `main`
+- the proposed PR title
+- the proposed PR body
+
+This handoff gives the operator a ready-to-submit upstream PR package while keeping the actual PR opening step under operator control.
+
+## Live-source safety checks
 
 A branch does not become live because you checked it out.
-
 A branch becomes live when OpenClaw is loading the DevClaw plugin from that checkout or worktree.
 
-That means branch switching for DevClaw development is really a **plugin source switch** followed by a **runtime verification** step.
+Before trusting a branch switch:
 
-## Recommended branch roles
+```bash
+openclaw plugins inspect devclaw
+openclaw gateway status
+git -C <live-source-root> rev-parse --abbrev-ref HEAD
+git -C <live-source-root> rev-parse HEAD
+```
 
-These are roles, not mandatory branch names:
+Use these checks to confirm:
 
-- **clean integration branch**: the branch that tracks the normal upstream line
-- **working branch**: a feature or fix branch carrying in-progress changes
-- **fallback branch**: an optional known-good branch you can switch back to quickly
-- **local docs branch**: an optional branch for operator runbooks that are not meant for upstream
+- which path is actually live
+- which branch that path is on
+- which exact commit is running
 
-Use names that fit your repo. The workflow matters more than the naming.
-
-## Safe live-switch procedure
-
-When changing the live DevClaw source during development:
-
-1. Choose the target checkout or worktree.
-2. Build that target source tree.
-3. Confirm the built artifact exists.
-4. Make sure only one DevClaw plugin source is active.
-5. Point OpenClaw at the intended source path.
-6. Restart the gateway.
-7. Verify the loaded plugin path.
-8. Verify the exact live git commit.
-
-## Build before switching
-
-Before switching live, verify the target source tree has a built artifact:
+## Build before switching live
 
 ```bash
 test -f <target-source-root>/dist/index.js && echo built || echo missing-dist
@@ -56,154 +87,11 @@ test -f <target-source-root>/dist/index.js && echo built || echo missing-dist
 
 If `dist/index.js` is missing, build first and do not switch the live source yet.
 
-## Verify the live source path
+## Duplicate-source warning
 
-The source of truth is the live plugin inspection output, not memory and not the checkout you happen to be editing.
+Do not trust a switch if DevClaw may be loading from more than one source, for example:
 
-```bash
-openclaw plugins inspect devclaw
-openclaw gateway status
-```
+- `~/.openclaw/extensions/devclaw`
+- a path or worktree entry in `plugins.load.paths[]`
 
-Use `openclaw plugins inspect devclaw` to answer:
-
-- what path is actually live
-- which plugin version is loaded
-
-Important distinction:
-
-- `inspect` tells you **what path is live**
-- git tells you **what commit that path contains**
-
-## Verify the exact live commit
-
-Once you know the live source path, resolve that path back to the checkout or worktree root and verify the commit directly:
-
-```bash
-openclaw plugins inspect devclaw
-git -C <live-source-root> rev-parse HEAD
-```
-
-Do not assume that the installed extension directory or your current shell checkout is the live commit.
-
-## Stronger proof for linked local installs
-
-If you are using a linked local install and want stronger proof that the live plugin really comes from the intended worktree, verify both the install path target and the branch name:
-
-```bash
-openclaw plugins inspect devclaw
-readlink -f ~/.openclaw/extensions/devclaw
-git -C <intended-worktree> rev-parse --abbrev-ref HEAD
-git -C <intended-worktree> rev-parse HEAD
-```
-
-This gives you four checks:
-
-- the live plugin id and loaded source
-- the real filesystem target behind the installed extension path
-- the branch name of the intended worktree
-- the exact commit of that worktree
-
-For example, if you intend to run from a `devclaw-local-stable` worktree, these checks should agree on both the path and the branch identity before you treat the switch as complete.
-
-## Avoid duplicate plugin-source collisions
-
-A common failure mode is loading DevClaw from more than one place at once, for example:
-
-- an installed copy under `~/.openclaw/extensions/devclaw`
-- and a path/worktree load via `plugins.load.paths[]`
-
-If both are in play, the gateway may load a different source than the one you intended.
-
-If startup logs mention duplicate plugin ids or the runtime path does not match your expected worktree, stop and clean up the duplicate before trusting the switch.
-
-## When a live switch failed
-
-Treat the switch as failed if any of the following happen:
-
-- `openclaw plugins inspect devclaw` reports the wrong source path
-- the plugin is missing after restart
-- startup logs show duplicate plugin warnings
-- the target source tree has no `dist/index.js`
-- the gateway is still loading an older installed copy
-
-In that case:
-
-1. verify the target build artifact exists
-2. inspect the live plugin path again
-3. remove or disable competing DevClaw plugin sources
-4. restart and verify again
-
-## Generic smoke test for a running environment
-
-Use this when you want to verify a local DevClaw install in an already-running environment without creating new projects or tasks.
-
-## Tracker routing verification for fork-based installs
-
-If your local checkout has both a fork and an upstream remote, do not trust ambient GitHub CLI repo inference.
-
-Before relying on issue-creation flows, verify both the configured tracker target and the checkout's ambient `gh` target:
-
-```bash
-python3 - <<'PY'
-import json
-p=json.load(open('devclaw/projects.json'))['projects']['devclaw']
-print(p['repoRemote'])
-PY
-git -C <repo-or-worktree> remote -v
-gh repo view --json nameWithOwner --jq .nameWithOwner
-```
-
-Expected safety rule:
-
-- DevClaw issue/task tooling must route to the repository configured in `projects.json`
-- it must not drift to the repo that `gh` happens to infer from the checkout context
-
-When validating a fix for tracker-routing bugs, record both:
-
-- a pre-change proof showing config target versus ambient `gh` target
-- a post-change proof showing issue/task creation calls explicitly target the configured repo
-
-Read-only checks:
-
-```bash
-openclaw plugins inspect devclaw
-openclaw plugins list
-openclaw gateway status
-openclaw agent --agent <agent-id> --message 'Call project_status with channelId "<channel-id>" and reply with the result only.' --json
-openclaw agent --agent <agent-id> --message 'Call tasks_status and reply with the result only.' --json
-openclaw agent --agent <agent-id> --message 'Call channel_list and reply with the result only.' --json
-```
-
-What this verifies:
-
-- the plugin is loaded
-- the gateway is healthy
-- the live agent can read local project state
-- the live agent can read tracker-backed task state
-- channel bindings are visible
-
-Expected result note:
-
-- in an unbound DM or admin session, `project_status` and `tasks_status` may correctly return `No project found` for that channel
-- treat that as a passing result for this smoke test unless you were specifically testing a known project-bound chat
-
-Avoid using project-creating or task-creating commands for smoke tests in a shared live environment unless you also have an explicit cleanup plan.
-
-## Keep generic guidance separate from local policy
-
-Generic repo docs should cover:
-
-- the branch/worktree switching model
-- build and verification steps
-- duplicate-source failure modes
-- how to reason about live source versus checked-out source
-
-Local-only docs should cover:
-
-- branch names used on one machine or fork
-- preferred fallback lanes
-- machine-specific paths
-- personal or operator-specific workflow habits
-
-That separation keeps the main docs useful in any environment while still allowing strong local runbooks.
+If the runtime path is wrong or duplicate plugin ids appear in logs, clean that up before continuing.

--- a/dev/runbooks/developing-devclaw-with-openclaw.md
+++ b/dev/runbooks/developing-devclaw-with-openclaw.md
@@ -1,0 +1,209 @@
+# Developing DevClaw with OpenClaw
+
+This guide covers the generic workflow for developing DevClaw while running DevClaw through OpenClaw.
+
+It is intentionally environment-agnostic. If your machine or fork has local policy, branch names, or operator habits layered on top, keep those in local-only docs and link back here.
+This runbook lives under `dev/runbooks/` because it is self-hosting and developer-facing guidance, not release-user documentation.
+
+## What this guide is for
+
+Use this when you are:
+
+- editing DevClaw source while DevClaw is your active orchestrator
+- switching the live plugin source between branches or worktrees
+- validating that a branch change actually became the runtime source
+- avoiding duplicate plugin-source loads during local development
+
+## Core idea
+
+A branch does not become live because you checked it out.
+
+A branch becomes live when OpenClaw is loading the DevClaw plugin from that checkout or worktree.
+
+That means branch switching for DevClaw development is really a **plugin source switch** followed by a **runtime verification** step.
+
+## Recommended branch roles
+
+These are roles, not mandatory branch names:
+
+- **clean integration branch**: the branch that tracks the normal upstream line
+- **working branch**: a feature or fix branch carrying in-progress changes
+- **fallback branch**: an optional known-good branch you can switch back to quickly
+- **local docs branch**: an optional branch for operator runbooks that are not meant for upstream
+
+Use names that fit your repo. The workflow matters more than the naming.
+
+## Safe live-switch procedure
+
+When changing the live DevClaw source during development:
+
+1. Choose the target checkout or worktree.
+2. Build that target source tree.
+3. Confirm the built artifact exists.
+4. Make sure only one DevClaw plugin source is active.
+5. Point OpenClaw at the intended source path.
+6. Restart the gateway.
+7. Verify the loaded plugin path.
+8. Verify the exact live git commit.
+
+## Build before switching
+
+Before switching live, verify the target source tree has a built artifact:
+
+```bash
+test -f <target-source-root>/dist/index.js && echo built || echo missing-dist
+```
+
+If `dist/index.js` is missing, build first and do not switch the live source yet.
+
+## Verify the live source path
+
+The source of truth is the live plugin inspection output, not memory and not the checkout you happen to be editing.
+
+```bash
+openclaw plugins inspect devclaw
+openclaw gateway status
+```
+
+Use `openclaw plugins inspect devclaw` to answer:
+
+- what path is actually live
+- which plugin version is loaded
+
+Important distinction:
+
+- `inspect` tells you **what path is live**
+- git tells you **what commit that path contains**
+
+## Verify the exact live commit
+
+Once you know the live source path, resolve that path back to the checkout or worktree root and verify the commit directly:
+
+```bash
+openclaw plugins inspect devclaw
+git -C <live-source-root> rev-parse HEAD
+```
+
+Do not assume that the installed extension directory or your current shell checkout is the live commit.
+
+## Stronger proof for linked local installs
+
+If you are using a linked local install and want stronger proof that the live plugin really comes from the intended worktree, verify both the install path target and the branch name:
+
+```bash
+openclaw plugins inspect devclaw
+readlink -f ~/.openclaw/extensions/devclaw
+git -C <intended-worktree> rev-parse --abbrev-ref HEAD
+git -C <intended-worktree> rev-parse HEAD
+```
+
+This gives you four checks:
+
+- the live plugin id and loaded source
+- the real filesystem target behind the installed extension path
+- the branch name of the intended worktree
+- the exact commit of that worktree
+
+For example, if you intend to run from a `devclaw-local-stable` worktree, these checks should agree on both the path and the branch identity before you treat the switch as complete.
+
+## Avoid duplicate plugin-source collisions
+
+A common failure mode is loading DevClaw from more than one place at once, for example:
+
+- an installed copy under `~/.openclaw/extensions/devclaw`
+- and a path/worktree load via `plugins.load.paths[]`
+
+If both are in play, the gateway may load a different source than the one you intended.
+
+If startup logs mention duplicate plugin ids or the runtime path does not match your expected worktree, stop and clean up the duplicate before trusting the switch.
+
+## When a live switch failed
+
+Treat the switch as failed if any of the following happen:
+
+- `openclaw plugins inspect devclaw` reports the wrong source path
+- the plugin is missing after restart
+- startup logs show duplicate plugin warnings
+- the target source tree has no `dist/index.js`
+- the gateway is still loading an older installed copy
+
+In that case:
+
+1. verify the target build artifact exists
+2. inspect the live plugin path again
+3. remove or disable competing DevClaw plugin sources
+4. restart and verify again
+
+## Generic smoke test for a running environment
+
+Use this when you want to verify a local DevClaw install in an already-running environment without creating new projects or tasks.
+
+## Tracker routing verification for fork-based installs
+
+If your local checkout has both a fork and an upstream remote, do not trust ambient GitHub CLI repo inference.
+
+Before relying on issue-creation flows, verify both the configured tracker target and the checkout's ambient `gh` target:
+
+```bash
+python3 - <<'PY'
+import json
+p=json.load(open('devclaw/projects.json'))['projects']['devclaw']
+print(p['repoRemote'])
+PY
+git -C <repo-or-worktree> remote -v
+gh repo view --json nameWithOwner --jq .nameWithOwner
+```
+
+Expected safety rule:
+
+- DevClaw issue/task tooling must route to the repository configured in `projects.json`
+- it must not drift to the repo that `gh` happens to infer from the checkout context
+
+When validating a fix for tracker-routing bugs, record both:
+
+- a pre-change proof showing config target versus ambient `gh` target
+- a post-change proof showing issue/task creation calls explicitly target the configured repo
+
+Read-only checks:
+
+```bash
+openclaw plugins inspect devclaw
+openclaw plugins list
+openclaw gateway status
+openclaw agent --agent <agent-id> --message 'Call project_status with channelId "<channel-id>" and reply with the result only.' --json
+openclaw agent --agent <agent-id> --message 'Call tasks_status and reply with the result only.' --json
+openclaw agent --agent <agent-id> --message 'Call channel_list and reply with the result only.' --json
+```
+
+What this verifies:
+
+- the plugin is loaded
+- the gateway is healthy
+- the live agent can read local project state
+- the live agent can read tracker-backed task state
+- channel bindings are visible
+
+Expected result note:
+
+- in an unbound DM or admin session, `project_status` and `tasks_status` may correctly return `No project found` for that channel
+- treat that as a passing result for this smoke test unless you were specifically testing a known project-bound chat
+
+Avoid using project-creating or task-creating commands for smoke tests in a shared live environment unless you also have an explicit cleanup plan.
+
+## Keep generic guidance separate from local policy
+
+Generic repo docs should cover:
+
+- the branch/worktree switching model
+- build and verification steps
+- duplicate-source failure modes
+- how to reason about live source versus checked-out source
+
+Local-only docs should cover:
+
+- branch names used on one machine or fork
+- preferred fallback lanes
+- machine-specific paths
+- personal or operator-specific workflow habits
+
+That separation keeps the main docs useful in any environment while still allowing strong local runbooks.

--- a/dev/runbooks/developing-devclaw-with-openclaw.md
+++ b/dev/runbooks/developing-devclaw-with-openclaw.md
@@ -160,6 +160,8 @@ After the operator reports testing complete, the orchestrator should:
 
 After the operator opens the upstream DevClaw official PR, the orchestrator should keep tracking on the local promotion issue until that upstream PR is resolved.
 
+At that point, the orchestrator should also create or refresh a persistent watch, such as a daily cron job, for that specific upstream PR so it does not get forgotten while waiting on review or merge.
+
 That ongoing tracking should include:
 
 - the upstream PR URL
@@ -167,6 +169,15 @@ That ongoing tracking should include:
 - any linked upstream issue comments or references that matter to the promotion record
 - exact export-branch or commit changes if the `pr/*` branch is refreshed
 - whether any local-truth or live-install follow-up happened in response to upstream review
+- the identity of the active scheduled watch responsible for follow-up
+
+If the promotion enters demotion or rollback flow while a watch exists for that upstream PR, the orchestrator should explicitly review that watch.
+
+Depending on the situation, the orchestrator should:
+
+- remove the watch if the upstream PR is no longer the active release vehicle
+- refresh or retarget the watch if the promotion issue or upstream PR has changed
+- record that watch change on the local promotion or release-tracking issue
 
 When the upstream PR is fully resolved, the orchestrator should finish the release cleanup on the local side.
 
@@ -176,8 +187,9 @@ That cleanup should include, as applicable:
 - deleting no-longer-needed local packaging artifacts and temp directories
 - deleting no-longer-needed `pr/*` branches after the upstream resolution is complete
 - deleting any other release-only local artifacts that no longer serve an active tracking purpose
+- removing the scheduled watch that was tracking the resolved upstream PR
 
-Use a persistent scheduled follow-up, such as a daily cron job, so opened upstream PRs do not get forgotten while waiting on review or merge.
+Use a persistent scheduled follow-up, such as a daily cron job, for each active upstream PR watch, and remove that watch when it is no longer needed.
 
 This handoff gives the operator a ready-to-submit upstream PR package while keeping only the final upstream PR opening step under operator control, while also making the live-install follow-up explicit instead of implicit.
 
@@ -198,10 +210,11 @@ The required rollback flow is:
 6. push the rollback `review/*` branch and open a fork PR into `devclaw-local-current`
 7. merge the rollback PR, then rebuild, reinstall, restart, and verify the live self-hosted environment from the reverted `devclaw-local-current`
 8. after the rollback is safely landed and verified, clean up the old failed-release artifacts so they no longer look current or reusable
-9. that cleanup should include, as applicable, stale local branches, stale remote branches, stale local PR/export worktrees, and stale temp packaging directories tied to the failed promotion family
-10. only after that cleanup, delete or retire the stale `review/*` and `pr/*` release branches that represented the failed promotion
-11. only then recreate fresh development, review, and export branches for the corrected fix if the work will continue
-12. do not create a replacement `review/*` PR for that same family until step 7 has succeeded, unless the operator explicitly authorizes a different sequencing with an unlock code
+9. that cleanup should include, as applicable, stale local branches, stale remote branches, stale local PR/export worktrees, stale temp packaging directories tied to the failed promotion family, and any scheduled upstream-PR watch that is no longer valid for the demoted release vehicle
+10. if a scheduled watch is still needed because the promotion is being rerun under a new upstream PR or tracking issue, recreate or retarget the watch and record that change on the local promotion or release-tracking issue
+11. only after that cleanup, delete or retire the stale `review/*` and `pr/*` release branches that represented the failed promotion
+12. only then recreate fresh development, review, and export branches for the corrected fix if the work will continue
+13. do not create a replacement `review/*` PR for that same family until step 7 has succeeded, unless the operator explicitly authorizes a different sequencing with an unlock code
 
 Normal rollback should be done as a visible revert PR into `devclaw-local-current`.
 Do not force-reset, force-push, or rewrite local-truth history unless the operator explicitly authorizes that divergence with an unlock code.

--- a/dev/runbooks/developing-devclaw-with-openclaw.md
+++ b/dev/runbooks/developing-devclaw-with-openclaw.md
@@ -10,6 +10,7 @@ Treat these branch roles as the working contract:
 - `devclaw-local-current`: local truth and day-to-day working lane
 - `devclaw-local-stable`: local fallback lane when `devclaw-local-current` is too noisy or risky
 - `issue/*`: local implementation branches for scoped work
+- `review/*`: local review branches opened against `devclaw-local-current`
 - `pr/*`: export branches prepared for upstream review
 
 Upstream `main` is a reference point and export target. It is not the normal day-to-day base for local work.
@@ -35,10 +36,11 @@ If the runbook itself needs to change, update it on `devclaw-local-current` and 
 
 ## Export policy
 
-Use `pr/*` for upstream-facing export branches, not `contrib/*`.
+Use `review/*` for local-review branches into `devclaw-local-current` and `pr/*` for upstream-facing export branches. Do not use `contrib/*`.
 
-The required export branch naming convention is:
+The required branch naming conventions are:
 
+- `review/<issue-number>-<short-description>`
 - `pr/<issue-number>-<short-description>`
 
 Where:
@@ -49,12 +51,15 @@ Where:
 Typical flow:
 
 1. implement and validate locally
-2. land the accepted result on `devclaw-local-current`
-3. open or update the local promotion issue that owns the full upstream-promotion workflow
-4. create or refresh the corresponding `pr/<issue-number>-<short-description>` branch for upstream review
-5. push the `pr/*` branch to the fork remote
-6. open the fork PR needed for human review and testing against `devclaw-local-current`
-7. after that review/test step, prepare the final compare/diff URL and PR body for DevClaw official
+2. open or update the local promotion issue that owns the full upstream-promotion workflow
+3. create or refresh `review/<issue-number>-<short-description>` from `devclaw-local-current`
+4. apply the exact accepted fix onto the `review/*` branch
+5. push the `review/*` branch to the fork remote
+6. open the fork PR from `review/*` into `devclaw-local-current` for human review, merge, and testing
+7. after the change is merged and validated on `devclaw-local-current`, create or refresh `pr/<issue-number>-<short-description>` from `upstream/main`
+8. apply the same upstreamable commit set onto the `pr/*` branch
+9. push the `pr/*` branch to the fork remote
+10. prepare the final compare/diff URL and PR body for DevClaw official
 
 Upstream review material should be prepared from `pr/*`, while `devclaw-local-current` remains the complete local operating branch.
 
@@ -81,6 +86,7 @@ The promotion issue should document:
 - the exact local issue or fix being promoted
 - the source branch or branches and exact commits
 - any prerequisite slices that must go upstream together
+- the target `review/<issue-number>-<short-description>` branch name
 - the target `pr/<issue-number>-<short-description>` branch name
 - the fork PR that will be opened against `devclaw-local-current` for human acceptance and testing
 - the compare or diff URL for the later DevClaw official PR
@@ -101,7 +107,7 @@ Instead, as part of the operator handoff, the agent should prepare:
 - the proposed PR title
 - the proposed PR body
 
-Before that final upstream handoff, the agent should also have opened or refreshed the fork PR into `devclaw-local-current` so the human can review, merge, and test the change on the local-truth lane first.
+Before that final upstream handoff, the agent should also have opened or refreshed the fork PR from `review/<issue-number>-<short-description>` into `devclaw-local-current` so the human can review, merge, and test the change on the local-truth lane first.
 
 This handoff gives the operator a ready-to-submit upstream PR package while keeping the actual upstream PR opening step under operator control.
 

--- a/dev/runbooks/developing-devclaw-with-openclaw.md
+++ b/dev/runbooks/developing-devclaw-with-openclaw.md
@@ -55,13 +55,30 @@ Typical flow:
 3. create or refresh `review/<issue-number>-<short-description>` from `devclaw-local-current`
 4. apply the exact accepted fix onto the `review/*` branch
 5. push the `review/*` branch to the fork remote
-6. open the fork PR from `review/*` into `devclaw-local-current` for human review, merge, and testing
-7. after the change is merged and validated on `devclaw-local-current`, create or refresh `pr/<issue-number>-<short-description>` from `upstream/main`
-8. apply the same upstreamable commit set onto the `pr/*` branch
-9. push the `pr/*` branch to the fork remote
-10. prepare the final compare/diff URL and PR body for DevClaw official
+6. autonomously open or refresh the fork PR from `review/*` into `devclaw-local-current`
+7. use that PR for local-truth review, merge, and testing on `devclaw-local-current`
+8. after the change is merged and validated on `devclaw-local-current`, create or refresh `pr/<issue-number>-<short-description>` from `upstream/main`
+9. apply the same upstreamable commit set onto the `pr/*` branch
+10. push the `pr/*` branch to the fork remote
+11. prepare the final compare/diff URL and PR body for DevClaw official
 
 Upstream review material should be prepared from `pr/*`, while `devclaw-local-current` remains the complete local operating branch.
+
+### Fresh-package rule for corrected reruns
+
+If a promotion family has already been merged, failed, gone stale, or otherwise stopped being a clean representation of the current fix, do **not** treat the old merged `review/*` branch or PR as reusable promotion state.
+
+Before creating a fresh review package for the same issue family:
+
+1. determine whether the previous `review/*` package for that family was already merged into `devclaw-local-current`
+2. if it was merged and the family is being rerun because the old result was wrong, incomplete, stale, or superseded, create a visible rollback or demotion PR first
+3. merge that rollback or demotion back into `devclaw-local-current`
+4. verify local truth is now in the intended pre-promotion state
+5. only then recreate fresh `review/*` and `pr/*` branches for the corrected fix
+
+Do **not** open or refresh a "new" `review/*` PR for a family whose prior promoted result is still present on `devclaw-local-current`, unless the operator explicitly says the new package should be treated as an additive follow-up rather than a replacement.
+
+In other words: if the old promoted code is what blocks the new review from being meaningful, demote the old code first.
 
 ## Traceability rule
 
@@ -99,7 +116,15 @@ As much non-human work as possible should be completed under that issue before t
 
 ## PR handoff policy
 
-The agent should not open the upstream DevClaw official PR itself.
+The agent should autonomously create or refresh local-truth fork PRs into `devclaw-local-current` whenever the runbook calls for a `review/*` promotion step.
+
+That means the agent should, without waiting for a separate human prompt:
+
+- push the `review/*` branch
+- open or refresh the fork PR from `review/*` into `devclaw-local-current`
+- record the PR URL and exact branch heads on the owning promotion issue
+
+The agent should **not** open the upstream DevClaw official PR itself.
 
 Instead, as part of the operator handoff, the agent should prepare:
 
@@ -107,9 +132,21 @@ Instead, as part of the operator handoff, the agent should prepare:
 - the proposed PR title
 - the proposed PR body
 
-Before that final upstream handoff, the agent should also have opened or refreshed the fork PR from `review/<issue-number>-<short-description>` into `devclaw-local-current` so the human can review, merge, and test the change on the local-truth lane first.
+So the rule is:
 
-This handoff gives the operator a ready-to-submit upstream PR package while keeping the actual upstream PR opening step under operator control.
+- `review/*` PRs into `devclaw-local-current` should be done autonomously
+- upstream official PR opening remains human-controlled
+
+After the relevant PR steps have succeeded, the orchestrator should not stop silently at "package prepared" or "PR merged".
+
+The orchestrator should:
+
+- inform the operator of the concrete result
+- include the relevant PR URLs, merge or success status, and the exact branch or commit that is now considered local truth
+- state whether `devclaw-local-current` is now the validated lane to install from
+- explicitly offer to install or reload `devclaw-local-current` into the live self-hosted environment
+
+This handoff gives the operator a ready-to-submit upstream PR package while keeping only the final upstream PR opening step under operator control, while also making the live-install follow-up explicit instead of implicit.
 
 ## Rollback policy for failed promotions
 
@@ -129,6 +166,7 @@ The required rollback flow is:
 7. merge the rollback PR, then rebuild, reinstall, restart, and verify the live self-hosted environment from the reverted `devclaw-local-current`
 8. after the rollback is safely landed and verified, delete the stale `review/*` and `pr/*` branches that represented the failed promotion
 9. only then recreate fresh development, review, and export branches for the corrected fix if the work will continue
+10. do not create a replacement `review/*` PR for that same family until step 7 has succeeded, unless the operator explicitly authorizes a different sequencing with an unlock code
 
 Normal rollback should be done as a visible revert PR into `devclaw-local-current`.
 Do not force-reset, force-push, or rewrite local-truth history unless the operator explicitly authorizes that divergence with an unlock code.

--- a/dev/runbooks/developing-devclaw-with-openclaw.md
+++ b/dev/runbooks/developing-devclaw-with-openclaw.md
@@ -158,6 +158,27 @@ After the operator reports testing complete, the orchestrator should:
 - explicitly offer to install or reload `devclaw-local-current` into the live self-hosted environment
 - then complete the upstream issue linkage step and write the final proposed upstream PR title/body into the promotion issue
 
+After the operator opens the upstream DevClaw official PR, the orchestrator should keep tracking on the local promotion issue until that upstream PR is resolved.
+
+That ongoing tracking should include:
+
+- the upstream PR URL
+- significant state changes such as opened, review feedback received, update pushed, approved, merged, or closed
+- any linked upstream issue comments or references that matter to the promotion record
+- exact export-branch or commit changes if the `pr/*` branch is refreshed
+- whether any local-truth or live-install follow-up happened in response to upstream review
+
+When the upstream PR is fully resolved, the orchestrator should finish the release cleanup on the local side.
+
+That cleanup should include, as applicable:
+
+- closing or otherwise completing the local promotion issue
+- deleting no-longer-needed local packaging artifacts and temp directories
+- deleting no-longer-needed `pr/*` branches after the upstream resolution is complete
+- deleting any other release-only local artifacts that no longer serve an active tracking purpose
+
+Use a persistent scheduled follow-up, such as a daily cron job, so opened upstream PRs do not get forgotten while waiting on review or merge.
+
 This handoff gives the operator a ready-to-submit upstream PR package while keeping only the final upstream PR opening step under operator control, while also making the live-install follow-up explicit instead of implicit.
 
 ## Rollback policy for failed promotions

--- a/dev/runbooks/developing-devclaw-with-openclaw.md
+++ b/dev/runbooks/developing-devclaw-with-openclaw.md
@@ -111,6 +111,28 @@ Before that final upstream handoff, the agent should also have opened or refresh
 
 This handoff gives the operator a ready-to-submit upstream PR package while keeping the actual upstream PR opening step under operator control.
 
+## Rollback policy for failed promotions
+
+If a promoted change fails real validation on `devclaw-local-current` or in the live self-hosted environment, treat that promotion as failed and send it back to development.
+
+Do not quietly leave a failed promotion presented as accepted or released.
+Do not keep stale release-tracking issues or stale export branches around as if they still represent valid release material.
+
+The required rollback flow is:
+
+1. record the failure on the development issue and on the promotion or release-tracking issue, with concrete evidence from the failed validation
+2. update or close the promotion or release-tracking issue so it no longer represents an active valid release
+3. move the development issue back into development or refinement as appropriate
+4. create a new `review/<issue-number>-<short-description>` rollback branch from `devclaw-local-current`
+5. revert the bad merge or bad commit on that rollback branch, rather than silently rewriting history on `devclaw-local-current`
+6. push the rollback `review/*` branch and open a fork PR into `devclaw-local-current`
+7. merge the rollback PR, then rebuild, reinstall, restart, and verify the live self-hosted environment from the reverted `devclaw-local-current`
+8. after the rollback is safely landed and verified, delete the stale `review/*` and `pr/*` branches that represented the failed promotion
+9. only then recreate fresh development, review, and export branches for the corrected fix if the work will continue
+
+Normal rollback should be done as a visible revert PR into `devclaw-local-current`.
+Do not force-reset, force-push, or rewrite local-truth history unless the operator explicitly authorizes that divergence with an unlock code.
+
 ## Live-source safety checks
 
 A branch does not become live because you checked it out.

--- a/dev/runbooks/developing-devclaw-with-openclaw.md
+++ b/dev/runbooks/developing-devclaw-with-openclaw.md
@@ -79,6 +79,25 @@ Use these checks to confirm:
 - which branch that path is on
 - which exact commit is running
 
+## Self-hosted install rule
+
+This runbook is mandatory for live self-hosted DevClaw installs and reloads. It is not optional guidance.
+
+When the task is to install or reload DevClaw into the live self-hosted environment, use the self-hosting document as the install procedure source of truth and follow it strictly, step by step.
+
+Do not improvise the install from memory.
+Do not substitute an isolated validation worktree for a real live self-hosted install when the task explicitly calls for live-environment validation.
+Do not branch into an ad hoc debug flow just because the install hits friction.
+
+If a change is prepared on `pr/*`, merge or carry that validated change back onto `devclaw-local-current` before treating it as the normal live operating branch.
+
+When friction appears, continue with the next documented runbook step.
+If the runbook says to clean up a collision, clean up the collision.
+If the runbook says to restart and verify again, restart and verify again.
+
+If the self-hosting document is missing, stale, or does not cover a required live-install step, stop and fix the documentation gap before proceeding.
+Do not invent a replacement procedure while the documentation gap is still open.
+
 ## Build before switching live
 
 ```bash

--- a/dev/runbooks/developing-devclaw-with-openclaw.md
+++ b/dev/runbooks/developing-devclaw-with-openclaw.md
@@ -21,17 +21,40 @@ Upstream `main` is a reference point and export target. It is not the normal day
 3. Land validated work back onto `devclaw-local-current` so local truth stays complete.
 4. When work needs to go upstream, export it onto a matching `pr/*` branch.
 5. Preserve the `/dev/` documentation changes on `devclaw-local-current` even when the upstream export omits local-only material.
+6. Push runbook and workflow changes to the Git remote that tracks `devclaw-local-current` so the policy is not left only in a local checkout or an unknown branch.
+
+## Mandatory compliance rule
+
+This runbook is required operating procedure, not optional guidance.
+
+Follow it without divergence.
+Any divergence from this runbook requires explicit human permission together with an unlock code.
+Without that explicit unlock, do not improvise, substitute a different flow, or quietly switch to a different branch or worktree strategy.
+
+If the runbook itself needs to change, update it on `devclaw-local-current` and push that update to the tracked Git remote before relying on the new rule.
 
 ## Export policy
 
 Use `pr/*` for upstream-facing export branches, not `contrib/*`.
 
+The required export branch naming convention is:
+
+- `pr/<issue-number>-<short-description>`
+
+Where:
+
+- `<issue-number>` is the local fix or feature issue being promoted toward DevClaw official
+- `<short-description>` is a short stable slug for the promoted change
+
 Typical flow:
 
 1. implement and validate locally
 2. land the accepted result on `devclaw-local-current`
-3. create or refresh the corresponding `pr/*` branch for upstream review
-4. push the `pr/*` branch to the fork remote
+3. open or update the local promotion issue that owns the full upstream-promotion workflow
+4. create or refresh the corresponding `pr/<issue-number>-<short-description>` branch for upstream review
+5. push the `pr/*` branch to the fork remote
+6. open the fork PR needed for human review and testing against `devclaw-local-current`
+7. after that review/test step, prepare the final compare/diff URL and PR body for DevClaw official
 
 Upstream review material should be prepared from `pr/*`, while `devclaw-local-current` remains the complete local operating branch.
 
@@ -47,9 +70,30 @@ That means:
 
 The point of the export is to publish local truth, not replace it.
 
+## Promotion issue requirement
+
+Do not promote code to DevClaw official without a local issue that covers the full promotion from start to finish.
+
+That issue is not just "prep". It owns the entire promotion workflow.
+
+The promotion issue should document:
+
+- the exact local issue or fix being promoted
+- the source branch or branches and exact commits
+- any prerequisite slices that must go upstream together
+- the target `pr/<issue-number>-<short-description>` branch name
+- the fork PR that will be opened against `devclaw-local-current` for human acceptance and testing
+- the compare or diff URL for the later DevClaw official PR
+- the proposed body for the later DevClaw official PR
+- any remaining human-only steps
+
+Use issue `#141` only as a rough shape reference, not as naming guidance. Avoid "start upstream promotion prep" style issue framing. The issue should describe the whole promotion, not just an initial prep stage.
+
+As much non-human work as possible should be completed under that issue before the human review step.
+
 ## PR handoff policy
 
-The agent should not open the upstream PR itself.
+The agent should not open the upstream DevClaw official PR itself.
 
 Instead, as part of the operator handoff, the agent should prepare:
 
@@ -57,7 +101,9 @@ Instead, as part of the operator handoff, the agent should prepare:
 - the proposed PR title
 - the proposed PR body
 
-This handoff gives the operator a ready-to-submit upstream PR package while keeping the actual PR opening step under operator control.
+Before that final upstream handoff, the agent should also have opened or refreshed the fork PR into `devclaw-local-current` so the human can review, merge, and test the change on the local-truth lane first.
+
+This handoff gives the operator a ready-to-submit upstream PR package while keeping the actual upstream PR opening step under operator control.
 
 ## Live-source safety checks
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -521,7 +521,7 @@ sequenceDiagram
     TK-->>HB: { pickups, skipped }
 ```
 
-## Worker instructions (bootstrap hook)
+## Prompt loading (bootstrap hook)
 
 Role-specific instructions (coding standards, deployment steps, completion rules) are injected into worker sessions via the `agent:bootstrap` hook — not appended to the task message.
 
@@ -541,8 +541,16 @@ sequenceDiagram
 ```
 
 **Resolution order:**
+Worker prompt precedence:
 1. `devclaw/projects/<project>/prompts/<role>.md` (project-specific)
 2. `devclaw/prompts/<role>.md` (workspace default)
+3. package default prompt
+
+Orchestrator prompt precedence inside the main session bootstrap content:
+1. `AGENTS.md` and runtime baseline
+2. `devclaw/prompts/orchestrator.md`
+3. `devclaw/projects/<project>/prompts/orchestrator.md`
+4. current issue/chat/task context
 
 The source path is logged for production traceability: `Bootstrap hook: injected developer instructions for project "my-app" from /path/to/prompts/developer.md`.
 
@@ -757,8 +765,10 @@ See [CONFIGURATION.md](CONFIGURATION.md) for the full reference.
 | Worker state | `<workspace>/devclaw/projects.json` | Per-project worker state |
 | Workflow config (workspace) | `<workspace>/devclaw/workflow.yaml` | Workspace-level role/workflow overrides |
 | Workflow config (project) | `<workspace>/devclaw/projects/<project>/workflow.yaml` | Project-specific overrides |
-| Default role instructions | `<workspace>/devclaw/prompts/<role>.md` | Default `developer.md`, `tester.md`, `architect.md` |
+| Default role instructions | `<workspace>/devclaw/prompts/<role>.md` | Default `developer.md`, `tester.md`, `architect.md`, `reviewer.md` |
 | Project role instructions | `<workspace>/devclaw/projects/<project>/prompts/<role>.md` | Per-project role instruction overrides |
+| Default orchestrator overlay | `<workspace>/devclaw/prompts/orchestrator.md` | Live orchestrator prompt layered after AGENTS.md |
+| Project orchestrator overlay | `<workspace>/devclaw/projects/<project>/prompts/orchestrator.md` | Project-specific orchestrator overlay layered after workspace orchestrator prompt |
 | Audit log | `<workspace>/devclaw/log/audit.log` | NDJSON event log |
 | Session transcripts | `~/.openclaw/agents/<agent>/sessions/<uuid>.jsonl` | Conversation history per session |
 | Git repos | `~/git/<project>/` | Project source code |

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -363,14 +363,16 @@ Each role in the `workers` record has a `WorkerState` object:
 │   ├── prompts/
 │   │   ├── developer.md           ← Default developer instructions
 │   │   ├── tester.md              ← Default tester instructions
-│   │   └── architect.md           ← Default architect instructions
+│   │   ├── architect.md           ← Default architect instructions
+│   │   └── orchestrator.md        ← Default orchestrator overlay prompt
 │   ├── projects/
 │   │   ├── my-webapp/
 │   │   │   ├── workflow.yaml      ← Project-specific config overrides
 │   │   │   └── prompts/
 │   │   │       ├── developer.md   ← Project-specific developer instructions
 │   │   │       ├── tester.md      ← Project-specific tester instructions
-│   │   │       └── architect.md   ← Project-specific architect instructions
+│   │   │       ├── architect.md   ← Project-specific architect instructions
+│   │   │       └── orchestrator.md← Project-specific orchestrator overlay prompt
 │   │   └── another-project/
 │   │       └── prompts/
 │   │           ├── developer.md
@@ -381,11 +383,13 @@ Each role in the `workers` record has a `WorkerState` object:
 └── HEARTBEAT.md                   ← Heartbeat operation guide
 ```
 
-### Role instruction files
+### Prompt instruction files
 
-Role instructions are injected into worker sessions via the `agent:bootstrap` hook at session startup. The hook loads instructions from `devclaw/projects/<project>/prompts/<role>.md`, falling back to `devclaw/prompts/<role>.md`.
+Worker instructions are injected via the `agent:bootstrap` hook at session startup. The hook loads `devclaw/projects/<project>/prompts/<role>.md`, falling back to `devclaw/prompts/<role>.md`.
 
-Edit to customize: deployment steps, test commands, acceptance criteria, coding standards.
+The orchestrator session keeps its AGENTS.md baseline, then appends `devclaw/prompts/orchestrator.md`, then `devclaw/projects/<project>/prompts/orchestrator.md` when the current chat resolves to a project.
+
+Edit these files to customize deployment steps, test commands, acceptance criteria, coding standards, and orchestration policy.
 
 **Source:** [`lib/dispatch/bootstrap-hook.ts`](../lib/dispatch/bootstrap-hook.ts)
 

--- a/docs/ONBOARDING.md
+++ b/docs/ONBOARDING.md
@@ -61,7 +61,7 @@ The setup wizard walks you through:
    - **Tester senior** (thorough review) — default: `anthropic/claude-opus-4-6`
    - **Architect junior** (standard design) — default: `anthropic/claude-sonnet-4-5`
    - **Architect senior** (complex architecture) — default: `anthropic/claude-opus-4-6`
-3. **Workspace** — Writes AGENTS.md, HEARTBEAT.md, workflow.yaml, role templates, and initializes state
+3. **Workspace** — Writes AGENTS.md, HEARTBEAT.md, workflow.yaml, prompt templates (including orchestrator.md), and initializes state
 
 Non-interactive mode:
 ```bash
@@ -155,7 +155,7 @@ Go to the Telegram/WhatsApp group for the project and tell the orchestrator agen
 The agent calls `project_register`, which atomically:
 - Validates the repo and auto-detects GitHub/GitLab from remote
 - Creates all state labels (idempotent)
-- Scaffolds role instruction files (`devclaw/projects/<project>/prompts/developer.md`, `tester.md`, `architect.md`)
+- Creates the project override directory for prompt files, including support for `devclaw/projects/<project>/prompts/orchestrator.md`
 - Adds the project entry to `projects.json`
 - Logs the registration event
 
@@ -271,7 +271,7 @@ Change which model powers each level in `workflow.yaml` — see [Configuration](
 | Agent + workspace setup | Plugin (`setup`) | Creates agent, configures models, writes workspace files |
 | Channel binding migration | Plugin (`setup` with `migrateFrom`) | Automatically moves channel-wide bindings between agents |
 | Label setup | Plugin (`project_register`) | State labels, created idempotently via IssueProvider |
-| Prompt file scaffolding | Plugin (`project_register`) | Creates `devclaw/projects/<project>/prompts/<role>.md` for each role |
+| Prompt file scaffolding | Plugin (`project_register`) | Creates the project prompt override directory and documents `devclaw/projects/<project>/prompts/<role>.md` plus `orchestrator.md` |
 | Project registration | Plugin (`project_register`) | Entry in `projects.json` with empty worker state |
 | Telegram group setup | You (once per project) | Add bot to group |
 | Issue creation | Plugin (`task_create`) | Orchestrator or workers create issues from chat |

--- a/docs/TOOLS.md
+++ b/docs/TOOLS.md
@@ -551,7 +551,7 @@ List channels for a project or all projects. Shows channel type, ID, name, and e
 
 ### `config`
 
-Manage DevClaw workspace configuration. Supports three actions: reset config files to defaults, diff against defaults, and show version info.
+Manage DevClaw workspace configuration. Supports four actions: reset config files to defaults, diff against defaults, show version info, and inspect live build provenance.
 
 **Source:** [`lib/tools/admin/config.ts`](../lib/tools/admin/config.ts)
 
@@ -559,7 +559,7 @@ Manage DevClaw workspace configuration. Supports three actions: reset config fil
 
 | Parameter | Type | Required | Description |
 |---|---|---|---|
-| `action` | `"reset"` \| `"diff"` \| `"version"` | Yes | Action to perform |
+| `action` | `"reset"` \| `"diff"` \| `"version"` \| `"provenance"` | Yes | Action to perform |
 | `scope` | `"prompts"` \| `"workflow"` \| `"all"` | No | Reset scope (only for `action: "reset"`) |
 
 **Actions:**
@@ -569,3 +569,4 @@ Manage DevClaw workspace configuration. Supports three actions: reset config fil
 | `reset` | Reset config files to package defaults. Creates `.bak` backups. Use `scope` to target: `prompts` (role prompts only), `workflow` (workflow.yaml only), `all` (everything). |
 | `diff` | Show differences between current `workflow.yaml` and the built-in default template. Helps identify customizations and see what changed in new versions. |
 | `version` | Show DevClaw package version and workspace tracked version. |
+| `provenance` | Show embedded live runtime build provenance: package version, commit SHA, short SHA, branch, dirty flag, build timestamp, and metadata source. |

--- a/docs/devclaw-self-hosting.md
+++ b/docs/devclaw-self-hosting.md
@@ -1,0 +1,132 @@
+# Developing DevClaw with OpenClaw
+
+This guide covers the generic workflow for developing DevClaw while running DevClaw through OpenClaw.
+
+It is intentionally environment-agnostic. If your machine or fork has local policy, branch names, or operator habits layered on top, keep those in local-only docs and link back here.
+
+## What this guide is for
+
+Use this when you are:
+
+- editing DevClaw source while DevClaw is your active orchestrator
+- switching the live plugin source between branches or worktrees
+- validating that a branch change actually became the runtime source
+- avoiding duplicate plugin-source loads during local development
+
+## Core idea
+
+A branch does not become live because you checked it out.
+
+A branch becomes live when OpenClaw is loading the DevClaw plugin from that checkout or worktree.
+
+That means branch switching for DevClaw development is really a **plugin source switch** followed by a **runtime verification** step.
+
+## Recommended branch roles
+
+These are roles, not mandatory branch names:
+
+- **clean integration branch**: the branch that tracks the normal upstream line
+- **working branch**: a feature or fix branch carrying in-progress changes
+- **fallback branch**: an optional known-good branch you can switch back to quickly
+- **local docs branch**: an optional branch for operator runbooks that are not meant for upstream
+
+Use names that fit your repo. The workflow matters more than the naming.
+
+## Safe live-switch procedure
+
+When changing the live DevClaw source during development:
+
+1. Choose the target checkout or worktree.
+2. Build that target source tree.
+3. Confirm the built artifact exists.
+4. Make sure only one DevClaw plugin source is active.
+5. Point OpenClaw at the intended source path.
+6. Restart the gateway.
+7. Verify the loaded plugin path.
+8. Verify the exact live git commit.
+
+## Build before switching
+
+Before switching live, verify the target source tree has a built artifact:
+
+```bash
+test -f <target-source-root>/dist/index.js && echo built || echo missing-dist
+```
+
+If `dist/index.js` is missing, build first and do not switch the live source yet.
+
+## Verify the live source path
+
+The source of truth is the live plugin inspection output, not memory and not the checkout you happen to be editing.
+
+```bash
+openclaw plugins inspect devclaw
+openclaw gateway status
+```
+
+Use `openclaw plugins inspect devclaw` to answer:
+
+- what path is actually live
+- which plugin version is loaded
+
+Important distinction:
+
+- `inspect` tells you **what path is live**
+- git tells you **what commit that path contains**
+
+## Verify the exact live commit
+
+Once you know the live source path, resolve that path back to the checkout or worktree root and verify the commit directly:
+
+```bash
+openclaw plugins inspect devclaw
+git -C <live-source-root> rev-parse HEAD
+```
+
+Do not assume that the installed extension directory or your current shell checkout is the live commit.
+
+## Avoid duplicate plugin-source collisions
+
+A common failure mode is loading DevClaw from more than one place at once, for example:
+
+- an installed copy under `~/.openclaw/extensions/devclaw`
+- and a path/worktree load via `plugins.load.paths[]`
+
+If both are in play, the gateway may load a different source than the one you intended.
+
+If startup logs mention duplicate plugin ids or the runtime path does not match your expected worktree, stop and clean up the duplicate before trusting the switch.
+
+## When a live switch failed
+
+Treat the switch as failed if any of the following happen:
+
+- `openclaw plugins inspect devclaw` reports the wrong source path
+- the plugin is missing after restart
+- startup logs show duplicate plugin warnings
+- the target source tree has no `dist/index.js`
+- the gateway is still loading an older installed copy
+
+In that case:
+
+1. verify the target build artifact exists
+2. inspect the live plugin path again
+3. remove or disable competing DevClaw plugin sources
+4. restart and verify again
+
+## Keep generic guidance separate from local policy
+
+Generic repo docs should cover:
+
+- the branch/worktree switching model
+- build and verification steps
+- duplicate-source failure modes
+- how to reason about live source versus checked-out source
+
+Local-only docs should cover:
+
+- branch names used on one machine or fork
+- preferred fallback lanes
+- machine-specific paths
+- personal or operator-specific workflow habits
+
+That separation keeps the main docs useful in any environment while still allowing strong local runbooks.

--- a/docs/devclaw-self-hosting.md
+++ b/docs/devclaw-self-hosting.md
@@ -113,6 +113,31 @@ In that case:
 3. remove or disable competing DevClaw plugin sources
 4. restart and verify again
 
+## Generic smoke test for a running environment
+
+Use this when you want to verify a local DevClaw install in an already-running environment without creating new projects or tasks.
+
+Read-only checks:
+
+```bash
+openclaw plugins inspect devclaw
+openclaw plugins list
+openclaw gateway status
+openclaw agent --agent <agent-id> --message 'Call project_status with channelId "<channel-id>" and reply with the result only.' --json
+openclaw agent --agent <agent-id> --message 'Call tasks_status and reply with the result only.' --json
+openclaw agent --agent <agent-id> --message 'Call channel_list and reply with the result only.' --json
+```
+
+What this verifies:
+
+- the plugin is loaded
+- the gateway is healthy
+- the live agent can read local project state
+- the live agent can read tracker-backed task state
+- channel bindings are visible
+
+Avoid using project-creating or task-creating commands for smoke tests in a shared live environment unless you also have an explicit cleanup plan.
+
 ## Keep generic guidance separate from local policy
 
 Generic repo docs should cover:

--- a/docs/devclaw-self-hosting.md
+++ b/docs/devclaw-self-hosting.md
@@ -117,6 +117,37 @@ This gives you four checks:
 
 For example, if you intend to run from a `devclaw-local-stable` worktree, these checks should agree on both the path and the branch identity before you treat the switch as complete.
 
+## Copied install versus linked install
+
+This distinction matters a lot during self-hosting.
+
+A local path install can exist in two very different states:
+
+- a **copied install**, where `~/.openclaw/extensions/devclaw` contains a copy of the plugin files
+- a **linked install**, where `~/.openclaw/extensions/devclaw` points back to your intended checkout or worktree
+
+If you only rebuild the source worktree, a copied install will keep running the old copied artifact. In that case, `openclaw plugins inspect devclaw` may still show the recorded source path you originally installed from, even though the live loaded code is coming from the copied install directory.
+
+That means:
+
+- rebuilding a worktree is **not** enough by itself to switch a copied install
+- restart alone is **not** enough if the installed files were copied earlier
+- for live branch or worktree development, you usually want a **linked** install
+
+Useful checks:
+
+```bash
+openclaw plugins inspect devclaw
+readlink -f ~/.openclaw/extensions/devclaw
+```
+
+Interpretation:
+
+- if the install path resolves to your intended worktree, you are running a linked install
+- if the install path stays under `~/.openclaw/extensions/devclaw`, treat it as a copied install until proven otherwise
+
+To refresh the live environment from a worktree after a copied install, reinstall the plugin from that worktree as a linked install, then restart the gateway and verify again.
+
 ## Avoid duplicate plugin-source collisions
 
 A common failure mode is loading DevClaw from more than one place at once, for example:

--- a/docs/devclaw-self-hosting.md
+++ b/docs/devclaw-self-hosting.md
@@ -136,6 +136,11 @@ What this verifies:
 - the live agent can read tracker-backed task state
 - channel bindings are visible
 
+Expected result note:
+
+- in an unbound DM or admin session, `project_status` and `tasks_status` may correctly return `No project found` for that channel
+- treat that as a passing result for this smoke test unless you were specifically testing a known project-bound chat
+
 Avoid using project-creating or task-creating commands for smoke tests in a shared live environment unless you also have an explicit cleanup plan.
 
 ## Keep generic guidance separate from local policy

--- a/docs/devclaw-self-hosting.md
+++ b/docs/devclaw-self-hosting.md
@@ -85,6 +85,26 @@ git -C <live-source-root> rev-parse HEAD
 
 Do not assume that the installed extension directory or your current shell checkout is the live commit.
 
+## Stronger proof for linked local installs
+
+If you are using a linked local install and want stronger proof that the live plugin really comes from the intended worktree, verify both the install path target and the branch name:
+
+```bash
+openclaw plugins inspect devclaw
+readlink -f ~/.openclaw/extensions/devclaw
+git -C <intended-worktree> rev-parse --abbrev-ref HEAD
+git -C <intended-worktree> rev-parse HEAD
+```
+
+This gives you four checks:
+
+- the live plugin id and loaded source
+- the real filesystem target behind the installed extension path
+- the branch name of the intended worktree
+- the exact commit of that worktree
+
+For example, if you intend to run from a `devclaw-local-stable` worktree, these checks should agree on both the path and the branch identity before you treat the switch as complete.
+
 ## Avoid duplicate plugin-source collisions
 
 A common failure mode is loading DevClaw from more than one place at once, for example:

--- a/docs/devclaw-self-hosting.md
+++ b/docs/devclaw-self-hosting.md
@@ -72,11 +72,23 @@ Use `openclaw plugins inspect devclaw` to answer:
 Important distinction:
 
 - `inspect` tells you **what path is live**
-- git tells you **what commit that path contains**
+- runtime provenance tells you **what embedded build is live**
+- git tells you **what commit a still-present source tree contains**
 
-## Verify the exact live commit
+## Verify the exact live build without the repo
 
-Once you know the live source path, resolve that path back to the checkout or worktree root and verify the commit directly:
+Use the embedded provenance first. It survives even if the linked source worktree is gone:
+
+```bash
+openclaw agent --agent <agent-id> --message 'Call config with action "provenance" and reply with the result only.' --json
+openclaw devclaw provenance
+```
+
+This reports the live package version, commit SHA, short SHA, branch, dirty flag, and build timestamp from the built artifact itself.
+
+## Verify the exact live commit from source path inspection
+
+If the source tree still exists, you can also resolve the live source path back to the checkout or worktree root and verify the commit directly:
 
 ```bash
 openclaw plugins inspect devclaw

--- a/docs/devclaw-self-hosting.md
+++ b/docs/devclaw-self-hosting.md
@@ -137,6 +137,32 @@ In that case:
 
 Use this when you want to verify a local DevClaw install in an already-running environment without creating new projects or tasks.
 
+## Tracker routing verification for fork-based installs
+
+If your local checkout has both a fork and an upstream remote, do not trust ambient GitHub CLI repo inference.
+
+Before relying on issue-creation flows, verify both the configured tracker target and the checkout's ambient `gh` target:
+
+```bash
+python3 - <<'PY'
+import json
+p=json.load(open('devclaw/projects.json'))['projects']['devclaw']
+print(p['repoRemote'])
+PY
+git -C <repo-or-worktree> remote -v
+gh repo view --json nameWithOwner --jq .nameWithOwner
+```
+
+Expected safety rule:
+
+- DevClaw issue/task tooling must route to the repository configured in `projects.json`
+- it must not drift to the repo that `gh` happens to infer from the checkout context
+
+When validating a fix for tracker-routing bugs, record both:
+
+- a pre-change proof showing config target versus ambient `gh` target
+- a post-change proof showing issue/task creation calls explicitly target the configured repo
+
 Read-only checks:
 
 ```bash

--- a/index.ts
+++ b/index.ts
@@ -39,6 +39,7 @@ import { registerCli } from "./lib/setup/cli.js";
 import { registerHeartbeatService } from "./lib/services/heartbeat/index.js";
 import { registerBootstrapHook } from "./lib/dispatch/bootstrap-hook.js";
 import { registerAttachmentHook } from "./lib/dispatch/attachment-hook.js";
+import { getBuildProvenance, formatBuildProvenanceSummary } from "./lib/build-provenance.js";
 
 const plugin = {
   id: "devclaw",
@@ -91,6 +92,7 @@ const plugin = {
 
   register(api: OpenClawPluginApi) {
     const ctx = createPluginContext(api);
+    const provenance = getBuildProvenance();
 
     // Worker lifecycle
     api.registerTool(createTaskStartTool(ctx), { names: ["task_start"] });
@@ -134,7 +136,7 @@ const plugin = {
     registerAttachmentHook(api, ctx);
 
     api.logger.info(
-      "DevClaw plugin registered (23 tools, 1 CLI command group, 1 service, 3 hooks)",
+      `DevClaw plugin registered (23 tools, 1 CLI command group, 1 service, 3 hooks) | build=${formatBuildProvenanceSummary(provenance)} | provenance=${JSON.stringify(provenance)}`,
     );
   },
 };

--- a/lib/build-provenance.ts
+++ b/lib/build-provenance.ts
@@ -1,0 +1,79 @@
+/**
+ * build-provenance.ts — Embedded live runtime provenance for built DevClaw installs.
+ *
+ * Build-time metadata is injected by esbuild so live installs remain self-describing
+ * even if the original source checkout/worktree is no longer available.
+ */
+import fsSync from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+/** Injected at build time by esbuild (see build.mjs). */
+declare const __PLUGIN_VERSION__: string | undefined;
+declare const __PACKAGE_NAME__: string | undefined;
+declare const __BUILD_PROVENANCE__: string | undefined;
+
+const THIS_DIR = path.dirname(fileURLToPath(import.meta.url));
+
+export type BuildProvenance = {
+  packageName: string;
+  packageVersion: string;
+  commitSha: string | null;
+  shortCommitSha: string | null;
+  branch: string | null;
+  dirty: boolean | null;
+  buildTimestamp: string | null;
+  source: "embedded" | "fallback";
+};
+
+function readPackageFallback(): { packageName: string; packageVersion: string } {
+  try {
+    const pkgPath = path.join(THIS_DIR, "..", "..", "package.json");
+    const pkg = JSON.parse(fsSync.readFileSync(pkgPath, "utf-8"));
+    return {
+      packageName: pkg.name ?? "devclaw",
+      packageVersion: pkg.version ?? "0.0.0",
+    };
+  } catch {
+    return {
+      packageName: typeof __PACKAGE_NAME__ !== "undefined" && __PACKAGE_NAME__ ? __PACKAGE_NAME__ : "devclaw",
+      packageVersion: typeof __PLUGIN_VERSION__ !== "undefined" && __PLUGIN_VERSION__ ? __PLUGIN_VERSION__ : "0.0.0",
+    };
+  }
+}
+
+export function getBuildProvenance(): BuildProvenance {
+  const fallbackPkg = readPackageFallback();
+
+  if (typeof __BUILD_PROVENANCE__ !== "undefined" && __BUILD_PROVENANCE__) {
+    try {
+      const parsed = JSON.parse(__BUILD_PROVENANCE__) as Omit<BuildProvenance, "source">;
+      return {
+        ...parsed,
+        source: "embedded",
+      };
+    } catch {
+      // Fall through to safe fallback.
+    }
+  }
+
+  return {
+    packageName: fallbackPkg.packageName,
+    packageVersion: fallbackPkg.packageVersion,
+    commitSha: null,
+    shortCommitSha: null,
+    branch: null,
+    dirty: null,
+    buildTimestamp: null,
+    source: "fallback",
+  };
+}
+
+export function formatBuildProvenanceSummary(provenance = getBuildProvenance()): string {
+  const dirtyText = provenance.dirty === null ? "unknown" : provenance.dirty ? "dirty" : "clean";
+  const commitText = provenance.commitSha ?? "unknown commit";
+  const branchText = provenance.branch ?? "unknown branch";
+  const builtAtText = provenance.buildTimestamp ?? "unknown build time";
+
+  return `${provenance.packageName}@${provenance.packageVersion} (${commitText}, ${branchText}, ${dirtyText}, built ${builtAtText})`;
+}

--- a/lib/dispatch/attachment-hook.ts
+++ b/lib/dispatch/attachment-hook.ts
@@ -19,6 +19,7 @@ import {
 } from "./attachments.js";
 import { readProjects, type Project } from "../projects/index.js";
 import { createProvider } from "../providers/index.js";
+import { normalizeRepoTarget } from "../tools/helpers.js";
 import { log as auditLog } from "../audit.js";
 
 /**
@@ -93,7 +94,12 @@ export function registerAttachmentHook(api: OpenClawPluginApi, ctx: PluginContex
     // Process each referenced issue
     for (const issueId of issueIds) {
       try {
-        const { provider } = await createProvider({ repo: project.repo, provider: project.provider, runCommand: ctx.runCommand });
+        const { provider } = await createProvider({
+          repo: project.repo,
+          provider: project.provider,
+          target: project.repoRemote ? { repo: normalizeRepoTarget(project.repoRemote) } : undefined,
+          runCommand: ctx.runCommand,
+        });
 
         await processAttachmentMessage({
           workspaceDir,

--- a/lib/dispatch/bootstrap-hook.test.ts
+++ b/lib/dispatch/bootstrap-hook.test.ts
@@ -5,6 +5,7 @@
 import { describe, it } from "node:test";
 import assert from "node:assert";
 import { parseDevClawSessionKey, loadRoleInstructions } from "./bootstrap-hook.js";
+import { DEFAULT_ROLE_INSTRUCTIONS } from "../setup/templates.js";
 import fs from "node:fs/promises";
 import path from "node:path";
 import os from "node:os";
@@ -81,10 +82,19 @@ describe("loadRoleInstructions", () => {
     await fs.rm(tmpDir, { recursive: true });
   });
 
-  it("should return empty string when no instructions exist", async () => {
+  it("should fall back to package defaults when no workspace instructions exist", async () => {
     const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "devclaw-test-"));
 
     const result = await loadRoleInstructions(tmpDir, "missing", "developer");
+    assert.strictEqual(result, DEFAULT_ROLE_INSTRUCTIONS.developer);
+
+    await fs.rm(tmpDir, { recursive: true });
+  });
+
+  it("should return empty string for unknown roles with no defaults", async () => {
+    const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "devclaw-test-"));
+
+    const result = await loadRoleInstructions(tmpDir, "missing", "unknown-role");
     assert.strictEqual(result, "");
 
     await fs.rm(tmpDir, { recursive: true });

--- a/lib/dispatch/bootstrap-hook.test.ts
+++ b/lib/dispatch/bootstrap-hook.test.ts
@@ -4,8 +4,8 @@
  */
 import { describe, it } from "node:test";
 import assert from "node:assert";
-import { parseDevClawSessionKey, loadRoleInstructions } from "./bootstrap-hook.js";
-import { DEFAULT_ROLE_INSTRUCTIONS } from "../setup/templates.js";
+import { parseDevClawSessionKey, loadOrchestratorInstructions, loadRoleInstructions } from "./bootstrap-hook.js";
+import { DEFAULT_ORCHESTRATOR_PROMPT, DEFAULT_ROLE_INSTRUCTIONS } from "../setup/templates.js";
 import fs from "node:fs/promises";
 import path from "node:path";
 import os from "node:os";
@@ -123,6 +123,46 @@ describe("loadRoleInstructions", () => {
 
     const result = await loadRoleInstructions(tmpDir, "old-project", "developer");
     assert.strictEqual(result, "Old layout instructions");
+
+    await fs.rm(tmpDir, { recursive: true });
+  });
+});
+
+describe("loadOrchestratorInstructions", () => {
+  it("should layer workspace and project orchestrator instructions in order", async () => {
+    const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "devclaw-test-"));
+    await fs.mkdir(path.join(tmpDir, "devclaw", "prompts"), { recursive: true });
+    await fs.mkdir(path.join(tmpDir, "devclaw", "projects", "my-project", "prompts"), { recursive: true });
+    await fs.writeFile(path.join(tmpDir, "devclaw", "prompts", "orchestrator.md"), "Workspace orchestrator prompt");
+    await fs.writeFile(path.join(tmpDir, "devclaw", "projects", "my-project", "prompts", "orchestrator.md"), "Project orchestrator prompt");
+
+    const result = await loadOrchestratorInstructions(tmpDir, "my-project");
+    assert.strictEqual(result, "Workspace orchestrator prompt\n\nProject orchestrator prompt");
+
+    await fs.rm(tmpDir, { recursive: true });
+  });
+
+  it("should return layered sources when requested", async () => {
+    const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "devclaw-test-"));
+    await fs.mkdir(path.join(tmpDir, "devclaw", "prompts"), { recursive: true });
+    await fs.mkdir(path.join(tmpDir, "devclaw", "projects", "my-project", "prompts"), { recursive: true });
+    const workspacePath = path.join(tmpDir, "devclaw", "prompts", "orchestrator.md");
+    const projectPath = path.join(tmpDir, "devclaw", "projects", "my-project", "prompts", "orchestrator.md");
+    await fs.writeFile(workspacePath, "Workspace orchestrator prompt");
+    await fs.writeFile(projectPath, "Project orchestrator prompt");
+
+    const result = await loadOrchestratorInstructions(tmpDir, "my-project", { withSource: true });
+    assert.strictEqual(result.content, "Workspace orchestrator prompt\n\nProject orchestrator prompt");
+    assert.deepStrictEqual(result.sources, [workspacePath, projectPath]);
+
+    await fs.rm(tmpDir, { recursive: true });
+  });
+
+  it("should fall back to package default orchestrator prompt", async () => {
+    const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "devclaw-test-"));
+
+    const result = await loadOrchestratorInstructions(tmpDir, "missing-project");
+    assert.strictEqual(result, DEFAULT_ORCHESTRATOR_PROMPT.trim());
 
     await fs.rm(tmpDir, { recursive: true });
   });

--- a/lib/dispatch/bootstrap-hook.ts
+++ b/lib/dispatch/bootstrap-hook.ts
@@ -1,45 +1,31 @@
 /**
- * bootstrap-hook.ts — Bootstrap support for DevClaw worker sessions.
+ * bootstrap-hook.ts — Bootstrap support for DevClaw sessions.
  *
  * Provides:
- *   1. agent:bootstrap (internal hook) — replaces the orchestrator's AGENTS.md
- *      with role-specific instructions so the worker sees its own prompt on
- *      every turn. Requires hooks.internal.enabled in config.
- *   2. loadRoleInstructions() — loads role-specific prompt files from workspace.
- *      Used by both the bootstrap hook (persistent per-turn injection) and
- *      dispatch.ts (extraSystemPrompt fallback for the dispatch turn).
+ *   1. agent:bootstrap (internal hook) for worker sessions, replacing the
+ *      orchestrator's AGENTS.md with role-specific instructions so workers see
+ *      their own prompt on every turn.
+ *   2. agent:bootstrap handling for main/orchestrator sessions, appending live
+ *      workspace and project-specific orchestrator prompt layers to AGENTS.md.
+ *   3. Prompt loaders used by bootstrap and dispatch fallback paths.
  */
 import fs from "node:fs/promises";
 import path from "node:path";
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
 import type { PluginContext } from "../context.js";
 import { getSessionKeyRolePattern } from "../roles/index.js";
+import { getProject, readProjects } from "../projects/index.js";
 import { DATA_DIR } from "../setup/migrate-layout.js";
-import { DEFAULT_ROLE_INSTRUCTIONS } from "../setup/templates.js";
+import { DEFAULT_ORCHESTRATOR_PROMPT, DEFAULT_ROLE_INSTRUCTIONS } from "../setup/templates.js";
 
-/**
- * Parse a DevClaw subagent session key to extract project name and role.
- *
- * Session key format (named): `agent:{agentId}:subagent:{projectName}-{role}-{level}-{name}` (name is lowercase)
- * Session key format (numeric): `agent:{agentId}:subagent:{projectName}-{role}-{level}-{slotIndex}`
- * Session key format (legacy): `agent:{agentId}:subagent:{projectName}-{role}-{level}`
- * Examples:
- *   - `agent:devclaw:subagent:my-project-developer-medior-ada`  → { projectName: "my-project", role: "developer" }
- *   - `agent:devclaw:subagent:my-project-developer-medior-0`    → { projectName: "my-project", role: "developer" }
- *   - `agent:devclaw:subagent:webapp-tester-medior`              → { projectName: "webapp", role: "tester" } (legacy)
- *
- * Note: projectName may contain hyphens, so we match role from the end.
- */
 export function parseDevClawSessionKey(
   sessionKey: string,
 ): { projectName: string; role: string } | null {
   const rolePattern = getSessionKeyRolePattern();
-  // Named/numeric format: ...-{role}-{level}-{nameOrIndex}
   const newMatch = sessionKey.match(
     new RegExp(`:subagent:(.+)-(${rolePattern})-[^-]+-[^-]+$`),
   );
   if (newMatch) return { projectName: newMatch[1], role: newMatch[2] };
-  // Legacy format fallback: ...-{role}-{level} (for in-flight sessions during migration)
   const legacyMatch = sessionKey.match(
     new RegExp(`:subagent:(.+)-(${rolePattern})-[^-]+$`),
   );
@@ -47,26 +33,62 @@ export function parseDevClawSessionKey(
   return null;
 }
 
-/**
- * Result of loading role instructions — includes the source for traceability.
- */
-export type RoleInstructionsResult = {
+export type PromptInstructionsResult = {
   content: string;
-  /** Which file the instructions were loaded from, or null if none found. */
   source: string | null;
 };
 
+export type LayeredPromptInstructionsResult = {
+  content: string;
+  sources: string[];
+};
+
+export type RoleInstructionsResult = PromptInstructionsResult;
+
+async function loadPromptInstructions(
+  workspaceDir: string,
+  promptName: string,
+  opts?: { projectName?: string; withSource?: boolean; includePackageDefault?: string },
+): Promise<string | PromptInstructionsResult> {
+  const dataDir = path.join(workspaceDir, DATA_DIR);
+  const candidates = [
+    opts?.projectName
+      ? path.join(dataDir, "projects", opts.projectName, "prompts", `${promptName}.md`)
+      : null,
+    opts?.projectName
+      ? path.join(workspaceDir, "projects", "roles", opts.projectName, `${promptName}.md`)
+      : null,
+    path.join(dataDir, "prompts", `${promptName}.md`),
+    path.join(workspaceDir, "projects", "roles", "default", `${promptName}.md`),
+  ].filter((value): value is string => Boolean(value));
+
+  for (const filePath of candidates) {
+    try {
+      const content = await fs.readFile(filePath, "utf-8");
+      if (opts?.withSource) return { content, source: filePath };
+      return content;
+    } catch {
+      /* not found, try next */
+    }
+  }
+
+  if (opts?.includePackageDefault) {
+    if (opts.withSource) return { content: opts.includePackageDefault, source: "package-default" };
+    return opts.includePackageDefault;
+  }
+
+  if (opts?.withSource) return { content: "", source: null };
+  return "";
+}
+
 /**
  * Load role-specific instructions from workspace.
- * Tries project-specific file first, then workspace default, then package default.
- * Returns both the content and the source path for logging/traceability.
- *
  * Resolution order:
- *   1. devclaw/projects/<project>/prompts/<role>.md  (project-specific override)
- *   2. projects/roles/<project>/<role>.md             (old project-specific)
- *   3. devclaw/prompts/<role>.md                      (workspace default)
- *   4. projects/roles/default/<role>.md               (old default)
- *   5. Package default from templates.ts              (in-memory fallback)
+ *   1. devclaw/projects/<project>/prompts/<role>.md
+ *   2. projects/roles/<project>/<role>.md
+ *   3. devclaw/prompts/<role>.md
+ *   4. projects/roles/default/<role>.md
+ *   5. package default
  */
 export async function loadRoleInstructions(
   workspaceDir: string,
@@ -85,48 +107,125 @@ export async function loadRoleInstructions(
   role: string,
   opts?: { withSource: true },
 ): Promise<string | RoleInstructionsResult> {
+  return loadPromptInstructions(workspaceDir, role, {
+    projectName,
+    withSource: opts?.withSource,
+    includePackageDefault: DEFAULT_ROLE_INSTRUCTIONS[role],
+  }) as Promise<string | RoleInstructionsResult>;
+}
+
+/**
+ * Load orchestrator-specific instructions from workspace.
+ * Resolution order inside the orchestrator session:
+ *   1. AGENTS.md / runtime baseline (outside this loader)
+ *   2. devclaw/prompts/orchestrator.md
+ *   3. devclaw/projects/<project>/prompts/orchestrator.md
+ *   4. package default
+ */
+export async function loadOrchestratorInstructions(
+  workspaceDir: string,
+  projectName?: string,
+): Promise<string>;
+export async function loadOrchestratorInstructions(
+  workspaceDir: string,
+  projectName: string | undefined,
+  opts: { withSource: true },
+): Promise<LayeredPromptInstructionsResult>;
+export async function loadOrchestratorInstructions(
+  workspaceDir: string,
+  projectName?: string,
+  opts?: { withSource: true },
+): Promise<string | LayeredPromptInstructionsResult> {
   const dataDir = path.join(workspaceDir, DATA_DIR);
+  const layers: string[] = [];
+  const sources: string[] = [];
 
-  const candidates = [
-    path.join(dataDir, "projects", projectName, "prompts", `${role}.md`),
-    path.join(workspaceDir, "projects", "roles", projectName, `${role}.md`),
-    path.join(dataDir, "prompts", `${role}.md`),
-    path.join(workspaceDir, "projects", "roles", "default", `${role}.md`),
+  const workspaceCandidates = [
+    path.join(dataDir, "prompts", "orchestrator.md"),
+    path.join(workspaceDir, "projects", "roles", "default", "orchestrator.md"),
   ];
-
-  for (const filePath of candidates) {
+  for (const filePath of workspaceCandidates) {
     try {
       const content = await fs.readFile(filePath, "utf-8");
-      if (opts?.withSource) return { content, source: filePath };
-      return content;
+      layers.push(content.trim());
+      sources.push(filePath);
+      break;
     } catch {
       /* not found, try next */
     }
   }
 
-  // Final fallback: package defaults (in-memory, always available)
-  const packageDefault = DEFAULT_ROLE_INSTRUCTIONS[role];
-  if (packageDefault) {
-    if (opts?.withSource) return { content: packageDefault, source: "package-default" };
-    return packageDefault;
+  if (projectName) {
+    const projectCandidates = [
+      path.join(dataDir, "projects", projectName, "prompts", "orchestrator.md"),
+      path.join(workspaceDir, "projects", "roles", projectName, "orchestrator.md"),
+    ];
+    for (const filePath of projectCandidates) {
+      try {
+        const content = await fs.readFile(filePath, "utf-8");
+        layers.push(content.trim());
+        sources.push(filePath);
+        break;
+      } catch {
+        /* not found, try next */
+      }
+    }
   }
 
-  if (opts?.withSource) return { content: "", source: null };
-  return "";
+  if (layers.length === 0 && DEFAULT_ORCHESTRATOR_PROMPT.trim()) {
+    layers.push(DEFAULT_ORCHESTRATOR_PROMPT.trim());
+    sources.push("package-default");
+  }
+
+  const content = layers.filter(Boolean).join("\n\n");
+  if (opts?.withSource) return { content, sources };
+  return content;
+}
+
+async function resolveProjectNameForBootstrap(
+  workspaceDir: string,
+  context: {
+    projectName?: string;
+    projectSlug?: string;
+    channelId?: string;
+    conversationId?: string;
+    messageThreadId?: number | string | null;
+    accountId?: string;
+    channel?: string;
+  },
+): Promise<string | undefined> {
+  if (context.projectName) return context.projectName;
+  if (context.projectSlug) return context.projectSlug;
+
+  const channelId = context.channelId ?? context.conversationId;
+  if (!channelId) return undefined;
+
+  try {
+    const data = await readProjects(workspaceDir);
+    return getProject(data, {
+      channelId,
+      channel: context.channel ?? "telegram",
+      accountId: context.accountId,
+      messageThreadId: context.messageThreadId,
+    })?.name;
+  } catch {
+    return undefined;
+  }
 }
 
 /**
- * Register the agent:bootstrap hook for DevClaw worker sessions.
+ * Register the agent:bootstrap hook for DevClaw sessions.
  *
- * Replaces the orchestrator's AGENTS.md with role-specific instructions
- * loaded from the workspace. This ensures workers see their own prompt on
- * every turn — not just the dispatch turn (where extraSystemPrompt is used).
+ * Worker precedence:
+ *   1. devclaw/projects/<project>/prompts/<role>.md
+ *   2. devclaw/prompts/<role>.md
+ *   3. package default prompt
  *
- * If role instructions are found, AGENTS.md content is replaced entirely.
- * If none are found, AGENTS.md is still stripped to avoid orchestrator bleed.
- *
- * Requires hooks.internal.enabled in config. If the hook doesn't fire,
- * dispatch.ts still passes instructions via extraSystemPrompt (single-turn).
+ * Orchestrator precedence inside bootstrap AGENTS content:
+ *   1. existing AGENTS.md/runtime baseline
+ *   2. devclaw/prompts/orchestrator.md
+ *   3. devclaw/projects/<project>/prompts/orchestrator.md
+ *   4. issue/task/chat-specific context (outside this hook)
  */
 export function registerBootstrapHook(api: OpenClawPluginApi, ctx: PluginContext): void {
   api.registerHook(
@@ -135,11 +234,15 @@ export function registerBootstrapHook(api: OpenClawPluginApi, ctx: PluginContext
       const sessionKey = event.sessionKey;
       if (!sessionKey) return;
 
-      const parsed = parseDevClawSessionKey(sessionKey);
-      if (!parsed) return;
-
       const context = event.context as {
         workspaceDir?: string;
+        projectName?: string;
+        projectSlug?: string;
+        channelId?: string;
+        conversationId?: string;
+        messageThreadId?: number | string | null;
+        accountId?: string;
+        channel?: string;
         bootstrapFiles?: Array<{
           name: string;
           path: string;
@@ -154,13 +257,30 @@ export function registerBootstrapHook(api: OpenClawPluginApi, ctx: PluginContext
       const agentsEntry = bootstrapFiles.find((f) => f.name === "AGENTS.md");
       if (!agentsEntry) return;
 
-      // Load role instructions from workspace (project-specific → default fallback)
+      const parsed = parseDevClawSessionKey(sessionKey);
       const workspaceDir = context.workspaceDir;
+
       if (!workspaceDir) {
+        if (!parsed) return;
         agentsEntry.content = "";
         agentsEntry.missing = true;
         ctx.logger.info(
           `agent:bootstrap: stripped AGENTS.md for ${parsed.role} worker in "${parsed.projectName}" (no workspaceDir)`,
+        );
+        return;
+      }
+
+      if (!parsed) {
+        const projectName = await resolveProjectNameForBootstrap(workspaceDir, context);
+        const { content, sources } = await loadOrchestratorInstructions(workspaceDir, projectName, { withSource: true });
+        if (!content.trim()) return;
+
+        const baseline = agentsEntry.content?.trimEnd() ?? "";
+        const separator = baseline ? "\n\n" : "";
+        agentsEntry.content = `${baseline}${separator}<!-- DEVCLAW:ORCHESTRATOR-PROMPT -->\n${content.trim()}\n<!-- /DEVCLAW:ORCHESTRATOR-PROMPT -->\n`;
+        agentsEntry.missing = false;
+        ctx.logger.info(
+          `agent:bootstrap: appended orchestrator instructions${projectName ? ` for "${projectName}"` : ""} from ${sources.join(" -> ")}`,
         );
         return;
       }
@@ -189,7 +309,7 @@ export function registerBootstrapHook(api: OpenClawPluginApi, ctx: PluginContext
     {
       name: "devclaw-bootstrap-role-instructions",
       description:
-        "Replaces orchestrator AGENTS.md with role-specific instructions for DevClaw workers",
+        "Replaces worker AGENTS.md with role prompts and appends live orchestrator prompts for main sessions",
     } as any,
   );
 }

--- a/lib/dispatch/index.ts
+++ b/lib/dispatch/index.ts
@@ -132,7 +132,11 @@ export async function dispatchTask(
   // Compute session key deterministically (avoids waiting for gateway)
   // Slot name provides both collision prevention and human-readable identity
   const botName = slotName(project.name, role, level, slotIndex);
-  const sessionKey = `agent:${agentId ?? "unknown"}:subagent:${project.name}-${role}-${level}-${botName.toLowerCase()}`;
+  // Use project.slug (always lowercase) to build session key.
+  // project.name may have mixed case (e.g. "UpMoltWork"), which caused heartbeat
+  // mismatches when the gateway stores session keys in lowercase format.
+  const projectKey = (project.slug ?? project.name).toLowerCase();
+  const sessionKey = `agent:${agentId ?? "unknown"}:subagent:${projectKey}-${role}-${level}-${botName.toLowerCase()}`;
 
   // Clear stale session key if it doesn't match the current deterministic key
   // (handles migration from old numeric format like ...-0 to name-based ...-Cordelia)

--- a/lib/dispatch/index.ts
+++ b/lib/dispatch/index.ts
@@ -271,6 +271,7 @@ export async function dispatchTask(
       channel: notifyTarget?.channel ?? "telegram",
       runtime,
       accountId: notifyTarget?.accountId,
+      messageThreadId: notifyTarget?.messageThreadId,
       runCommand: rc,
     },
   ).catch((err) => {

--- a/lib/dispatch/index.ts
+++ b/lib/dispatch/index.ts
@@ -7,6 +7,7 @@
 import type { PluginRuntime } from "openclaw/plugin-sdk";
 import type { RunCommand } from "../context.js";
 import { log as auditLog } from "../audit.js";
+import { recordLoopDiagnostic } from "../services/loop-diagnostics.js";
 import {
   type Project,
   activateWorker,
@@ -184,6 +185,16 @@ export async function dispatchTask(
 
   // ── Commitment point — transition label (issue leaves queue) ────────
   await provider.transitionLabel(issueId, fromLabel, toLabel);
+  await recordLoopDiagnostic(workspaceDir, "dispatch_pickup", {
+    project: project.name,
+    issueId,
+    role,
+    level,
+    from: fromLabel,
+    to: toLabel,
+    sessionAction,
+    sessionKey,
+  }).catch(() => {});
 
   // Mark issue + PR as managed and all consumed comments as seen (fire-and-forget)
   provider.reactToIssue(issueId, EYES_EMOJI).catch(() => {});

--- a/lib/dispatch/index.ts
+++ b/lib/dispatch/index.ts
@@ -299,6 +299,7 @@ export async function dispatchTask(
     dispatchTimeoutMs: timeouts.dispatchMs,
     extraSystemPrompt: roleInstructions.trim() || undefined,
     runCommand: rc,
+    notifyTarget,
   });
 
   // Step 5: Update worker state

--- a/lib/dispatch/notify.test.ts
+++ b/lib/dispatch/notify.test.ts
@@ -1,0 +1,149 @@
+/**
+ * Tests for notification delivery fallbacks.
+ *
+ * Run with: npx tsx --test lib/dispatch/notify.test.ts
+ */
+import { after, before, describe, it } from "node:test";
+import assert from "node:assert";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import type { CommandOptions, SpawnResult } from "openclaw/plugin-sdk/process/exec";
+import { notify } from "./notify.js";
+
+describe("notify", () => {
+  let tempDir: string;
+
+  before(async () => {
+    tempDir = await mkdtemp(join(tmpdir(), "devclaw-notify-test-"));
+  });
+
+  after(async () => {
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  it("falls back to CLI when the Telegram runtime sender is unavailable", async () => {
+    const calls: Array<{ args: string[]; timeoutMs?: number }> = [];
+
+    const ok = await notify(
+      {
+        type: "workerStart",
+        project: "devclaw",
+        issueId: 7,
+        issueTitle: "Fix Telegram worker notifications",
+        issueUrl: "https://example.com/issues/7",
+        role: "developer",
+        level: "senior",
+        name: "firstlight",
+        sessionAction: "spawn",
+      },
+      {
+        workspaceDir: tempDir,
+        channelId: "-100123",
+        channel: "telegram",
+        runtime: { channel: {} } as any,
+        runCommand: async (args, opts): Promise<SpawnResult> => {
+          const options = typeof opts === "number" ? { timeoutMs: opts } : opts as CommandOptions;
+          calls.push({ args, timeoutMs: options?.timeoutMs });
+          return {
+            stdout: "",
+            stderr: "",
+            code: 0,
+            signal: null,
+            killed: false,
+            termination: "exit",
+          };
+        },
+      },
+    );
+
+    assert.equal(ok, true);
+    assert.equal(calls.length, 1);
+    assert.deepEqual(calls[0]?.args.slice(0, 6), [
+      "openclaw",
+      "message",
+      "send",
+      "--channel",
+      "telegram",
+      "--target",
+    ]);
+    assert.equal(calls[0]?.args[6], "-100123");
+    assert.equal(calls[0]?.timeoutMs, 30_000);
+  });
+
+  it("falls back to CLI when the runtime sender throws", async () => {
+    const calls: Array<{ args: string[]; timeoutMs?: number }> = [];
+
+    const ok = await notify(
+      {
+        type: "workerComplete",
+        project: "devclaw",
+        issueId: 7,
+        issueUrl: "https://example.com/issues/7",
+        role: "developer",
+        result: "done",
+      },
+      {
+        workspaceDir: tempDir,
+        channelId: "-100123",
+        channel: "telegram",
+        runtime: {
+          channel: {
+            telegram: {
+              sendMessageTelegram: async () => {
+                throw new Error("telegram runtime unavailable");
+              },
+            },
+          },
+        } as any,
+        runCommand: async (args, opts): Promise<SpawnResult> => {
+          const options = typeof opts === "number" ? { timeoutMs: opts } : opts as CommandOptions;
+          calls.push({ args, timeoutMs: options?.timeoutMs });
+          return {
+            stdout: "",
+            stderr: "",
+            code: 0,
+            signal: null,
+            killed: false,
+            termination: "exit",
+          };
+        },
+      },
+    );
+
+    assert.equal(ok, true);
+    assert.equal(calls.length, 1);
+
+    const auditLog = await readFile(join(tempDir, "devclaw", "log", "audit.log"), "utf-8");
+    assert.match(auditLog, /"event":"notify_runtime_error"/);
+    assert.match(auditLog, /telegram runtime unavailable/);
+    assert.match(auditLog, /"event":"notify_delivery"/);
+    assert.match(auditLog, /"delivery":"cli-fallback"/);
+  });
+
+  it("logs notify_error and returns false when no sender is available", async () => {
+    const ok = await notify(
+      {
+        type: "workerComplete",
+        project: "devclaw",
+        issueId: 7,
+        issueUrl: "https://example.com/issues/7",
+        role: "developer",
+        result: "done",
+      },
+      {
+        workspaceDir: tempDir,
+        channelId: "-100123",
+        channel: "telegram",
+        runtime: { channel: {} } as any,
+      },
+    );
+
+    assert.equal(ok, false);
+
+    const auditLog = await readFile(join(tempDir, "devclaw", "log", "audit.log"), "utf-8");
+    assert.match(auditLog, /"event":"notify_error"/);
+    assert.match(auditLog, /"delivery":"failed"/);
+    assert.match(auditLog, /No runtime sender available for channel telegram/);
+  });
+});

--- a/lib/dispatch/notify.test.ts
+++ b/lib/dispatch/notify.test.ts
@@ -121,6 +121,57 @@ describe("notify", () => {
     assert.match(auditLog, /"delivery":"cli-fallback"/);
   });
 
+  it("passes messageThreadId through the Telegram CLI fallback", async () => {
+    const calls: Array<{ args: string[]; timeoutMs?: number }> = [];
+
+    const ok = await notify(
+      {
+        type: "workerComplete",
+        project: "devclaw",
+        issueId: 7,
+        issueUrl: "https://example.com/issues/7",
+        role: "developer",
+        result: "refine",
+      },
+      {
+        workspaceDir: tempDir,
+        channelId: "-100123",
+        channel: "telegram",
+        runtime: {
+          channel: {
+            telegram: {
+              sendMessageTelegram: async () => {
+                throw new Error("telegram runtime unavailable");
+              },
+            },
+          },
+        } as any,
+        runCommand: async (args, opts): Promise<SpawnResult> => {
+          const options = typeof opts === "number" ? { timeoutMs: opts } : opts as CommandOptions;
+          calls.push({ args, timeoutMs: options?.timeoutMs });
+          return {
+            stdout: "",
+            stderr: "",
+            code: 0,
+            signal: null,
+            killed: false,
+            termination: "exit",
+          };
+        },
+        messageThreadId: 176,
+      },
+    );
+
+    assert.equal(ok, true);
+    assert.equal(calls.length, 1);
+    assert.ok(calls[0]?.args.includes("--thread-id"));
+    assert.ok(calls[0]?.args.includes("176"));
+
+    const auditLog = await readFile(join(tempDir, "devclaw", "log", "audit.log"), "utf-8");
+    assert.match(auditLog, /"delivery":"cli-fallback"/);
+    assert.match(auditLog, /"messageThreadId":176/);
+  });
+
   it("logs notify_error and returns false when no sender is available", async () => {
     const ok = await notify(
       {

--- a/lib/dispatch/notify.test.ts
+++ b/lib/dispatch/notify.test.ts
@@ -121,57 +121,6 @@ describe("notify", () => {
     assert.match(auditLog, /"delivery":"cli-fallback"/);
   });
 
-  it("passes messageThreadId through the Telegram CLI fallback", async () => {
-    const calls: Array<{ args: string[]; timeoutMs?: number }> = [];
-
-    const ok = await notify(
-      {
-        type: "workerComplete",
-        project: "devclaw",
-        issueId: 7,
-        issueUrl: "https://example.com/issues/7",
-        role: "developer",
-        result: "refine",
-      },
-      {
-        workspaceDir: tempDir,
-        channelId: "-100123",
-        channel: "telegram",
-        runtime: {
-          channel: {
-            telegram: {
-              sendMessageTelegram: async () => {
-                throw new Error("telegram runtime unavailable");
-              },
-            },
-          },
-        } as any,
-        runCommand: async (args, opts): Promise<SpawnResult> => {
-          const options = typeof opts === "number" ? { timeoutMs: opts } : opts as CommandOptions;
-          calls.push({ args, timeoutMs: options?.timeoutMs });
-          return {
-            stdout: "",
-            stderr: "",
-            code: 0,
-            signal: null,
-            killed: false,
-            termination: "exit",
-          };
-        },
-        messageThreadId: 176,
-      },
-    );
-
-    assert.equal(ok, true);
-    assert.equal(calls.length, 1);
-    assert.ok(calls[0]?.args.includes("--thread-id"));
-    assert.ok(calls[0]?.args.includes("176"));
-
-    const auditLog = await readFile(join(tempDir, "devclaw", "log", "audit.log"), "utf-8");
-    assert.match(auditLog, /"delivery":"cli-fallback"/);
-    assert.match(auditLog, /"messageThreadId":176/);
-  });
-
   it("logs notify_error and returns false when no sender is available", async () => {
     const ok = await notify(
       {

--- a/lib/dispatch/notify.ts
+++ b/lib/dispatch/notify.ts
@@ -262,13 +262,16 @@ async function sendMessage(
   runtime?: PluginRuntime,
   accountId?: string,
   runCommand?: RunCommand,
+  messageThreadId?: number,
 ): Promise<boolean> {
   try {
     // Use runtime API when available (avoids CLI subprocess timeouts)
     if (runtime) {
       if (channel === "telegram") {
-        // Cast to any to bypass TypeScript type limitation; disableWebPagePreview is valid in Telegram API
-        await runtime.channel.telegram.sendMessageTelegram(target, message, { silent: true, disableWebPagePreview: true, accountId } as any);
+        // Cast to any to bypass TypeScript type limitation; disableWebPagePreview and messageThreadId are valid in Telegram API
+        const telegramOpts: Record<string, unknown> = { silent: true, disableWebPagePreview: true, accountId };
+        if (messageThreadId != null) telegramOpts.messageThreadId = messageThreadId;
+        await runtime.channel.telegram.sendMessageTelegram(target, message, telegramOpts as any);
         return true;
       }
       if (channel === "whatsapp") {
@@ -341,6 +344,8 @@ export async function notify(
     accountId?: string;
     /** Injected runCommand for dependency injection. */
     runCommand?: RunCommand;
+    /** Optional Telegram forum topic ID for per-topic routing */
+    messageThreadId?: number;
   },
 ): Promise<boolean> {
   if (opts.config?.[event.type] === false) return true;
@@ -364,7 +369,7 @@ export async function notify(
     message,
   });
 
-  return sendMessage(target, message, channel, opts.workspaceDir, opts.runtime, opts.accountId, opts.runCommand);
+  return sendMessage(target, message, channel, opts.workspaceDir, opts.runtime, opts.accountId, opts.runCommand, opts.messageThreadId);
 }
 
 /**

--- a/lib/dispatch/notify.ts
+++ b/lib/dispatch/notify.ts
@@ -85,6 +85,14 @@ export type NotifyEvent =
       issueUrl: string;
       issueTitle: string;
       prUrl?: string;
+    }
+  | {
+      type: "issueComplete";
+      project: string;
+      issueId: number;
+      issueUrl: string;
+      issueTitle: string;
+      prUrl?: string;
     };
 
 /**
@@ -243,6 +251,15 @@ function buildMessage(event: NotifyEvent): string {
       if (event.prUrl) msg += `\n🔗 ${prLink(event.prUrl)}`;
       msg += `\n📋 [Issue #${event.issueId}](${event.issueUrl})`;
       msg += `\n→ Moving to To Improve for developer attention`;
+      return msg;
+    }
+
+    case "issueComplete": {
+      let msg = `🏁 Issue completed: #${event.issueId} — ${event.issueTitle}`;
+      msg += `\n📦 Project: ${event.project}`;
+      if (event.prUrl) msg += `\n🔗 ${prLink(event.prUrl)}`;
+      msg += `\n📋 [Issue #${event.issueId}](${event.issueUrl})`;
+      msg += `\n✅ Issue closed — work delivered.`;
       return msg;
     }
   }

--- a/lib/dispatch/notify.ts
+++ b/lib/dispatch/notify.ts
@@ -281,84 +281,60 @@ async function sendMessage(
   runCommand?: RunCommand,
   messageThreadId?: number,
 ): Promise<boolean> {
-  const runtimeChannel = runtime?.channel as Record<string, any> | undefined;
-  const runtimeSender =
-    channel === "telegram" ? runtimeChannel?.telegram?.sendMessageTelegram :
-    channel === "whatsapp" ? runtimeChannel?.whatsapp?.sendMessageWhatsApp :
-    channel === "discord" ? runtimeChannel?.discord?.sendMessageDiscord :
-    channel === "slack" ? runtimeChannel?.slack?.sendMessageSlack :
-    channel === "signal" ? runtimeChannel?.signal?.sendMessageSignal :
-    undefined;
-
-  if (runtimeSender) {
-    try {
+  try {
+    // Use runtime API when available (avoids CLI subprocess timeouts)
+    if (runtime) {
       if (channel === "telegram") {
+        // Cast to any to bypass TypeScript type limitation; disableWebPagePreview and messageThreadId are valid in Telegram API
         const telegramOpts: Record<string, unknown> = { silent: true, disableWebPagePreview: true, accountId };
         if (messageThreadId != null) telegramOpts.messageThreadId = messageThreadId;
-        await runtimeSender(target, message, telegramOpts as any);
-      } else if (channel === "whatsapp") {
-        await runtimeSender(target, message, { verbose: false, accountId });
-      } else {
-        await runtimeSender(target, message, { accountId });
+        await runtime.channel.telegram.sendMessageTelegram(target, message, telegramOpts as any);
+        return true;
       }
-
-      await auditLog(workspaceDir, "notify_delivery", {
-        target,
-        channel,
-        delivery: "runtime",
-      });
-      return true;
-    } catch (err) {
-      await auditLog(workspaceDir, "notify_runtime_error", {
-        target,
-        channel,
-        error: (err as Error).message,
-      });
+      if (channel === "whatsapp") {
+        await runtime.channel.whatsapp.sendMessageWhatsApp(target, message, { verbose: false, accountId });
+        return true;
+      }
+      if (channel === "discord") {
+        await runtime.channel.discord.sendMessageDiscord(target, message, { accountId });
+        return true;
+      }
+      if (channel === "slack") {
+        await runtime.channel.slack.sendMessageSlack(target, message, { accountId });
+        return true;
+      }
+      if (channel === "signal") {
+        await runtime.channel.signal.sendMessageSignal(target, message, { accountId });
+        return true;
+      }
     }
-  }
 
-  if (!runCommand) {
-    await auditLog(workspaceDir, "notify_error", {
-      target,
-      channel,
-      delivery: "failed",
-      error: `No runtime sender available for channel ${channel} and runCommand is not available`,
-    });
-    return false;
-  }
-
-  try {
+    // Fallback: use CLI (for unsupported channels or when runtime isn't available)
+    if (!runCommand) throw new Error("runCommand is required when runtime is not available");
     const rc = runCommand;
-    const argv = [
-      "openclaw",
-      "message",
-      "send",
-      "--channel",
-      channel,
-      "--target",
-      target,
-      "--message",
-      message,
-    ];
-    if (channel === "telegram" && messageThreadId != null) {
-      argv.push("--thread-id", String(messageThreadId));
-    }
-    argv.push("--json");
-
-    await rc(argv, { timeoutMs: 30_000 });
-
-    await auditLog(workspaceDir, "notify_delivery", {
-      target,
-      channel,
-      delivery: "cli-fallback",
-      ...(channel === "telegram" && messageThreadId != null ? { messageThreadId } : {}),
-    });
+    // Note: openclaw message send CLI doesn't expose disable_web_page_preview flag.
+    // The runtime API path (above) handles it; CLI fallback won't suppress previews.
+    await rc(
+      [
+        "openclaw",
+        "message",
+        "send",
+        "--channel",
+        channel,
+        "--target",
+        target,
+        "--message",
+        message,
+        "--json",
+      ],
+      { timeoutMs: 30_000 },
+    );
     return true;
   } catch (err) {
+    // Log but don't throw — notifications shouldn't break the main flow
     await auditLog(workspaceDir, "notify_error", {
       target,
       channel,
-      delivery: "failed",
       error: (err as Error).message,
     });
     return false;

--- a/lib/dispatch/notify.ts
+++ b/lib/dispatch/notify.ts
@@ -281,60 +281,84 @@ async function sendMessage(
   runCommand?: RunCommand,
   messageThreadId?: number,
 ): Promise<boolean> {
-  try {
-    // Use runtime API when available (avoids CLI subprocess timeouts)
-    if (runtime) {
+  const runtimeChannel = runtime?.channel as Record<string, any> | undefined;
+  const runtimeSender =
+    channel === "telegram" ? runtimeChannel?.telegram?.sendMessageTelegram :
+    channel === "whatsapp" ? runtimeChannel?.whatsapp?.sendMessageWhatsApp :
+    channel === "discord" ? runtimeChannel?.discord?.sendMessageDiscord :
+    channel === "slack" ? runtimeChannel?.slack?.sendMessageSlack :
+    channel === "signal" ? runtimeChannel?.signal?.sendMessageSignal :
+    undefined;
+
+  if (runtimeSender) {
+    try {
       if (channel === "telegram") {
-        // Cast to any to bypass TypeScript type limitation; disableWebPagePreview and messageThreadId are valid in Telegram API
         const telegramOpts: Record<string, unknown> = { silent: true, disableWebPagePreview: true, accountId };
         if (messageThreadId != null) telegramOpts.messageThreadId = messageThreadId;
-        await runtime.channel.telegram.sendMessageTelegram(target, message, telegramOpts as any);
-        return true;
+        await runtimeSender(target, message, telegramOpts as any);
+      } else if (channel === "whatsapp") {
+        await runtimeSender(target, message, { verbose: false, accountId });
+      } else {
+        await runtimeSender(target, message, { accountId });
       }
-      if (channel === "whatsapp") {
-        await runtime.channel.whatsapp.sendMessageWhatsApp(target, message, { verbose: false, accountId });
-        return true;
-      }
-      if (channel === "discord") {
-        await runtime.channel.discord.sendMessageDiscord(target, message, { accountId });
-        return true;
-      }
-      if (channel === "slack") {
-        await runtime.channel.slack.sendMessageSlack(target, message, { accountId });
-        return true;
-      }
-      if (channel === "signal") {
-        await runtime.channel.signal.sendMessageSignal(target, message, { accountId });
-        return true;
-      }
-    }
 
-    // Fallback: use CLI (for unsupported channels or when runtime isn't available)
-    if (!runCommand) throw new Error("runCommand is required when runtime is not available");
-    const rc = runCommand;
-    // Note: openclaw message send CLI doesn't expose disable_web_page_preview flag.
-    // The runtime API path (above) handles it; CLI fallback won't suppress previews.
-    await rc(
-      [
-        "openclaw",
-        "message",
-        "send",
-        "--channel",
-        channel,
-        "--target",
+      await auditLog(workspaceDir, "notify_delivery", {
         target,
-        "--message",
-        message,
-        "--json",
-      ],
-      { timeoutMs: 30_000 },
-    );
-    return true;
-  } catch (err) {
-    // Log but don't throw — notifications shouldn't break the main flow
+        channel,
+        delivery: "runtime",
+      });
+      return true;
+    } catch (err) {
+      await auditLog(workspaceDir, "notify_runtime_error", {
+        target,
+        channel,
+        error: (err as Error).message,
+      });
+    }
+  }
+
+  if (!runCommand) {
     await auditLog(workspaceDir, "notify_error", {
       target,
       channel,
+      delivery: "failed",
+      error: `No runtime sender available for channel ${channel} and runCommand is not available`,
+    });
+    return false;
+  }
+
+  try {
+    const rc = runCommand;
+    const argv = [
+      "openclaw",
+      "message",
+      "send",
+      "--channel",
+      channel,
+      "--target",
+      target,
+      "--message",
+      message,
+    ];
+    if (channel === "telegram" && messageThreadId != null) {
+      argv.push("--thread-id", String(messageThreadId));
+    }
+    argv.push("--json");
+
+    await rc(argv, { timeoutMs: 30_000 });
+
+    await auditLog(workspaceDir, "notify_delivery", {
+      target,
+      channel,
+      delivery: "cli-fallback",
+      ...(channel === "telegram" && messageThreadId != null ? { messageThreadId } : {}),
+    });
+    return true;
+  } catch (err) {
+    await auditLog(workspaceDir, "notify_error", {
+      target,
+      channel,
+      delivery: "failed",
       error: (err as Error).message,
     });
     return false;

--- a/lib/dispatch/notify.ts
+++ b/lib/dispatch/notify.ts
@@ -263,34 +263,54 @@ async function sendMessage(
   accountId?: string,
   runCommand?: RunCommand,
 ): Promise<boolean> {
-  try {
-    // Use runtime API when available (avoids CLI subprocess timeouts)
-    if (runtime) {
+  const runtimeChannel = runtime?.channel as Record<string, any> | undefined;
+  const runtimeSender =
+    channel === "telegram" ? runtimeChannel?.telegram?.sendMessageTelegram :
+    channel === "whatsapp" ? runtimeChannel?.whatsapp?.sendMessageWhatsApp :
+    channel === "discord" ? runtimeChannel?.discord?.sendMessageDiscord :
+    channel === "slack" ? runtimeChannel?.slack?.sendMessageSlack :
+    channel === "signal" ? runtimeChannel?.signal?.sendMessageSignal :
+    undefined;
+
+  // Use runtime API when available (avoids CLI subprocess timeouts)
+  if (runtimeSender) {
+    try {
       if (channel === "telegram") {
         // Cast to any to bypass TypeScript type limitation; disableWebPagePreview is valid in Telegram API
-        await runtime.channel.telegram.sendMessageTelegram(target, message, { silent: true, disableWebPagePreview: true, accountId } as any);
-        return true;
+        await runtimeSender(target, message, { silent: true, disableWebPagePreview: true, accountId } as any);
+      } else if (channel === "whatsapp") {
+        await runtimeSender(target, message, { verbose: false, accountId });
+      } else {
+        await runtimeSender(target, message, { accountId });
       }
-      if (channel === "whatsapp") {
-        await runtime.channel.whatsapp.sendMessageWhatsApp(target, message, { verbose: false, accountId });
-        return true;
-      }
-      if (channel === "discord") {
-        await runtime.channel.discord.sendMessageDiscord(target, message, { accountId });
-        return true;
-      }
-      if (channel === "slack") {
-        await runtime.channel.slack.sendMessageSlack(target, message, { accountId });
-        return true;
-      }
-      if (channel === "signal") {
-        await runtime.channel.signal.sendMessageSignal(target, message, { accountId });
-        return true;
-      }
-    }
 
-    // Fallback: use CLI (for unsupported channels or when runtime isn't available)
-    if (!runCommand) throw new Error("runCommand is required when runtime is not available");
+      await auditLog(workspaceDir, "notify_delivery", {
+        target,
+        channel,
+        delivery: "runtime",
+      });
+      return true;
+    } catch (err) {
+      await auditLog(workspaceDir, "notify_runtime_error", {
+        target,
+        channel,
+        error: (err as Error).message,
+      });
+    }
+  }
+
+  // Fallback: use CLI (for unsupported channels, missing runtime senders, or runtime send failures)
+  if (!runCommand) {
+    await auditLog(workspaceDir, "notify_error", {
+      target,
+      channel,
+      delivery: "failed",
+      error: `No runtime sender available for channel ${channel} and runCommand is not available`,
+    });
+    return false;
+  }
+
+  try {
     const rc = runCommand;
     // Note: openclaw message send CLI doesn't expose disable_web_page_preview flag.
     // The runtime API path (above) handles it; CLI fallback won't suppress previews.
@@ -309,12 +329,19 @@ async function sendMessage(
       ],
       { timeoutMs: 30_000 },
     );
+
+    await auditLog(workspaceDir, "notify_delivery", {
+      target,
+      channel,
+      delivery: "cli-fallback",
+    });
     return true;
   } catch (err) {
     // Log but don't throw — notifications shouldn't break the main flow
     await auditLog(workspaceDir, "notify_error", {
       target,
       channel,
+      delivery: "failed",
       error: (err as Error).message,
     });
     return false;

--- a/lib/dispatch/session.ts
+++ b/lib/dispatch/session.ts
@@ -82,12 +82,56 @@ export function ensureSessionFireAndForget(sessionKey: string, model: string, wo
   });
 }
 
+/** Same shape as `resolveNotifyChannel()` — used to pass Telegram chat/topic into the gateway agent run. */
+export type NotifyRoutingTarget = {
+  channelId: string;
+  channel: string;
+  accountId?: string;
+  messageThreadId?: number;
+};
+
+function applyNotifyRoutingToGatewayParams(
+  params: Record<string, unknown>,
+  target: NotifyRoutingTarget | undefined,
+): void {
+  if (!target?.channelId) {
+    return;
+  }
+  params.to = target.channelId;
+  params.channel = target.channel;
+  if (target.accountId) {
+    params.accountId = target.accountId;
+  }
+  if (target.messageThreadId != null && Number.isFinite(Number(target.messageThreadId))) {
+    params.threadId = String(Math.trunc(Number(target.messageThreadId)));
+  }
+}
+
 export function sendToAgent(
   sessionKey: string, taskMessage: string,
-  opts: { agentId?: string; projectName: string; issueId: number; role: string; level?: string; slotIndex?: number; fromLabel?: string; orchestratorSessionKey?: string; workspaceDir: string; dispatchTimeoutMs?: number; extraSystemPrompt?: string; runCommand: RunCommand },
+  opts: {
+    agentId?: string;
+    projectName: string;
+    issueId: number;
+    role: string;
+    level?: string;
+    slotIndex?: number;
+    fromLabel?: string;
+    orchestratorSessionKey?: string;
+    workspaceDir: string;
+    dispatchTimeoutMs?: number;
+    extraSystemPrompt?: string;
+    runCommand: RunCommand;
+    /**
+     * When set (e.g. from `resolveNotifyChannel`), forwarded to the gateway `agent` call as
+     * `to`, `channel`, `accountId`, and `threadId` so plugin tools get `messageThreadId` injection
+     * (Telegram forum topics) on the worker run.
+     */
+    notifyTarget?: NotifyRoutingTarget;
+  },
 ): void {
   const rc = opts.runCommand;
-  const gatewayParams = JSON.stringify({
+  const gatewayParamsRecord: Record<string, unknown> = {
     idempotencyKey: `devclaw-${opts.projectName}-${opts.issueId}-${opts.role}-${opts.level ?? "unknown"}-${opts.slotIndex ?? 0}-${opts.fromLabel ?? "unknown"}-${sessionKey}`,
     agentId: opts.agentId ?? "devclaw",
     sessionKey,
@@ -96,7 +140,9 @@ export function sendToAgent(
     lane: "subagent",
     ...(opts.orchestratorSessionKey ? { spawnedBy: opts.orchestratorSessionKey } : {}),
     ...(opts.extraSystemPrompt ? { extraSystemPrompt: opts.extraSystemPrompt } : {}),
-  });
+  };
+  applyNotifyRoutingToGatewayParams(gatewayParamsRecord, opts.notifyTarget);
+  const gatewayParams = JSON.stringify(gatewayParamsRecord);
   // Fire-and-forget: long-running agent turn, don't await
   rc(
     ["openclaw", "gateway", "call", "agent", "--params", gatewayParams, "--expect-final", "--json"],

--- a/lib/json-result.ts
+++ b/lib/json-result.ts
@@ -1,0 +1,14 @@
+/**
+ * OpenClaw tool success shape — mirrors `jsonResult` from `openclaw/plugin-sdk`.
+ * Implemented locally so DevClaw tools work when the host resolves `openclaw/plugin-sdk`
+ * in a way that breaks named imports (e.g. interop / bundling).
+ */
+export function jsonResult(payload: unknown): {
+  content: Array<{ type: "text"; text: string }>;
+  details: unknown;
+} {
+  return {
+    content: [{ type: "text", text: JSON.stringify(payload, null, 2) }],
+    details: payload,
+  };
+}

--- a/lib/projects/io.ts
+++ b/lib/projects/io.ts
@@ -7,7 +7,7 @@ import { homedir } from "node:os";
 import { migrateProject } from "./migrations.js";
 import { ensureWorkspaceMigrated, DATA_DIR } from "../setup/migrate-layout.js";
 import { isLegacySchema, migrateLegacySchema } from "./schema-migration.js";
-import type { ProjectsData, Project, Channel } from "./types.js";
+import type { ProjectsData, Project } from "./types.js";
 import { emptySlot } from "./slots.js";
 
 
@@ -117,22 +117,6 @@ export function resolveProjectChannelScope(opts: {
 }
 
 /**
- * Normalize a channel's topic-related fields for resolution.
- * - For Telegram, map legacy topicId into messageThreadId when needed.
- * - Leaves non-Telegram channels unchanged (they are effectively root-scope).
- */
-function normalizeChannelTopic(ch: Channel): Channel {
-  if (ch.channel !== "telegram") {
-    return ch;
-  }
-  const legacy = ch as Channel & { topicId?: number };
-  if (ch.messageThreadId == null && legacy.topicId != null) {
-    ch.messageThreadId = legacy.topicId;
-  }
-  return ch;
-}
-
-/**
  * Resolve a project by slug or channel scope (for backward compatibility).
  * When given a bare string, treats it as slug or channelId (legacy behavior).
  * When given a scope object, performs topic-aware resolution.
@@ -177,8 +161,7 @@ export function resolveProjectSlug(
   let fallbackSlug: string | undefined;
 
   for (const [slug, project] of Object.entries(data.projects)) {
-    for (const rawCh of project.channels) {
-      const ch = normalizeChannelTopic(rawCh);
+    for (const ch of project.channels) {
       const scopeKey = resolveProjectChannelScope({
         channel: ch.channel,
         channelId: ch.channelId,

--- a/lib/projects/io.ts
+++ b/lib/projects/io.ts
@@ -7,7 +7,7 @@ import { homedir } from "node:os";
 import { migrateProject } from "./migrations.js";
 import { ensureWorkspaceMigrated, DATA_DIR } from "../setup/migrate-layout.js";
 import { isLegacySchema, migrateLegacySchema } from "./schema-migration.js";
-import type { ProjectsData, Project } from "./types.js";
+import type { ProjectsData, Project, Channel } from "./types.js";
 import { emptySlot } from "./slots.js";
 
 
@@ -102,36 +102,122 @@ export async function writeProjects(
 }
 
 /**
- * Resolve a project by slug or channelId (for backward compatibility).
- * Returns the slug of the found project.
+ * Build a stable scope key for a channel binding.
+ * Used for topic-aware project resolution.
  */
-export function resolveProjectSlug(
-  data: ProjectsData,
-  slugOrChannelId: string,
-): string | undefined {
-  // Direct lookup by slug
-  if (data.projects[slugOrChannelId]) {
-    return slugOrChannelId;
-  }
-
-  // Reverse lookup by channelId in channels
-  for (const [slug, project] of Object.entries(data.projects)) {
-    if (project.channels.some(ch => ch.channelId === slugOrChannelId)) {
-      return slug;
-    }
-  }
-
-  return undefined;
+export function resolveProjectChannelScope(opts: {
+  channel: string;
+  channelId: string;
+  accountId?: string;
+  messageThreadId?: number | string | null;
+}): string {
+  const account = opts.accountId ?? "default";
+  const topic = opts.messageThreadId ?? "root";
+  return `${opts.channel}:${account}:${opts.channelId}:topic:${topic}`;
 }
 
 /**
- * Get a project by slug or channelId (dual-mode resolution).
+ * Normalize a channel's topic-related fields for resolution.
+ * - For Telegram, map legacy topicId into messageThreadId when needed.
+ * - Leaves non-Telegram channels unchanged (they are effectively root-scope).
+ */
+function normalizeChannelTopic(ch: Channel): Channel {
+  if (ch.channel !== "telegram") {
+    return ch;
+  }
+  const legacy = ch as Channel & { topicId?: number };
+  if (ch.messageThreadId == null && legacy.topicId != null) {
+    ch.messageThreadId = legacy.topicId;
+  }
+  return ch;
+}
+
+/**
+ * Resolve a project by slug or channel scope (for backward compatibility).
+ * When given a bare string, treats it as slug or channelId (legacy behavior).
+ * When given a scope object, performs topic-aware resolution.
+ */
+export function resolveProjectSlug(
+  data: ProjectsData,
+  slugOrChannelIdOrScope: string | {
+    channelId: string;
+    channel?: string;
+    accountId?: string;
+    messageThreadId?: number | string | null;
+  },
+): string | undefined {
+  // String input: legacy mode (slug or channelId)
+  if (typeof slugOrChannelIdOrScope === "string") {
+    const slugOrChannelId = slugOrChannelIdOrScope;
+    // Direct lookup by slug
+    if (data.projects[slugOrChannelId]) {
+      return slugOrChannelId;
+    }
+
+    // Reverse lookup by channelId in channels
+    for (const [slug, project] of Object.entries(data.projects)) {
+      if (project.channels.some((ch) => ch.channelId === slugOrChannelId)) {
+        return slug;
+      }
+    }
+
+    return undefined;
+  }
+
+  // Scoped input: topic-aware resolution
+  const { channelId, channel, accountId, messageThreadId } = slugOrChannelIdOrScope;
+  const requestedChannel = channel ?? "telegram";
+  const requestedKey = resolveProjectChannelScope({
+    channel: requestedChannel,
+    channelId,
+    accountId,
+    messageThreadId,
+  });
+
+  let fallbackSlug: string | undefined;
+
+  for (const [slug, project] of Object.entries(data.projects)) {
+    for (const rawCh of project.channels) {
+      const ch = normalizeChannelTopic(rawCh);
+      const scopeKey = resolveProjectChannelScope({
+        channel: ch.channel,
+        channelId: ch.channelId,
+        accountId: ch.accountId,
+        messageThreadId: ch.messageThreadId,
+      });
+
+      // Exact topic match wins immediately
+      if (scopeKey === requestedKey) {
+        return slug;
+      }
+
+      // Record chat-level fallback when messageThreadId is undefined/root
+      const isRootScope =
+        ch.channel === requestedChannel &&
+        ch.channelId === channelId &&
+        (ch.messageThreadId == null || ch.messageThreadId === ("root" as any));
+      if (isRootScope && !fallbackSlug) {
+        fallbackSlug = slug;
+      }
+    }
+  }
+
+  return fallbackSlug;
+}
+
+/**
+ * Get a project by slug or channel scope (dual-mode resolution).
  */
 export function getProject(
   data: ProjectsData,
-  slugOrChannelId: string,
+  slugOrChannelIdOrScope: string | {
+    channelId: string;
+    channel?: string;
+    accountId?: string;
+    messageThreadId?: number | string | null;
+  },
 ): Project | undefined {
-  const slug = resolveProjectSlug(data, slugOrChannelId);
+  const slug = resolveProjectSlug(data, slugOrChannelIdOrScope);
   return slug ? data.projects[slug] : undefined;
 }
 

--- a/lib/projects/migrations.ts
+++ b/lib/projects/migrations.ts
@@ -12,7 +12,7 @@
  * - projects.json format: flat slots → per-level format
  */
 
-import type { RoleWorkerState, SlotState, Project } from "./types.js";
+import type { RoleWorkerState, SlotState, Project, Channel } from "./types.js";
 
 // ---------------------------------------------------------------------------
 // Role aliases — old role IDs → canonical IDs
@@ -228,6 +228,25 @@ export function migrateProject(project: Project): boolean {
     }
   } else {
     project.workers = {};
+  }
+
+  // Normalize channel topic fields for Telegram channels:
+  // - Migrate legacy groupId -> channelId (handled below)
+  // - Migrate legacy topicId -> messageThreadId when messageThreadId is missing
+  if (project.channels) {
+    for (const ch of project.channels) {
+      const rawCh = ch as unknown as Record<string, unknown> & Channel;
+
+      // Normalize legacy Telegram topic field: topicId -> messageThreadId
+      if (
+        rawCh.channel === "telegram" &&
+        rawCh.topicId != null &&
+        rawCh.messageThreadId == null
+      ) {
+        rawCh.messageThreadId = Number(rawCh.topicId);
+        changed = true;
+      }
+    }
   }
 
   // Migrate legacy `groupId` field to `channelId` in channel objects.

--- a/lib/projects/migrations.ts
+++ b/lib/projects/migrations.ts
@@ -195,6 +195,7 @@ function parseWorkerState(worker: Record<string, unknown>, role: string): RoleWo
  * 3. Old level names in worker state
  * 4. Old slot-based format → per-level format
  * 5. Missing channel field defaults to "telegram"
+ * 6. Telegram: legacy topicId → messageThreadId; topicId removed from stored shape
  */
 /**
  * Returns true if any migration was applied (caller should persist).
@@ -230,22 +231,16 @@ export function migrateProject(project: Project): boolean {
     project.workers = {};
   }
 
-  // Normalize channel topic fields for Telegram channels:
-  // - Migrate legacy groupId -> channelId (handled below)
-  // - Migrate legacy topicId -> messageThreadId when messageThreadId is missing
+  // Telegram channels: legacy topicId → messageThreadId; drop topicId (canonical field only)
   if (project.channels) {
     for (const ch of project.channels) {
       const rawCh = ch as unknown as Record<string, unknown> & Channel;
-
-      // Normalize legacy Telegram topic field: topicId -> messageThreadId
-      if (
-        rawCh.channel === "telegram" &&
-        rawCh.topicId != null &&
-        rawCh.messageThreadId == null
-      ) {
+      if (rawCh.channel !== "telegram" || rawCh.topicId == null) continue;
+      if (rawCh.messageThreadId == null) {
         rawCh.messageThreadId = Number(rawCh.topicId);
-        changed = true;
       }
+      delete rawCh.topicId;
+      changed = true;
     }
   }
 

--- a/lib/projects/projects.test.ts
+++ b/lib/projects/projects.test.ts
@@ -17,6 +17,7 @@ import {
   countActiveSlots,
   reconcileSlots,
   writeProjects,
+  resolveProjectSlug,
   type ProjectsData,
   type RoleWorkerState,
 } from "./index.js";
@@ -257,6 +258,87 @@ describe("readProjects migration", () => {
     assert.ok(project.workers.tester, "qa should be migrated to tester");
     assert.ok(project.workers.developer.levels.medior, "mid should be migrated to medior");
     assert.strictEqual(project.workers.developer.levels.medior[0]!.sessionKey, "key-m");
+
+    await fs.rm(tmpDir, { recursive: true });
+  });
+
+  it("should migrate legacy topicId to messageThreadId and strip topicId from disk", async () => {
+    const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "devclaw-proj-"));
+    const dataDir = path.join(tmpDir, "devclaw");
+    await fs.mkdir(dataDir, { recursive: true });
+
+    const raw = {
+      projects: {
+        p1: {
+          slug: "p1",
+          name: "P1",
+          repo: "~/p1",
+          groupName: "P1",
+          deployUrl: "",
+          baseBranch: "main",
+          deployBranch: "main",
+          channels: [
+            {
+              channelId: "-100",
+              channel: "telegram",
+              name: "primary",
+              events: ["*"],
+              topicId: 42,
+            },
+          ],
+          workers: {
+            developer: emptyRoleWorkerState({ junior: 1 }),
+            tester: emptyRoleWorkerState({ junior: 1 }),
+            architect: emptyRoleWorkerState({ senior: 1 }),
+          },
+        },
+        p2: {
+          slug: "p2",
+          name: "P2",
+          repo: "~/p2",
+          groupName: "P2",
+          deployUrl: "",
+          baseBranch: "main",
+          deployBranch: "main",
+          channels: [
+            {
+              channelId: "-100",
+              channel: "telegram",
+              name: "primary",
+              events: ["*"],
+              topicId: 176,
+              messageThreadId: 176,
+            },
+          ],
+          workers: {
+            developer: emptyRoleWorkerState({ junior: 1 }),
+            tester: emptyRoleWorkerState({ junior: 1 }),
+            architect: emptyRoleWorkerState({ senior: 1 }),
+          },
+        },
+      },
+    };
+    await fs.writeFile(path.join(dataDir, "projects.json"), JSON.stringify(raw), "utf-8");
+
+    const data = await readProjects(tmpDir);
+    const ch1 = data.projects.p1.channels[0]!;
+    assert.strictEqual(ch1.messageThreadId, 42);
+    assert.strictEqual((ch1 as { topicId?: unknown }).topicId, undefined);
+
+    const ch2 = data.projects.p2.channels[0]!;
+    assert.strictEqual(ch2.messageThreadId, 176);
+    assert.strictEqual((ch2 as { topicId?: unknown }).topicId, undefined);
+
+    const disk = JSON.parse(await fs.readFile(path.join(dataDir, "projects.json"), "utf-8")) as {
+      projects: { p1: { channels: Array<{ topicId?: number }> }; p2: { channels: Array<{ topicId?: number }> } };
+    };
+    assert.strictEqual(disk.projects.p1.channels[0]!.topicId, undefined);
+    assert.strictEqual(disk.projects.p2.channels[0]!.topicId, undefined);
+
+    assert.strictEqual(
+      resolveProjectSlug(data, { channelId: "-100", channel: "telegram", messageThreadId: 42 }),
+      "p1",
+    );
 
     await fs.rm(tmpDir, { recursive: true });
   });

--- a/lib/projects/types.ts
+++ b/lib/projects/types.ts
@@ -33,6 +33,7 @@ export type Channel = {
   name: string; // e.g. "primary", "dev-chat"
   events: string[]; // e.g. ["*"] for all, ["workerComplete"] for filtered
   accountId?: string; // Optional account ID for multi-account setups
+  messageThreadId?: number; // Optional Telegram forum topic ID for per-topic routing
 };
 
 /**

--- a/lib/projects/types.ts
+++ b/lib/projects/types.ts
@@ -33,7 +33,11 @@ export type Channel = {
   name: string; // e.g. "primary", "dev-chat"
   events: string[]; // e.g. ["*"] for all, ["workerComplete"] for filtered
   accountId?: string; // Optional account ID for multi-account setups
-  messageThreadId?: number; // Optional Telegram forum topic ID for per-topic routing
+  /**
+   * Telegram forum topic ID used for topic-scoped routing.
+   * Mirrors Telegram API naming for clarity and interoperability.
+   */
+  messageThreadId?: number;
 };
 
 /**

--- a/lib/providers/github.ts
+++ b/lib/providers/github.ts
@@ -73,6 +73,7 @@ export class GitHubProvider implements IssueProvider {
     if (args[0] === "repo") return true;
     if (args[0] === "issue") return true;
     if (args[0] === "pr") return true;
+    if (args[0] === "label") return true;
     if (args[0] !== "api") return false;
     return !args.includes("graphql");
   }

--- a/lib/providers/github.ts
+++ b/lib/providers/github.ts
@@ -61,11 +61,25 @@ export class GitHubProvider implements IssueProvider {
   }
 
   private withRepo(args: string[]): string[] {
-    if (!this.targetRepo) return args;
-    const needsExplicitRepo = this.commandSupportsRepo(args);
-    if (!needsExplicitRepo) return args;
+    if (!this.targetRepo || args.length === 0) return args;
+    if (args[0] === "api") return this.withApiTarget(args);
+    if (!this.commandSupportsRepo(args)) return args;
     if (args.includes("--repo") || args.includes("-R")) return args;
     return [...args, "--repo", this.targetRepo];
+  }
+
+  private withApiTarget(args: string[]): string[] {
+    if (args.includes("graphql")) return args;
+    const repo = this.getTargetRepoParts();
+    if (!repo) return args;
+    if (args.length < 2) return args;
+
+    const route = args[1]
+      .replace(/(^|\/)repos\/:owner\/:repo(?=\/|$)/, `$1repos/${repo.owner}/${repo.name}`)
+      .replace(/(^|\/)projects\/:id(?=\/|$)/, `$1repos/${repo.owner}/${repo.name}`);
+
+    if (route === args[1]) return args;
+    return [args[0], route, ...args.slice(2)];
   }
 
   private commandSupportsRepo(args: string[]): boolean {
@@ -74,8 +88,13 @@ export class GitHubProvider implements IssueProvider {
     if (args[0] === "issue") return true;
     if (args[0] === "pr") return true;
     if (args[0] === "label") return true;
-    if (args[0] !== "api") return false;
-    return !args.includes("graphql");
+    return false;
+  }
+
+  private getTargetRepoParts(): { owner: string; name: string } | null {
+    if (!this.targetRepo) return null;
+    const [owner, name] = this.targetRepo.split("/");
+    return owner && name ? { owner, name } : null;
   }
 
   /** Cached repo owner/name for GraphQL queries. */
@@ -88,12 +107,10 @@ export class GitHubProvider implements IssueProvider {
   private async getRepoInfo(): Promise<{ owner: string; name: string } | null> {
     if (this.repoInfo !== undefined) return this.repoInfo;
     try {
-      if (this.targetRepo) {
-        const [owner, name] = this.targetRepo.split("/");
-        if (owner && name) {
-          this.repoInfo = { owner, name };
-          return this.repoInfo;
-        }
+      const targetRepo = this.getTargetRepoParts();
+      if (targetRepo) {
+        this.repoInfo = targetRepo;
+        return this.repoInfo;
       }
       const raw = await this.gh(["repo", "view", "--json", "owner,name"]);
       const data = JSON.parse(raw);

--- a/lib/providers/github.ts
+++ b/lib/providers/github.ts
@@ -10,6 +10,7 @@ import {
   type PrReviewComment,
   PrState,
 } from "./provider.js";
+import type { ProviderTarget } from "./provider.js";
 import type { RunCommand } from "../context.js";
 import { withResilience } from "./resilience.js";
 import {
@@ -39,21 +40,41 @@ export class GitHubProvider implements IssueProvider {
   private repoPath: string;
   private workflow: WorkflowConfig;
   private runCommand: RunCommand;
+  private targetRepo?: string;
 
-  constructor(opts: { repoPath: string; runCommand: RunCommand; workflow?: WorkflowConfig }) {
+  constructor(opts: { repoPath: string; runCommand: RunCommand; workflow?: WorkflowConfig; target?: ProviderTarget }) {
     this.repoPath = opts.repoPath;
     this.runCommand = opts.runCommand;
     this.workflow = opts.workflow ?? DEFAULT_WORKFLOW;
+    this.targetRepo = opts.target?.repo;
   }
 
   private async gh(args: string[]): Promise<string> {
     return withResilience(async () => {
-      const result = await this.runCommand(["gh", ...args], { timeoutMs: 30_000, cwd: this.repoPath });
+      const fullArgs = ["gh", ...this.withRepo(args)];
+      const result = await this.runCommand(fullArgs, { timeoutMs: 30_000, cwd: this.repoPath });
       if (result.code != null && result.code !== 0) {
         throw new Error(result.stderr?.trim() || `gh command failed with exit code ${result.code}`);
       }
       return result.stdout.trim();
     });
+  }
+
+  private withRepo(args: string[]): string[] {
+    if (!this.targetRepo) return args;
+    const needsExplicitRepo = this.commandSupportsRepo(args);
+    if (!needsExplicitRepo) return args;
+    if (args.includes("--repo") || args.includes("-R")) return args;
+    return [...args, "--repo", this.targetRepo];
+  }
+
+  private commandSupportsRepo(args: string[]): boolean {
+    if (args.length === 0) return false;
+    if (args[0] === "repo") return true;
+    if (args[0] === "issue") return true;
+    if (args[0] === "pr") return true;
+    if (args[0] !== "api") return false;
+    return !args.includes("graphql");
   }
 
   /** Cached repo owner/name for GraphQL queries. */
@@ -66,6 +87,13 @@ export class GitHubProvider implements IssueProvider {
   private async getRepoInfo(): Promise<{ owner: string; name: string } | null> {
     if (this.repoInfo !== undefined) return this.repoInfo;
     try {
+      if (this.targetRepo) {
+        const [owner, name] = this.targetRepo.split("/");
+        if (owner && name) {
+          this.repoInfo = { owner, name };
+          return this.repoInfo;
+        }
+      }
       const raw = await this.gh(["repo", "view", "--json", "owner,name"]);
       const data = JSON.parse(raw);
       this.repoInfo = { owner: data.owner.login, name: data.name };

--- a/lib/providers/gitlab.ts
+++ b/lib/providers/gitlab.ts
@@ -10,6 +10,7 @@ import {
   type PrReviewComment,
   PrState,
 } from "./provider.js";
+import type { ProviderTarget } from "./provider.js";
 import type { RunCommand } from "../context.js";
 import { withResilience } from "./resilience.js";
 import {
@@ -35,16 +36,19 @@ export class GitLabProvider implements IssueProvider {
   private repoPath: string;
   private workflow: WorkflowConfig;
   private runCommand: RunCommand;
+  private targetRepo?: string;
 
-  constructor(opts: { repoPath: string; runCommand: RunCommand; workflow?: WorkflowConfig }) {
+  constructor(opts: { repoPath: string; runCommand: RunCommand; workflow?: WorkflowConfig; target?: ProviderTarget }) {
     this.repoPath = opts.repoPath;
     this.runCommand = opts.runCommand;
     this.workflow = opts.workflow ?? DEFAULT_WORKFLOW;
+    this.targetRepo = opts.target?.repo;
   }
 
   private async glab(args: string[]): Promise<string> {
     return withResilience(async () => {
-      const result = await this.runCommand(["glab", ...args], { timeoutMs: 30_000, cwd: this.repoPath });
+      const fullArgs = this.targetRepo && !args.includes("--repo") ? ["glab", ...args, "--repo", this.targetRepo] : ["glab", ...args];
+      const result = await this.runCommand(fullArgs, { timeoutMs: 30_000, cwd: this.repoPath });
       return result.stdout.trim();
     });
   }

--- a/lib/providers/index.ts
+++ b/lib/providers/index.ts
@@ -2,6 +2,7 @@
  * Provider factory — auto-detects GitHub vs GitLab from git remote.
  */
 import type { IssueProvider } from "./provider.js";
+import type { ProviderTarget } from "./provider.js";
 import type { RunCommand } from "../context.js";
 import { GitLabProvider } from "./gitlab.js";
 import { GitHubProvider } from "./github.js";
@@ -11,6 +12,7 @@ export type ProviderOptions = {
   provider?: "gitlab" | "github";
   repo?: string;
   repoPath?: string;
+  target?: ProviderTarget;
   runCommand: RunCommand;
 };
 
@@ -34,7 +36,7 @@ export async function createProvider(opts: ProviderOptions): Promise<ProviderWit
   const rc = opts.runCommand;
   const type = opts.provider ?? await detectProvider(repoPath, rc);
   const provider = type === "github"
-    ? new GitHubProvider({ repoPath, runCommand: rc })
-    : new GitLabProvider({ repoPath, runCommand: rc });
+    ? new GitHubProvider({ repoPath, runCommand: rc, target: opts.target })
+    : new GitLabProvider({ repoPath, runCommand: rc, target: opts.target });
   return { provider, type };
 }

--- a/lib/providers/provider-targeting.test.ts
+++ b/lib/providers/provider-targeting.test.ts
@@ -1,0 +1,48 @@
+/**
+ * Regression tests for explicit tracker targeting from project config.
+ *
+ * Run with: npx tsx --test lib/providers/provider-targeting.test.ts
+ */
+import { describe, it, mock } from "node:test";
+import assert from "node:assert/strict";
+import { GitHubProvider } from "./github.js";
+
+describe("GitHubProvider explicit repo targeting", () => {
+  it("passes --repo for issue creation when target repo is configured", async () => {
+    const calls: string[][] = [];
+    const runCommand = mock.fn(async (args: string[]) => {
+      calls.push(args);
+      if (args[1] === "issue" && args[2] === "create") {
+        return { stdout: "https://github.com/yaqub0r/devclaw/issues/999\n", stderr: "", code: 0 };
+      }
+      if (args[1] === "issue" && args[2] === "view") {
+        return {
+          stdout: JSON.stringify({ number: 999, title: "t", body: "d", labels: [{ name: "Planning" }], state: "OPEN", url: "https://github.com/yaqub0r/devclaw/issues/999" }),
+          stderr: "",
+          code: 0,
+        };
+      }
+      throw new Error(`Unexpected command: ${args.join(" ")}`);
+    });
+
+    const provider = new GitHubProvider({ repoPath: "/fake", runCommand: runCommand as any, target: { repo: "yaqub0r/devclaw" } });
+    const issue = await provider.createIssue("t", "d", "Planning");
+
+    assert.equal(issue.iid, 999);
+    const createCall = calls.find((c) => c[1] === "issue" && c[2] === "create");
+    assert.ok(createCall, "expected issue create call");
+    assert.deepEqual(createCall.slice(-2), ["--repo", "yaqub0r/devclaw"]);
+  });
+
+  it("uses configured target repo for repo info without gh repo view", async () => {
+    const runCommand = mock.fn(async (_args: string[]) => {
+      throw new Error("gh repo view should not be called when target is configured");
+    });
+
+    const provider = new GitHubProvider({ repoPath: "/fake", runCommand: runCommand as any, target: { repo: "yaqub0r/devclaw" } });
+    const info = await (provider as any).getRepoInfo();
+
+    assert.deepEqual(info, { owner: "yaqub0r", name: "devclaw" });
+    assert.equal(runCommand.mock.calls.length, 0);
+  });
+});

--- a/lib/providers/provider-targeting.test.ts
+++ b/lib/providers/provider-targeting.test.ts
@@ -34,6 +34,71 @@ describe("GitHubProvider explicit repo targeting", () => {
     assert.deepEqual(createCall.slice(-2), ["--repo", "yaqub0r/devclaw"]);
   });
 
+  it("passes --repo for issue read, edit, label, and comment paths when target repo is configured", async () => {
+    const calls: string[][] = [];
+    let issue95State = "Planning";
+    const runCommand = mock.fn(async (args: string[]) => {
+      calls.push(args);
+
+      if (args[1] === "issue" && args[2] === "view") {
+        const issueId = args[3];
+        const labels = issueId === "95"
+          ? [{ name: issue95State }, { name: "telegram:DevClaw" }]
+          : [{ name: "To Do" }, { name: "telegram:DevClaw" }];
+        return {
+          stdout: JSON.stringify({ number: Number(issueId), title: "Issue", body: "Body", labels, state: "OPEN", url: `https://github.com/yaqub0r/devclaw/issues/${issueId}` }),
+          stderr: "",
+          code: 0,
+        };
+      }
+
+      if (args[1] === "issue" && args[2] === "edit") {
+        if (args.includes("--add-label") && args.includes("To Do")) issue95State = "To Do";
+        return { stdout: "", stderr: "", code: 0 };
+      }
+
+      if (args[1] === "label" && args[2] === "create") {
+        return { stdout: "", stderr: "", code: 0 };
+      }
+
+      if (args[1] === "api" && args[2] === "repos/:owner/:repo/issues/95/comments") {
+        return { stdout: JSON.stringify({ id: 12345 }), stderr: "", code: 0 };
+      }
+
+      throw new Error(`Unexpected command: ${args.join(" ")}`);
+    });
+
+    const provider = new GitHubProvider({ repoPath: "/fake", runCommand: runCommand as any, target: { repo: "yaqub0r/devclaw" } });
+
+    const issue = await provider.getIssue(95);
+    assert.equal(issue.iid, 95);
+
+    await provider.transitionLabel(95, "Planning", "To Do");
+    await provider.ensureLabel("developer:medior", "#123456");
+    const commentId = await provider.addComment(95, "routing proof");
+    assert.equal(commentId, 12345);
+
+    const issueViewCalls = calls.filter((c) => c[1] === "issue" && c[2] === "view");
+    assert.ok(issueViewCalls.length >= 2, "expected issue view calls for read + transition validation");
+    for (const call of issueViewCalls) {
+      assert.deepEqual(call.slice(-2), ["--repo", "yaqub0r/devclaw"]);
+    }
+
+    const issueEditCalls = calls.filter((c) => c[1] === "issue" && c[2] === "edit");
+    assert.ok(issueEditCalls.length >= 1, "expected issue edit calls during transition");
+    for (const call of issueEditCalls) {
+      assert.deepEqual(call.slice(-2), ["--repo", "yaqub0r/devclaw"]);
+    }
+
+    const labelCreateCall = calls.find((c) => c[1] === "label" && c[2] === "create");
+    assert.ok(labelCreateCall, "expected label create call");
+    assert.deepEqual(labelCreateCall.slice(-2), ["--repo", "yaqub0r/devclaw"]);
+
+    const commentCall = calls.find((c) => c[1] === "api" && c[2] === "repos/:owner/:repo/issues/95/comments");
+    assert.ok(commentCall, "expected issue comment api call");
+    assert.deepEqual(commentCall.slice(-2), ["--repo", "yaqub0r/devclaw"]);
+  });
+
   it("uses configured target repo for repo info without gh repo view", async () => {
     const runCommand = mock.fn(async (_args: string[]) => {
       throw new Error("gh repo view should not be called when target is configured");

--- a/lib/providers/provider-targeting.test.ts
+++ b/lib/providers/provider-targeting.test.ts
@@ -34,7 +34,7 @@ describe("GitHubProvider explicit repo targeting", () => {
     assert.deepEqual(createCall.slice(-2), ["--repo", "yaqub0r/devclaw"]);
   });
 
-  it("passes --repo for issue read, edit, label, and comment paths when target repo is configured", async () => {
+  it("passes --repo for issue read, edit, and label paths when target repo is configured", async () => {
     const calls: string[][] = [];
     let issue95State = "Planning";
     const runCommand = mock.fn(async (args: string[]) => {
@@ -61,7 +61,7 @@ describe("GitHubProvider explicit repo targeting", () => {
         return { stdout: "", stderr: "", code: 0 };
       }
 
-      if (args[1] === "api" && args[2] === "repos/:owner/:repo/issues/95/comments") {
+      if (args[1] === "api" && args[2] === "repos/yaqub0r/devclaw/issues/95/comments") {
         return { stdout: JSON.stringify({ id: 12345 }), stderr: "", code: 0 };
       }
 
@@ -94,9 +94,48 @@ describe("GitHubProvider explicit repo targeting", () => {
     assert.ok(labelCreateCall, "expected label create call");
     assert.deepEqual(labelCreateCall.slice(-2), ["--repo", "yaqub0r/devclaw"]);
 
-    const commentCall = calls.find((c) => c[1] === "api" && c[2] === "repos/:owner/:repo/issues/95/comments");
+    const commentCall = calls.find((c) => c[1] === "api" && c[2] === "repos/yaqub0r/devclaw/issues/95/comments");
     assert.ok(commentCall, "expected issue comment api call");
-    assert.deepEqual(commentCall.slice(-2), ["--repo", "yaqub0r/devclaw"]);
+    assert.ok(!commentCall.includes("--repo"), "gh api must not receive --repo");
+  });
+
+  it("rewrites only the gh api route placeholder to the configured repo without adding --repo", async () => {
+    const calls: string[][] = [];
+    const runCommand = mock.fn(async (args: string[]) => {
+      calls.push(args);
+
+      if (args[1] === "api" && args[2] === "repos/yaqub0r/devclaw/issues/95/comments") {
+        return { stdout: JSON.stringify([]), stderr: "", code: 0 };
+      }
+
+      if (args[1] === "api" && args[2] === "repos/yaqub0r/devclaw/issues/comments/42/reactions") {
+        return { stdout: "", stderr: "", code: 0 };
+      }
+
+      if (args[1] === "api" && args[2] === "repos/yaqub0r/devclaw/pulls/7/reviews") {
+        return { stdout: JSON.stringify([]), stderr: "", code: 0 };
+      }
+
+      throw new Error(`Unexpected command: ${args.join(" ")}`);
+    });
+
+    const provider = new GitHubProvider({ repoPath: "/fake", runCommand: runCommand as any, target: { repo: "yaqub0r/devclaw" } });
+
+    await provider.listComments(95);
+    await provider.reactToIssueComment(95, 42, "repos/:owner/:repo");
+    await (provider as any).hasChangesRequestedReview(7);
+
+    const apiCalls = calls.filter((c) => c[1] === "api");
+    assert.equal(apiCalls.length, 3);
+    for (const call of apiCalls) {
+      assert.ok(!call.includes("--repo"), "gh api must not receive --repo");
+      assert.ok(call[2]?.startsWith("repos/yaqub0r/devclaw/"), `expected concrete repo path, got ${call[2]}`);
+    }
+
+    const reactionCall = apiCalls.find((c) => c[2] === "repos/yaqub0r/devclaw/issues/comments/42/reactions");
+    assert.ok(reactionCall, "expected reactions api call");
+    const fieldIndex = reactionCall.indexOf("--field");
+    assert.equal(reactionCall[fieldIndex + 1], "content=repos/:owner/:repo", "non-route args must remain untouched");
   });
 
   it("uses configured target repo for repo info without gh repo view", async () => {

--- a/lib/providers/provider.ts
+++ b/lib/providers/provider.ts
@@ -170,3 +170,13 @@ export interface IssueProvider {
   }): Promise<string | null>;
   healthCheck(): Promise<boolean>;
 }
+
+/**
+ * Optional tracker target override derived from project configuration.
+ *
+ * Example GitHub target: "yaqub0r/devclaw"
+ * Example GitLab target: "group/project"
+ */
+export type ProviderTarget = {
+  repo?: string;
+};

--- a/lib/services/bootstrap.e2e.test.ts
+++ b/lib/services/bootstrap.e2e.test.ts
@@ -102,8 +102,8 @@ describe("E2E bootstrap — extraSystemPrompt injection", () => {
     });
 
     const prompts = h.commands.extraSystemPrompts();
-    // No prompt files exist in this temp workspace — extraSystemPrompt should be absent
-    assert.strictEqual(prompts.length, 0, "No extraSystemPrompt when no prompt files exist");
+    assert.strictEqual(prompts.length, 1, "Default scaffolded prompt should be injected");
+    assert.match(prompts[0], /Developer/i);
   });
 
   it("should resolve tester instructions independently from developer", async () => {

--- a/lib/services/bootstrap.e2e.test.ts
+++ b/lib/services/bootstrap.e2e.test.ts
@@ -215,11 +215,17 @@ describe("E2E bootstrap — agent:bootstrap hook (AGENTS.md stripping)", () => {
     assert.strictEqual(result.agentsMdStripped, true);
   });
 
-  it("should NOT strip AGENTS.md for non-DevClaw sessions", async () => {
+  it("should append orchestrator prompt layers for main sessions", async () => {
     h = await createTestHarness();
+    await h.writePrompt("orchestrator", "Workspace orchestrator prompt");
+    await h.writePrompt("orchestrator", "Project orchestrator prompt", h.project.name);
 
     const result = await h.simulateBootstrap("agent:main:orchestrator");
     assert.strictEqual(result.agentsMdStripped, false);
+    assert.match(result.agentsMdContent, /# Orchestrator instructions/);
+    assert.match(result.agentsMdContent, /Workspace orchestrator prompt/);
+    assert.match(result.agentsMdContent, /Project orchestrator prompt/);
+    assert.match(result.agentsMdContent, /Workspace orchestrator prompt[\s\S]*Project orchestrator prompt/);
   });
 
   it("should NOT strip AGENTS.md for unknown roles", async () => {

--- a/lib/services/heartbeat/health.ts
+++ b/lib/services/heartbeat/health.ts
@@ -45,6 +45,7 @@ import {
   getCurrentStateLabel,
   isOwnedByOrUnclaimed,
   isFeedbackState,
+  resolveNotifyChannel,
   type WorkflowConfig,
   type Role,
 } from "../../workflow/index.js";
@@ -456,6 +457,9 @@ export async function checkWorkerHealth(opts: {
               await deactivateSlot();
             } else {
               // Task arrived but worker stalled → nudge the session
+              const notifyTarget = issue
+                ? resolveNotifyChannel(issue.labels, project.channels)
+                : undefined;
               sendToAgent(sessionKey, NUDGE_MESSAGE, {
                 agentId: opts.agentId,
                 projectName: project.name,
@@ -465,6 +469,7 @@ export async function checkWorkerHealth(opts: {
                 slotIndex,
                 workspaceDir,
                 runCommand: opts.runCommand,
+                notifyTarget,
               });
               fix.nudgeSent = true;
             }

--- a/lib/services/heartbeat/health.ts
+++ b/lib/services/heartbeat/health.ts
@@ -51,6 +51,7 @@ import {
 import { isSessionAlive, type SessionLookup } from "../gateway-sessions.js";
 import { sendToAgent } from "../../dispatch/session.js";
 import type { RunCommand } from "../../context.js";
+import { recordLoopDiagnostic } from "../loop-diagnostics.js";
 
 // Re-export for consumers that import from health.ts
 export { fetchGatewaySessions, isSessionAlive, type GatewaySession, type SessionLookup } from "../gateway-sessions.js";
@@ -231,6 +232,16 @@ export async function checkWorkerHealth(opts: {
         if (!issueIdNum) return;
         try {
           await provider.transitionLabel(issueIdNum, from, to);
+          await recordLoopDiagnostic(workspaceDir, "health_requeue", {
+            project: project.name,
+            projectSlug,
+            issueId: issueIdNum,
+            role,
+            from,
+            to,
+            slotLevel: level,
+            slotIndex,
+          }).catch(() => {});
           fix.labelReverted = `${from} → ${to}`;
         } catch {
           fix.labelRevertFailed = true;

--- a/lib/services/heartbeat/passes.ts
+++ b/lib/services/heartbeat/passes.ts
@@ -133,6 +133,7 @@ export async function performReviewPass(
               channel: target?.channel ?? "telegram",
               runtime,
               accountId: target?.accountId,
+              messageThreadId: target?.messageThreadId,
               runCommand,
             },
           ).catch(() => {});
@@ -162,6 +163,7 @@ export async function performReviewPass(
           channel: target?.channel ?? "telegram",
           runtime,
           accountId: target?.accountId,
+          messageThreadId: target?.messageThreadId,
           runCommand,
         },
       ).catch(() => {});
@@ -185,6 +187,7 @@ export async function performReviewPass(
           channel: target?.channel ?? "telegram",
           runtime,
           accountId: target?.accountId,
+          messageThreadId: target?.messageThreadId,
           runCommand,
         },
       ).catch(() => {});
@@ -242,6 +245,7 @@ export async function performReviewSkipPass(
               channel: target?.channel ?? "telegram",
               runtime,
               accountId: target?.accountId,
+              messageThreadId: target?.messageThreadId,
               runCommand,
             },
           ).catch(() => {});

--- a/lib/services/heartbeat/review.ts
+++ b/lib/services/heartbeat/review.ts
@@ -17,6 +17,7 @@ import {
 import { detectStepRouting } from "../queue-scan.js";
 import type { RunCommand } from "../../context.js";
 import { log as auditLog } from "../../audit.js";
+import { recordLoopDiagnostic } from "../loop-diagnostics.js";
 
 /**
  * Scan review-type states and transition issues whose PR check condition is met.
@@ -98,6 +99,15 @@ export async function reviewPass(opts: {
           const targetState = workflow.states[targetKey];
           if (targetState) {
             await provider.transitionLabel(issue.iid, state.label, targetState.label);
+            await recordLoopDiagnostic(workspaceDir, "review_feedback_transition", {
+              project: projectName,
+              issueId: issue.iid,
+              from: state.label,
+              to: targetState.label,
+              reason: status.state === PrState.HAS_COMMENTS ? "pr_comments" : "changes_requested",
+              prUrl: status.url,
+              sourceBranch: status.sourceBranch,
+            }).catch(() => {});
             await auditLog(workspaceDir, "review_transition", {
               project: projectName, issueId: issue.iid,
               from: state.label, to: targetState.label,
@@ -121,6 +131,15 @@ export async function reviewPass(opts: {
           const targetState = workflow.states[targetKey];
           if (targetState) {
             await provider.transitionLabel(issue.iid, state.label, targetState.label);
+            await recordLoopDiagnostic(workspaceDir, "review_feedback_transition", {
+              project: projectName,
+              issueId: issue.iid,
+              from: state.label,
+              to: targetState.label,
+              reason: "merge_conflict",
+              prUrl: status.url,
+              sourceBranch: status.sourceBranch,
+            }).catch(() => {});
             await auditLog(workspaceDir, "review_transition", {
               project: projectName, issueId: issue.iid,
               from: state.label, to: targetState.label,
@@ -212,6 +231,15 @@ export async function reviewPass(opts: {
                   const failedState = workflow.states[failedKey];
                   if (failedState) {
                     await provider.transitionLabel(issue.iid, state.label, failedState.label);
+                    await recordLoopDiagnostic(workspaceDir, "review_feedback_transition", {
+                      project: projectName,
+                      issueId: issue.iid,
+                      from: state.label,
+                      to: failedState.label,
+                      reason: "merge_failed",
+                      prUrl: status.url,
+                      sourceBranch: status.sourceBranch,
+                    }).catch(() => {});
                     await auditLog(workspaceDir, "review_transition", {
                       project: projectName,
                       issueId: issue.iid,

--- a/lib/services/heartbeat/tick-runner.ts
+++ b/lib/services/heartbeat/tick-runner.ts
@@ -13,6 +13,7 @@ import {
 } from "./health.js";
 import { projectTick } from "../tick.js";
 import { createProvider } from "../../providers/index.js";
+import { normalizeRepoTarget } from "../../tools/helpers.js";
 import { loadConfig } from "../../config/index.js";
 import { ExecutionMode } from "../../workflow/index.js";
 import type { HeartbeatConfig } from "./config.js";
@@ -91,6 +92,7 @@ export async function tick(opts: {
       const { provider } = await createProvider({
         repo: project.repo,
         provider: project.provider,
+        target: project.repoRemote ? { repo: normalizeRepoTarget(project.repoRemote) } : undefined,
         runCommand,
       });
       const resolvedConfig = await loadConfig(workspaceDir, project.name);

--- a/lib/services/loop-diagnostics.ts
+++ b/lib/services/loop-diagnostics.ts
@@ -1,0 +1,20 @@
+import { log as auditLog } from "../audit.js";
+
+export type LoopDiagnosticData = Record<string, unknown>;
+
+function isEnabled(): boolean {
+  const raw = process.env.DEVCLAW_LOOP_DIAGNOSTICS?.trim().toLowerCase();
+  return raw === "1" || raw === "true" || raw === "yes" || raw === "on";
+}
+
+export async function recordLoopDiagnostic(
+  workspaceDir: string,
+  stage: string,
+  data: LoopDiagnosticData,
+): Promise<void> {
+  if (!isEnabled()) return;
+  await auditLog(workspaceDir, "loop_diagnostic", {
+    stage,
+    ...data,
+  });
+}

--- a/lib/services/pipeline.e2e.test.ts
+++ b/lib/services/pipeline.e2e.test.ts
@@ -297,6 +297,17 @@ describe("E2E pipeline", () => {
       assert.strictEqual(output.labelTransition, "Reviewing → Refining");
       const issue = await h.provider.getIssue(25);
       assert.ok(issue.labels.includes("Refining"), `Labels: ${issue.labels}`);
+
+      const comments = h.provider.comments.get(25) ?? [];
+      assert.strictEqual(comments.length, 1);
+      assert.ok(comments[0]!.body.startsWith("👁️ **REVIEWER**: Refining hold reason"));
+      assert.ok(comments[0]!.body.includes("### Why this is on hold"));
+      assert.ok(comments[0]!.body.includes("- from: `Reviewing`"));
+      assert.ok(comments[0]!.body.includes("- to: `Refining`"));
+      assert.ok(comments[0]!.body.includes("- category: `work_finish_blocked`"));
+      assert.ok(comments[0]!.body.includes("- source: `worker`"));
+      assert.ok(comments[0]!.body.includes("- role: `reviewer`"));
+      assert.ok(comments[0]!.body.includes("- result: `blocked`"));
     });
   });
 
@@ -419,6 +430,21 @@ describe("E2E pipeline", () => {
 
       const issue = await h.provider.getIssue(50);
       assert.ok(issue.labels.includes("Refining"));
+
+      const comments = h.provider.comments.get(50) ?? [];
+      assert.strictEqual(comments.length, 1, "Should leave the canonical Refining hold reason");
+      const addCommentCall = h.provider.callsTo("addComment")[0];
+      const transitionCall = h.provider.callsTo("transitionLabel")[0];
+      assert.ok(addCommentCall && transitionCall, "Should record both comment and transition");
+      assert.ok(h.provider.calls.indexOf(addCommentCall) < h.provider.calls.indexOf(transitionCall), "Should comment before entering Refining");
+      assert.ok(comments[0]!.body.startsWith("🔧 **DEVELOPER**: Refining hold reason"));
+      assert.ok(comments[0]!.body.includes("DevClaw is moving this issue from `Doing` to `Refining` because work cannot continue yet."));
+      assert.ok(comments[0]!.body.includes("### Why this is on hold"));
+      assert.ok(comments[0]!.body.includes("- Need design decision"));
+      assert.ok(comments[0]!.body.includes("### Transition details"));
+      assert.ok(comments[0]!.body.includes("- category: `work_finish_blocked`"));
+      assert.ok(comments[0]!.body.includes("### Context"));
+      assert.ok(comments[0]!.body.includes("Please review this hold reason and update the issue before re-queueing it."));
     });
   });
 

--- a/lib/services/pipeline.e2e.test.ts
+++ b/lib/services/pipeline.e2e.test.ts
@@ -376,6 +376,34 @@ describe("E2E pipeline", () => {
       assert.ok(notifyCalls.length >= 2, "Expected workerComplete and issueComplete CLI fallback notifications");
       assert.ok(notifyCalls.every((c) => c.argv.includes("--thread-id") && c.argv.includes("176")));
     });
+
+    it("should await completion notification fallback delivery before returning", async () => {
+      h.project.channels[0]!.messageThreadId = 176;
+      const delayedRunCommand = async (argv: string[], opts: any) => {
+        if (argv[0] === "openclaw" && argv[1] === "message" && argv[2] === "send") {
+          await new Promise((resolve) => setTimeout(resolve, 25));
+        }
+        return h.runCommand(argv, opts);
+      };
+
+      const startedAt = Date.now();
+      await executeCompletion({
+        workspaceDir: h.workspaceDir,
+        projectSlug: h.project.slug,
+        channels: h.project.channels,
+        role: "tester",
+        result: "pass",
+        issueId: 30,
+        summary: "All tests pass",
+        provider: h.provider,
+        repoPath: "/tmp/test-repo",
+        projectName: "test-project",
+        runCommand: delayedRunCommand,
+      });
+      const elapsedMs = Date.now() - startedAt;
+
+      assert.ok(elapsedMs >= 50, `Expected executeCompletion to await both fallback sends, got ${elapsedMs}ms`);
+    });
   });
 
   // =========================================================================
@@ -493,6 +521,34 @@ describe("E2E pipeline", () => {
       );
       assert.ok(notifyCalls.length >= 1, "Expected CLI fallback notification call");
       assert.ok(notifyCalls.some((c) => c.argv.includes("--thread-id") && c.argv.includes("176")));
+    });
+
+    it("should await Refining notification fallback delivery before returning", async () => {
+      h.project.channels[0]!.messageThreadId = 176;
+      const delayedRunCommand = async (argv: string[], opts: any) => {
+        if (argv[0] === "openclaw" && argv[1] === "message" && argv[2] === "send") {
+          await new Promise((resolve) => setTimeout(resolve, 25));
+        }
+        return h.runCommand(argv, opts);
+      };
+
+      const startedAt = Date.now();
+      await executeCompletion({
+        workspaceDir: h.workspaceDir,
+        projectSlug: h.project.slug,
+        channels: h.project.channels,
+        role: "developer",
+        result: "blocked",
+        issueId: 50,
+        summary: "Need design decision",
+        provider: h.provider,
+        repoPath: "/tmp/test-repo",
+        projectName: "test-project",
+        runCommand: delayedRunCommand,
+      });
+      const elapsedMs = Date.now() - startedAt;
+
+      assert.ok(elapsedMs >= 25, `Expected executeCompletion to await Refining fallback send, got ${elapsedMs}ms`);
     });
   });
 

--- a/lib/services/pipeline.e2e.test.ts
+++ b/lib/services/pipeline.e2e.test.ts
@@ -352,58 +352,6 @@ describe("E2E pipeline", () => {
       assert.strictEqual(closeCalls.length, 1);
       assert.strictEqual(closeCalls[0].args.issueId, 30);
     });
-
-    it("should use CLI fallback for completion notifications and preserve Telegram topic routing", async () => {
-      h.project.channels[0]!.messageThreadId = 176;
-
-      await executeCompletion({
-        workspaceDir: h.workspaceDir,
-        projectSlug: h.project.slug,
-        channels: h.project.channels,
-        role: "tester",
-        result: "pass",
-        issueId: 30,
-        summary: "All tests pass",
-        provider: h.provider,
-        repoPath: "/tmp/test-repo",
-        projectName: "test-project",
-        runCommand: h.runCommand,
-      });
-
-      const notifyCalls = h.commands.commands.filter(
-        (c) => c.argv[0] === "openclaw" && c.argv[1] === "message" && c.argv[2] === "send",
-      );
-      assert.ok(notifyCalls.length >= 2, "Expected workerComplete and issueComplete CLI fallback notifications");
-      assert.ok(notifyCalls.every((c) => c.argv.includes("--thread-id") && c.argv.includes("176")));
-    });
-
-    it("should await completion notification fallback delivery before returning", async () => {
-      h.project.channels[0]!.messageThreadId = 176;
-      const delayedRunCommand = async (argv: string[], opts: any) => {
-        if (argv[0] === "openclaw" && argv[1] === "message" && argv[2] === "send") {
-          await new Promise((resolve) => setTimeout(resolve, 25));
-        }
-        return h.runCommand(argv, opts);
-      };
-
-      const startedAt = Date.now();
-      await executeCompletion({
-        workspaceDir: h.workspaceDir,
-        projectSlug: h.project.slug,
-        channels: h.project.channels,
-        role: "tester",
-        result: "pass",
-        issueId: 30,
-        summary: "All tests pass",
-        provider: h.provider,
-        repoPath: "/tmp/test-repo",
-        projectName: "test-project",
-        runCommand: delayedRunCommand,
-      });
-      const elapsedMs = Date.now() - startedAt;
-
-      assert.ok(elapsedMs >= 50, `Expected executeCompletion to await both fallback sends, got ${elapsedMs}ms`);
-    });
   });
 
   // =========================================================================
@@ -497,58 +445,6 @@ describe("E2E pipeline", () => {
       assert.ok(comments[0]!.body.includes("- category: `work_finish_blocked`"));
       assert.ok(comments[0]!.body.includes("### Context"));
       assert.ok(comments[0]!.body.includes("Please review this hold reason and update the issue before re-queueing it."));
-    });
-
-    it("should use CLI fallback for Refining notifications and preserve Telegram topic routing", async () => {
-      h.project.channels[0]!.messageThreadId = 176;
-
-      await executeCompletion({
-        workspaceDir: h.workspaceDir,
-        projectSlug: h.project.slug,
-        channels: h.project.channels,
-        role: "developer",
-        result: "blocked",
-        issueId: 50,
-        summary: "Need design decision",
-        provider: h.provider,
-        repoPath: "/tmp/test-repo",
-        projectName: "test-project",
-        runCommand: h.runCommand,
-      });
-
-      const notifyCalls = h.commands.commands.filter(
-        (c) => c.argv[0] === "openclaw" && c.argv[1] === "message" && c.argv[2] === "send",
-      );
-      assert.ok(notifyCalls.length >= 1, "Expected CLI fallback notification call");
-      assert.ok(notifyCalls.some((c) => c.argv.includes("--thread-id") && c.argv.includes("176")));
-    });
-
-    it("should await Refining notification fallback delivery before returning", async () => {
-      h.project.channels[0]!.messageThreadId = 176;
-      const delayedRunCommand = async (argv: string[], opts: any) => {
-        if (argv[0] === "openclaw" && argv[1] === "message" && argv[2] === "send") {
-          await new Promise((resolve) => setTimeout(resolve, 25));
-        }
-        return h.runCommand(argv, opts);
-      };
-
-      const startedAt = Date.now();
-      await executeCompletion({
-        workspaceDir: h.workspaceDir,
-        projectSlug: h.project.slug,
-        channels: h.project.channels,
-        role: "developer",
-        result: "blocked",
-        issueId: 50,
-        summary: "Need design decision",
-        provider: h.provider,
-        repoPath: "/tmp/test-repo",
-        projectName: "test-project",
-        runCommand: delayedRunCommand,
-      });
-      const elapsedMs = Date.now() - startedAt;
-
-      assert.ok(elapsedMs >= 25, `Expected executeCompletion to await Refining fallback send, got ${elapsedMs}ms`);
     });
   });
 

--- a/lib/services/pipeline.e2e.test.ts
+++ b/lib/services/pipeline.e2e.test.ts
@@ -352,6 +352,30 @@ describe("E2E pipeline", () => {
       assert.strictEqual(closeCalls.length, 1);
       assert.strictEqual(closeCalls[0].args.issueId, 30);
     });
+
+    it("should use CLI fallback for completion notifications and preserve Telegram topic routing", async () => {
+      h.project.channels[0]!.messageThreadId = 176;
+
+      await executeCompletion({
+        workspaceDir: h.workspaceDir,
+        projectSlug: h.project.slug,
+        channels: h.project.channels,
+        role: "tester",
+        result: "pass",
+        issueId: 30,
+        summary: "All tests pass",
+        provider: h.provider,
+        repoPath: "/tmp/test-repo",
+        projectName: "test-project",
+        runCommand: h.runCommand,
+      });
+
+      const notifyCalls = h.commands.commands.filter(
+        (c) => c.argv[0] === "openclaw" && c.argv[1] === "message" && c.argv[2] === "send",
+      );
+      assert.ok(notifyCalls.length >= 2, "Expected workerComplete and issueComplete CLI fallback notifications");
+      assert.ok(notifyCalls.every((c) => c.argv.includes("--thread-id") && c.argv.includes("176")));
+    });
   });
 
   // =========================================================================
@@ -445,6 +469,30 @@ describe("E2E pipeline", () => {
       assert.ok(comments[0]!.body.includes("- category: `work_finish_blocked`"));
       assert.ok(comments[0]!.body.includes("### Context"));
       assert.ok(comments[0]!.body.includes("Please review this hold reason and update the issue before re-queueing it."));
+    });
+
+    it("should use CLI fallback for Refining notifications and preserve Telegram topic routing", async () => {
+      h.project.channels[0]!.messageThreadId = 176;
+
+      await executeCompletion({
+        workspaceDir: h.workspaceDir,
+        projectSlug: h.project.slug,
+        channels: h.project.channels,
+        role: "developer",
+        result: "blocked",
+        issueId: 50,
+        summary: "Need design decision",
+        provider: h.provider,
+        repoPath: "/tmp/test-repo",
+        projectName: "test-project",
+        runCommand: h.runCommand,
+      });
+
+      const notifyCalls = h.commands.commands.filter(
+        (c) => c.argv[0] === "openclaw" && c.argv[1] === "message" && c.argv[2] === "send",
+      );
+      assert.ok(notifyCalls.length >= 1, "Expected CLI fallback notification call");
+      assert.ok(notifyCalls.some((c) => c.argv.includes("--thread-id") && c.argv.includes("176")));
     });
   });
 

--- a/lib/services/pipeline.ts
+++ b/lib/services/pipeline.ts
@@ -212,6 +212,27 @@ export async function executeCompletion(opts: {
     switch (action) {
       case Action.CLOSE_ISSUE:
         await provider.closeIssue(issueId);
+        // Notify that the issue has been fully completed and closed
+        notify(
+          {
+            type: "issueComplete",
+            project: projectName,
+            issueId,
+            issueUrl: issue.web_url,
+            issueTitle: issue.title,
+            prUrl,
+          },
+          {
+            workspaceDir,
+            config: notifyConfig,
+            channelId: notifyTarget?.channelId,
+            channel: notifyTarget?.channel ?? "telegram",
+            runtime,
+            accountId: notifyTarget?.accountId,
+          },
+        ).catch((err) => {
+          auditLog(workspaceDir, "pipeline_warning", { step: "issueCompleteNotify", issue: issueId, role, error: (err as Error).message ?? String(err) }).catch(() => {});
+        });
         break;
       case Action.REOPEN_ISSUE:
         await provider.reopenIssue(issueId);

--- a/lib/services/pipeline.ts
+++ b/lib/services/pipeline.ts
@@ -176,6 +176,7 @@ export async function executeCompletion(opts: {
       channel: notifyTarget?.channel ?? "telegram",
       runtime,
       accountId: notifyTarget?.accountId,
+      messageThreadId: notifyTarget?.messageThreadId,
     },
   ).catch((err) => {
     auditLog(workspaceDir, "pipeline_warning", { step: "notify", issue: issueId, role, error: (err as Error).message ?? String(err) }).catch(() => {});
@@ -195,7 +196,7 @@ export async function executeCompletion(opts: {
         sourceBranch,
         mergedBy: "pipeline",
       },
-      { workspaceDir, config: notifyConfig, channelId: notifyTarget?.channelId, channel: notifyTarget?.channel ?? "telegram", runtime, accountId: notifyTarget?.accountId },
+      { workspaceDir, config: notifyConfig, channelId: notifyTarget?.channelId, channel: notifyTarget?.channel ?? "telegram", runtime, accountId: notifyTarget?.accountId, messageThreadId: notifyTarget?.messageThreadId },
     ).catch((err) => {
       auditLog(workspaceDir, "pipeline_warning", { step: "mergeNotify", issue: issueId, role, error: (err as Error).message ?? String(err) }).catch(() => {});
     });
@@ -245,6 +246,7 @@ export async function executeCompletion(opts: {
           channel: notifyTarget?.channel ?? "telegram",
           runtime,
           accountId: notifyTarget?.accountId,
+          messageThreadId: notifyTarget?.messageThreadId,
         },
       ).catch((err) => {
         auditLog(workspaceDir, "pipeline_warning", { step: "reviewNotify", issue: issueId, role, error: (err as Error).message ?? String(err) }).catch(() => {});

--- a/lib/services/pipeline.ts
+++ b/lib/services/pipeline.ts
@@ -214,57 +214,52 @@ export async function executeCompletion(opts: {
 
   // Send notification early (before deactivation and label transition which can fail)
   const notifyConfig = getNotificationConfig(pluginConfig);
-  try {
-    await notify(
-      {
-        type: "workerComplete",
-        project: projectName,
-        issueId,
-        issueUrl: issue.web_url,
-        role,
-        level: opts.level,
-        name: workerName,
-        result: result as "done" | "pass" | "fail" | "refine" | "blocked",
-        summary,
-        nextState,
-        prUrl,
-        createdTasks,
-      },
-      {
-        workspaceDir,
-        config: notifyConfig,
-        channelId: notifyTarget?.channelId,
-        channel: notifyTarget?.channel ?? "telegram",
-        runtime,
-        accountId: notifyTarget?.accountId,
-        runCommand: rc,
-        messageThreadId: notifyTarget?.messageThreadId,
-      },
-    );
-  } catch (err) {
+  notify(
+    {
+      type: "workerComplete",
+      project: projectName,
+      issueId,
+      issueUrl: issue.web_url,
+      role,
+      level: opts.level,
+      name: workerName,
+      result: result as "done" | "pass" | "fail" | "refine" | "blocked",
+      summary,
+      nextState,
+      prUrl,
+      createdTasks,
+    },
+    {
+      workspaceDir,
+      config: notifyConfig,
+      channelId: notifyTarget?.channelId,
+      channel: notifyTarget?.channel ?? "telegram",
+      runtime,
+      accountId: notifyTarget?.accountId,
+      messageThreadId: notifyTarget?.messageThreadId,
+    },
+  ).catch((err) => {
     auditLog(workspaceDir, "pipeline_warning", { step: "notify", issue: issueId, role, error: (err as Error).message ?? String(err) }).catch(() => {});
-  }
+  });
 
   // Send merge notification when PR was merged during this completion
   if (mergedPr) {
-    try {
-      await notify(
-        {
-          type: "prMerged",
-          project: projectName,
-          issueId,
-          issueUrl: issue.web_url,
-          issueTitle: issue.title,
-          prUrl,
-          prTitle,
-          sourceBranch,
-          mergedBy: "pipeline",
-        },
-        { workspaceDir, config: notifyConfig, channelId: notifyTarget?.channelId, channel: notifyTarget?.channel ?? "telegram", runtime, accountId: notifyTarget?.accountId, runCommand: rc, messageThreadId: notifyTarget?.messageThreadId },
-      );
-    } catch (err) {
+    notify(
+      {
+        type: "prMerged",
+        project: projectName,
+        issueId,
+        issueUrl: issue.web_url,
+        issueTitle: issue.title,
+        prUrl,
+        prTitle,
+        sourceBranch,
+        mergedBy: "pipeline",
+      },
+      { workspaceDir, config: notifyConfig, channelId: notifyTarget?.channelId, channel: notifyTarget?.channel ?? "telegram", runtime, accountId: notifyTarget?.accountId, messageThreadId: notifyTarget?.messageThreadId },
+    ).catch((err) => {
       auditLog(workspaceDir, "pipeline_warning", { step: "mergeNotify", issue: issueId, role, error: (err as Error).message ?? String(err) }).catch(() => {});
-    }
+    });
   }
 
   // Transition label first (critical — if this fails, issue still has correct state)
@@ -300,30 +295,26 @@ export async function executeCompletion(opts: {
       case Action.CLOSE_ISSUE:
         await provider.closeIssue(issueId);
         // Notify that the issue has been fully completed and closed
-        try {
-          await notify(
-            {
-              type: "issueComplete",
-              project: projectName,
-              issueId,
-              issueUrl: issue.web_url,
-              issueTitle: issue.title,
-              prUrl,
-            },
-            {
-              workspaceDir,
-              config: notifyConfig,
-              channelId: notifyTarget?.channelId,
-              channel: notifyTarget?.channel ?? "telegram",
-              runtime,
-              accountId: notifyTarget?.accountId,
-              runCommand: rc,
-              messageThreadId: notifyTarget?.messageThreadId,
-            },
-          );
-        } catch (err) {
+        notify(
+          {
+            type: "issueComplete",
+            project: projectName,
+            issueId,
+            issueUrl: issue.web_url,
+            issueTitle: issue.title,
+            prUrl,
+          },
+          {
+            workspaceDir,
+            config: notifyConfig,
+            channelId: notifyTarget?.channelId,
+            channel: notifyTarget?.channel ?? "telegram",
+            runtime,
+            accountId: notifyTarget?.accountId,
+          },
+        ).catch((err) => {
           auditLog(workspaceDir, "pipeline_warning", { step: "issueCompleteNotify", issue: issueId, role, error: (err as Error).message ?? String(err) }).catch(() => {});
-        }
+        });
         break;
       case Action.REOPEN_ISSUE:
         await provider.reopenIssue(issueId);
@@ -340,31 +331,28 @@ export async function executeCompletion(opts: {
     const updated = await provider.getIssue(issueId);
     const routing = detectStepRouting(updated.labels, "review") as "human" | "agent" | null;
     if (routing === "human" || routing === "agent") {
-      try {
-        await notify(
-          {
-            type: "reviewNeeded",
-            project: projectName,
-            issueId,
-            issueUrl: updated.web_url,
-            issueTitle: updated.title,
-            routing,
-            prUrl,
-          },
-          {
-            workspaceDir,
-            config: notifyConfig,
-            channelId: notifyTarget?.channelId,
-            channel: notifyTarget?.channel ?? "telegram",
-            runtime,
-            accountId: notifyTarget?.accountId,
-            runCommand: rc,
-            messageThreadId: notifyTarget?.messageThreadId,
-          },
-        );
-      } catch (err) {
+      notify(
+        {
+          type: "reviewNeeded",
+          project: projectName,
+          issueId,
+          issueUrl: updated.web_url,
+          issueTitle: updated.title,
+          routing,
+          prUrl,
+        },
+        {
+          workspaceDir,
+          config: notifyConfig,
+          channelId: notifyTarget?.channelId,
+          channel: notifyTarget?.channel ?? "telegram",
+          runtime,
+          accountId: notifyTarget?.accountId,
+          messageThreadId: notifyTarget?.messageThreadId,
+        },
+      ).catch((err) => {
         auditLog(workspaceDir, "pipeline_warning", { step: "reviewNotify", issue: issueId, role, error: (err as Error).message ?? String(err) }).catch(() => {});
-      }
+      });
     }
   }
 

--- a/lib/services/pipeline.ts
+++ b/lib/services/pipeline.ts
@@ -11,6 +11,7 @@ import { notify, getNotificationConfig } from "../dispatch/notify.js";
 import { log as auditLog } from "../audit.js";
 import { loadConfig } from "../config/index.js";
 import { detectStepRouting } from "./queue-scan.js";
+import { recordLoopDiagnostic } from "./loop-diagnostics.js";
 import {
   DEFAULT_WORKFLOW,
   Action,
@@ -204,8 +205,19 @@ export async function executeCompletion(opts: {
   // Transition label first (critical — if this fails, issue still has correct state)
   // Then execute post-transition actions (close/reopen)
   // Finally deactivate worker (last — ensures label is set even if deactivation fails)
-  
-  await provider.transitionLabel(issueId, rule.from as StateLabel, rule.to as StateLabel);
+  const transitionedTo = rule.to as StateLabel;
+  await provider.transitionLabel(issueId, rule.from as StateLabel, transitionedTo);
+
+  await recordLoopDiagnostic(workspaceDir, "work_finish_transition", {
+    project: projectName,
+    issueId,
+    role,
+    result,
+    from: rule.from,
+    to: transitionedTo,
+    summary: summary ?? null,
+    prUrl: prUrl ?? null,
+  }).catch(() => {});
 
   // Execute post-transition actions
   for (const action of rule.actions) {

--- a/lib/services/pipeline.ts
+++ b/lib/services/pipeline.ts
@@ -236,6 +236,7 @@ export async function executeCompletion(opts: {
       channel: notifyTarget?.channel ?? "telegram",
       runtime,
       accountId: notifyTarget?.accountId,
+      runCommand: rc,
       messageThreadId: notifyTarget?.messageThreadId,
     },
   ).catch((err) => {
@@ -256,7 +257,7 @@ export async function executeCompletion(opts: {
         sourceBranch,
         mergedBy: "pipeline",
       },
-      { workspaceDir, config: notifyConfig, channelId: notifyTarget?.channelId, channel: notifyTarget?.channel ?? "telegram", runtime, accountId: notifyTarget?.accountId, messageThreadId: notifyTarget?.messageThreadId },
+      { workspaceDir, config: notifyConfig, channelId: notifyTarget?.channelId, channel: notifyTarget?.channel ?? "telegram", runtime, accountId: notifyTarget?.accountId, runCommand: rc, messageThreadId: notifyTarget?.messageThreadId },
     ).catch((err) => {
       auditLog(workspaceDir, "pipeline_warning", { step: "mergeNotify", issue: issueId, role, error: (err as Error).message ?? String(err) }).catch(() => {});
     });
@@ -311,6 +312,8 @@ export async function executeCompletion(opts: {
             channel: notifyTarget?.channel ?? "telegram",
             runtime,
             accountId: notifyTarget?.accountId,
+            runCommand: rc,
+            messageThreadId: notifyTarget?.messageThreadId,
           },
         ).catch((err) => {
           auditLog(workspaceDir, "pipeline_warning", { step: "issueCompleteNotify", issue: issueId, role, error: (err as Error).message ?? String(err) }).catch(() => {});
@@ -348,6 +351,7 @@ export async function executeCompletion(opts: {
           channel: notifyTarget?.channel ?? "telegram",
           runtime,
           accountId: notifyTarget?.accountId,
+          runCommand: rc,
           messageThreadId: notifyTarget?.messageThreadId,
         },
       ).catch((err) => {

--- a/lib/services/pipeline.ts
+++ b/lib/services/pipeline.ts
@@ -214,53 +214,57 @@ export async function executeCompletion(opts: {
 
   // Send notification early (before deactivation and label transition which can fail)
   const notifyConfig = getNotificationConfig(pluginConfig);
-  notify(
-    {
-      type: "workerComplete",
-      project: projectName,
-      issueId,
-      issueUrl: issue.web_url,
-      role,
-      level: opts.level,
-      name: workerName,
-      result: result as "done" | "pass" | "fail" | "refine" | "blocked",
-      summary,
-      nextState,
-      prUrl,
-      createdTasks,
-    },
-    {
-      workspaceDir,
-      config: notifyConfig,
-      channelId: notifyTarget?.channelId,
-      channel: notifyTarget?.channel ?? "telegram",
-      runtime,
-      accountId: notifyTarget?.accountId,
-      runCommand: rc,
-      messageThreadId: notifyTarget?.messageThreadId,
-    },
-  ).catch((err) => {
-    auditLog(workspaceDir, "pipeline_warning", { step: "notify", issue: issueId, role, error: (err as Error).message ?? String(err) }).catch(() => {});
-  });
-
-  // Send merge notification when PR was merged during this completion
-  if (mergedPr) {
-    notify(
+  try {
+    await notify(
       {
-        type: "prMerged",
+        type: "workerComplete",
         project: projectName,
         issueId,
         issueUrl: issue.web_url,
-        issueTitle: issue.title,
+        role,
+        level: opts.level,
+        name: workerName,
+        result: result as "done" | "pass" | "fail" | "refine" | "blocked",
+        summary,
+        nextState,
         prUrl,
-        prTitle,
-        sourceBranch,
-        mergedBy: "pipeline",
+        createdTasks,
       },
-      { workspaceDir, config: notifyConfig, channelId: notifyTarget?.channelId, channel: notifyTarget?.channel ?? "telegram", runtime, accountId: notifyTarget?.accountId, runCommand: rc, messageThreadId: notifyTarget?.messageThreadId },
-    ).catch((err) => {
+      {
+        workspaceDir,
+        config: notifyConfig,
+        channelId: notifyTarget?.channelId,
+        channel: notifyTarget?.channel ?? "telegram",
+        runtime,
+        accountId: notifyTarget?.accountId,
+        runCommand: rc,
+        messageThreadId: notifyTarget?.messageThreadId,
+      },
+    );
+  } catch (err) {
+    auditLog(workspaceDir, "pipeline_warning", { step: "notify", issue: issueId, role, error: (err as Error).message ?? String(err) }).catch(() => {});
+  }
+
+  // Send merge notification when PR was merged during this completion
+  if (mergedPr) {
+    try {
+      await notify(
+        {
+          type: "prMerged",
+          project: projectName,
+          issueId,
+          issueUrl: issue.web_url,
+          issueTitle: issue.title,
+          prUrl,
+          prTitle,
+          sourceBranch,
+          mergedBy: "pipeline",
+        },
+        { workspaceDir, config: notifyConfig, channelId: notifyTarget?.channelId, channel: notifyTarget?.channel ?? "telegram", runtime, accountId: notifyTarget?.accountId, runCommand: rc, messageThreadId: notifyTarget?.messageThreadId },
+      );
+    } catch (err) {
       auditLog(workspaceDir, "pipeline_warning", { step: "mergeNotify", issue: issueId, role, error: (err as Error).message ?? String(err) }).catch(() => {});
-    });
+    }
   }
 
   // Transition label first (critical — if this fails, issue still has correct state)
@@ -296,28 +300,30 @@ export async function executeCompletion(opts: {
       case Action.CLOSE_ISSUE:
         await provider.closeIssue(issueId);
         // Notify that the issue has been fully completed and closed
-        notify(
-          {
-            type: "issueComplete",
-            project: projectName,
-            issueId,
-            issueUrl: issue.web_url,
-            issueTitle: issue.title,
-            prUrl,
-          },
-          {
-            workspaceDir,
-            config: notifyConfig,
-            channelId: notifyTarget?.channelId,
-            channel: notifyTarget?.channel ?? "telegram",
-            runtime,
-            accountId: notifyTarget?.accountId,
-            runCommand: rc,
-            messageThreadId: notifyTarget?.messageThreadId,
-          },
-        ).catch((err) => {
+        try {
+          await notify(
+            {
+              type: "issueComplete",
+              project: projectName,
+              issueId,
+              issueUrl: issue.web_url,
+              issueTitle: issue.title,
+              prUrl,
+            },
+            {
+              workspaceDir,
+              config: notifyConfig,
+              channelId: notifyTarget?.channelId,
+              channel: notifyTarget?.channel ?? "telegram",
+              runtime,
+              accountId: notifyTarget?.accountId,
+              runCommand: rc,
+              messageThreadId: notifyTarget?.messageThreadId,
+            },
+          );
+        } catch (err) {
           auditLog(workspaceDir, "pipeline_warning", { step: "issueCompleteNotify", issue: issueId, role, error: (err as Error).message ?? String(err) }).catch(() => {});
-        });
+        }
         break;
       case Action.REOPEN_ISSUE:
         await provider.reopenIssue(issueId);
@@ -334,29 +340,31 @@ export async function executeCompletion(opts: {
     const updated = await provider.getIssue(issueId);
     const routing = detectStepRouting(updated.labels, "review") as "human" | "agent" | null;
     if (routing === "human" || routing === "agent") {
-      notify(
-        {
-          type: "reviewNeeded",
-          project: projectName,
-          issueId,
-          issueUrl: updated.web_url,
-          issueTitle: updated.title,
-          routing,
-          prUrl,
-        },
-        {
-          workspaceDir,
-          config: notifyConfig,
-          channelId: notifyTarget?.channelId,
-          channel: notifyTarget?.channel ?? "telegram",
-          runtime,
-          accountId: notifyTarget?.accountId,
-          runCommand: rc,
-          messageThreadId: notifyTarget?.messageThreadId,
-        },
-      ).catch((err) => {
+      try {
+        await notify(
+          {
+            type: "reviewNeeded",
+            project: projectName,
+            issueId,
+            issueUrl: updated.web_url,
+            issueTitle: updated.title,
+            routing,
+            prUrl,
+          },
+          {
+            workspaceDir,
+            config: notifyConfig,
+            channelId: notifyTarget?.channelId,
+            channel: notifyTarget?.channel ?? "telegram",
+            runtime,
+            accountId: notifyTarget?.accountId,
+            runCommand: rc,
+            messageThreadId: notifyTarget?.messageThreadId,
+          },
+        );
+      } catch (err) {
         auditLog(workspaceDir, "pipeline_warning", { step: "reviewNotify", issue: issueId, role, error: (err as Error).message ?? String(err) }).catch(() => {});
-      });
+      }
     }
   }
 

--- a/lib/services/pipeline.ts
+++ b/lib/services/pipeline.ts
@@ -36,6 +36,65 @@ export type CompletionOutput = {
   issueReopened?: boolean;
 };
 
+function getRefiningCommentPrefix(role: string): string {
+  switch (role) {
+    case "developer":
+      return "🔧 **DEVELOPER**";
+    case "tester":
+      return "🧪 **TESTER**";
+    case "reviewer":
+      return "👁️ **REVIEWER**";
+    case "architect":
+      return "🏗️ **ARCHITECT**";
+    default:
+      return "🎛️ **ORCHESTRATOR**";
+  }
+}
+
+export function buildRefiningHoldComment(opts: {
+  role: string;
+  result: string;
+  from: string;
+  to: string;
+  summary?: string;
+  source?: "worker" | "system";
+}): string {
+  const {
+    role,
+    result,
+    from,
+    to,
+    summary,
+    source = "worker",
+  } = opts;
+
+  const lines = [
+    `${getRefiningCommentPrefix(role)}: Refining hold reason`,
+    "",
+    `DevClaw is moving this issue from \`${from}\` to \`${to}\` because work cannot continue yet.`,
+    "",
+    "### Why this is on hold",
+    "",
+    `- ${summary?.trim() || "Work stopped without a summary, and operator follow-up is required before this issue can continue."}`,
+    "",
+    "### Transition details",
+    "",
+    `- from: \`${from}\``,
+    `- to: \`${to}\``,
+    `- category: \`work_finish_${result}\``,
+    `- source: \`${source}\``,
+    "",
+    "### Context",
+    "",
+    `- role: \`${role}\``,
+    `- result: \`${result}\``,
+    "",
+    "Please review this hold reason and update the issue before re-queueing it.",
+  ];
+
+  return lines.join("\n");
+}
+
 /**
  * Get completion rule for a role:result pair.
  * Uses workflow config when available.
@@ -207,6 +266,16 @@ export async function executeCompletion(opts: {
   // Then execute post-transition actions (close/reopen)
   // Finally deactivate worker (last — ensures label is set even if deactivation fails)
   const transitionedTo = rule.to as StateLabel;
+  if (transitionedTo === "Refining") {
+    await provider.addComment(issueId, buildRefiningHoldComment({
+      role,
+      result,
+      from: rule.from,
+      to: transitionedTo,
+      summary,
+      source: "worker",
+    }));
+  }
   await provider.transitionLabel(issueId, rule.from as StateLabel, transitionedTo);
 
   await recordLoopDiagnostic(workspaceDir, "work_finish_transition", {

--- a/lib/services/tick-provider-targeting.test.ts
+++ b/lib/services/tick-provider-targeting.test.ts
@@ -1,0 +1,51 @@
+/**
+ * Regression tests for projectTick provider creation with repoRemote targeting.
+ *
+ * Run with: npx tsx --test lib/services/tick-provider-targeting.test.ts
+ */
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { createTestHarness } from "../testing/index.js";
+import { projectTick } from "./tick.js";
+
+describe("projectTick provider targeting", () => {
+  it("threads project repoRemote into provider creation from persisted project config", async () => {
+    const h = await createTestHarness();
+    try {
+      const projects = await h.readProjects();
+      projects.projects[h.project.slug] = {
+        ...projects.projects[h.project.slug]!,
+        repoRemote: "https://github.com/yaqub0r/devclaw.git",
+        provider: "github",
+      };
+      await h.writeProjects(projects);
+
+      const ghCalls: string[][] = [];
+      const runCommand = async (argv: string[]) => {
+        if (argv[0] === "gh") {
+          ghCalls.push(argv);
+          if (argv[1] === "issue" && argv[2] === "list") {
+            return { stdout: "[]", stderr: "", code: 0, signal: null, killed: false as const };
+          }
+        }
+        return { stdout: "{}", stderr: "", code: 0, signal: null, killed: false as const };
+      };
+
+      const result = await projectTick({
+        workspaceDir: h.workspaceDir,
+        projectSlug: h.project.slug,
+        targetRole: "developer",
+        runCommand: runCommand as any,
+      });
+
+      assert.equal(result.pickups.length, 0);
+      const issueListCalls = ghCalls.filter((call) => call[1] === "issue" && call[2] === "list");
+      assert.ok(issueListCalls.length >= 1, "expected projectTick to hit gh through a created provider");
+      for (const call of issueListCalls) {
+        assert.deepEqual(call.slice(-2), ["--repo", "yaqub0r/devclaw"]);
+      }
+    } finally {
+      await h.cleanup();
+    }
+  });
+});

--- a/lib/services/tick.ts
+++ b/lib/services/tick.ts
@@ -8,6 +8,7 @@ import type { PluginRuntime } from "openclaw/plugin-sdk";
 import type { RunCommand } from "../context.js";
 import type { Issue, IssueProvider } from "../providers/provider.js";
 import { createProvider } from "../providers/index.js";
+import { normalizeRepoTarget } from "../tools/helpers.js";
 import { selectLevel } from "../roles/model-selector.js";
 import { getRoleWorker, getProject, readProjects, findFreeSlot, countActiveSlots, reconcileSlots } from "../projects/index.js";
 import { dispatchTask } from "../dispatch/index.js";
@@ -82,7 +83,12 @@ export async function projectTick(opts: {
   const resolvedConfig = await loadConfig(workspaceDir, project.name);
   const workflow = opts.workflow ?? resolvedConfig.workflow;
 
-  const provider = opts.provider ?? (await createProvider({ repo: project.repo, provider: project.provider, runCommand: runCommand! })).provider;
+  const provider = opts.provider ?? (await createProvider({
+    repo: project.repo,
+    provider: project.provider,
+    target: project.repoRemote ? { repo: normalizeRepoTarget(project.repoRemote) } : undefined,
+    runCommand: runCommand!,
+  })).provider;
   const roleExecution = workflow.roleExecution ?? ExecutionMode.PARALLEL;
   const enabledRoles = Object.entries(resolvedConfig.roles)
     .filter(([, r]) => r.enabled)

--- a/lib/setup/cli.ts
+++ b/lib/setup/cli.ts
@@ -10,6 +10,7 @@ import { runSetup } from "./index.js";
 import { getAllDefaultModels, getAllRoleIds, getLevelsForRole } from "../roles/index.js";
 import { readProjects, writeProjects, type Channel } from "../projects/index.js";
 import { log as auditLog } from "../audit.js";
+import { getBuildProvenance } from "../build-provenance.js";
 
 /**
  * Get the default workspace directory from the OpenClaw config.
@@ -99,6 +100,13 @@ export function registerCli(program: Command, ctx: PluginContext): void {
     });
 
   // Channel management commands
+  devclaw
+    .command("provenance")
+    .description("Show embedded live runtime build provenance")
+    .action(() => {
+      console.log(JSON.stringify(getBuildProvenance(), null, 2));
+    });
+
   const channel = devclaw
     .command("channel")
     .description("Manage project channels (register, deregister, list)");

--- a/lib/setup/onboarding.ts
+++ b/lib/setup/onboarding.ts
@@ -59,11 +59,11 @@ Models are configured in \`devclaw/workflow.yaml\`. Edit that file directly or c
 
 ## What can be changed
 1. **Model levels** — call \`setup\` with a \`models\` object containing only the levels to change
-2. **Workspace files** — \`setup\` re-writes AGENTS.md, HEARTBEAT.md (backs up existing files)
+2. **Workspace files** — \`setup\` seeds missing workspace files, and normal startup refreshes only DevClaw-managed tagged blocks inside AGENTS.md / HEARTBEAT.md / TOOLS.md
 3. **Register new projects** — use \`project_register\`
 
 Ask what they want to change, then call the appropriate tool.
-\`setup\` is safe to re-run — it backs up existing files before overwriting.
+Use \`setup({ resetDefaults: true })\` only when they explicitly want package defaults force-written again.
 `;
 }
 

--- a/lib/setup/templates.ts
+++ b/lib/setup/templates.ts
@@ -12,9 +12,21 @@ import path from "node:path";
 // File loader — reads from defaults/ (single source of truth)
 // ---------------------------------------------------------------------------
 
-// esbuild bundles everything into dist/index.js, so import.meta.url points to
-// dist/index.js → one level up reaches the repo root where defaults/ lives.
-const DEFAULTS_DIR = path.join(path.dirname(fileURLToPath(import.meta.url)), "..", "defaults");
+function resolveDefaultsDir(): string {
+  const here = path.dirname(fileURLToPath(import.meta.url));
+  const candidates = [
+    path.join(here, "..", "..", "defaults"),
+    path.join(here, "..", "defaults"),
+  ];
+
+  for (const candidate of candidates) {
+    if (fs.existsSync(candidate)) return candidate;
+  }
+
+  throw new Error(`Failed to locate defaults directory from ${here}`);
+}
+
+const DEFAULTS_DIR = resolveDefaultsDir();
 
 function loadDefault(filename: string): string {
   const filePath = path.join(DEFAULTS_DIR, filename);

--- a/lib/setup/templates.ts
+++ b/lib/setup/templates.ts
@@ -13,17 +13,21 @@ import path from "node:path";
 // ---------------------------------------------------------------------------
 
 function resolveDefaultsDir(): string {
-  const here = path.dirname(fileURLToPath(import.meta.url));
+  const moduleDir = path.dirname(fileURLToPath(import.meta.url));
   const candidates = [
-    path.join(here, "..", "..", "defaults"),
-    path.join(here, "..", "defaults"),
+    // Source layout: lib/setup/templates.ts -> repo root is ../..
+    path.join(moduleDir, "..", "..", "defaults"),
+    // Bundled layout: dist/index.js -> repo root is ..
+    path.join(moduleDir, "..", "defaults"),
+    // Last resort for unusual invocation cwd
+    path.join(process.cwd(), "defaults"),
   ];
 
   for (const candidate of candidates) {
     if (fs.existsSync(candidate)) return candidate;
   }
 
-  throw new Error(`Failed to locate defaults directory from ${here}`);
+  throw new Error(`Failed to locate defaults/ directory. Tried: ${candidates.join(", ")}`);
 }
 
 const DEFAULTS_DIR = resolveDefaultsDir();

--- a/lib/setup/templates.ts
+++ b/lib/setup/templates.ts
@@ -49,6 +49,9 @@ const DEFAULT_DEV_INSTRUCTIONS = loadDefault("devclaw/prompts/developer.md");
 const DEFAULT_QA_INSTRUCTIONS = loadDefault("devclaw/prompts/tester.md");
 const DEFAULT_ARCHITECT_INSTRUCTIONS = loadDefault("devclaw/prompts/architect.md");
 const DEFAULT_REVIEWER_INSTRUCTIONS = loadDefault("devclaw/prompts/reviewer.md");
+const DEFAULT_ORCHESTRATOR_INSTRUCTIONS = loadDefault("devclaw/prompts/orchestrator.md");
+
+export const DEFAULT_ORCHESTRATOR_PROMPT = DEFAULT_ORCHESTRATOR_INSTRUCTIONS;
 
 /** Default role instructions indexed by role ID. Used by project scaffolding. */
 export const DEFAULT_ROLE_INSTRUCTIONS: Record<string, string> = {
@@ -56,6 +59,12 @@ export const DEFAULT_ROLE_INSTRUCTIONS: Record<string, string> = {
   tester: DEFAULT_QA_INSTRUCTIONS,
   architect: DEFAULT_ARCHITECT_INSTRUCTIONS,
   reviewer: DEFAULT_REVIEWER_INSTRUCTIONS,
+};
+
+/** Prompt files scaffolded into devclaw/prompts/. Includes non-worker orchestrator prompt. */
+export const DEFAULT_PROMPT_INSTRUCTIONS: Record<string, string> = {
+  ...DEFAULT_ROLE_INSTRUCTIONS,
+  orchestrator: DEFAULT_ORCHESTRATOR_INSTRUCTIONS,
 };
 
 // ---------------------------------------------------------------------------

--- a/lib/setup/workspace.test.ts
+++ b/lib/setup/workspace.test.ts
@@ -1,8 +1,8 @@
 /**
- * workspace.test.ts — Tests for write-once default file behavior.
+ * workspace.test.ts — Tests for default workspace file behavior.
  *
- * Verifies that ensureDefaultFiles() creates missing files but never
- * overwrites user-owned config (workflow.yaml, prompts, IDENTITY.md).
+ * Verifies that ensureDefaultFiles() preserves user-owned config and only
+ * manages tagged DevClaw blocks in workspace-root guidance files.
  *
  * Run: npx tsx --test lib/setup/workspace.test.ts
  */
@@ -11,7 +11,7 @@ import assert from "node:assert";
 import fs from "node:fs/promises";
 import path from "node:path";
 import os from "node:os";
-import { ensureDefaultFiles, fileExists } from "./workspace.js";
+import { ensureDefaultFiles, fileExists, writeAllDefaults } from "./workspace.js";
 import { DATA_DIR } from "./migrate-layout.js";
 
 let tmpDir: string;
@@ -27,7 +27,7 @@ afterEach(async () => {
   if (tmpDir) await fs.rm(tmpDir, { recursive: true, force: true });
 });
 
-describe("ensureDefaultFiles — write-once behavior", () => {
+describe("ensureDefaultFiles — managed root-block behavior", () => {
   it("should create workflow.yaml when missing", async () => {
     const ws = await makeTmpDir();
     await ensureDefaultFiles(ws);
@@ -100,15 +100,95 @@ describe("ensureDefaultFiles — write-once behavior", () => {
     assert.strictEqual(afterContent, customIdentity, "IDENTITY.md should not be overwritten");
   });
 
-  it("should always overwrite AGENTS.md (system instructions)", async () => {
+  it("should scaffold AGENTS.md with a managed block when missing", async () => {
+    const ws = await makeTmpDir();
+
+    await ensureDefaultFiles(ws);
+
+    const agentsPath = path.join(ws, "AGENTS.md");
+    const content = await fs.readFile(agentsPath, "utf-8");
+    assert.match(content, /<!-- DEVCLAW:START agents -->/);
+    assert.match(content, /<!-- DEVCLAW:END agents -->/);
+  });
+
+  it("should insert a managed block into an existing AGENTS.md without destroying user content", async () => {
     const ws = await makeTmpDir();
     const agentsPath = path.join(ws, "AGENTS.md");
-    await fs.writeFile(agentsPath, "# Old agents content", "utf-8");
+    const before = "# My workspace rules\n\nKeep this.\n\n## After\nStill mine.\n";
+    await fs.writeFile(agentsPath, before, "utf-8");
 
     await ensureDefaultFiles(ws);
 
     const afterContent = await fs.readFile(agentsPath, "utf-8");
-    assert.notStrictEqual(afterContent, "# Old agents content", "AGENTS.md should be overwritten");
+    assert.match(afterContent, /^# My workspace rules/m);
+    assert.match(afterContent, /Keep this\./);
+    assert.match(afterContent, /^## After$/m);
+    assert.match(afterContent, /Still mine\./);
+    assert.match(afterContent, /<!-- DEVCLAW:START agents -->[\s\S]*<!-- DEVCLAW:END agents -->/);
+  });
+
+  it("should update an existing managed block without duplicating it", async () => {
+    const ws = await makeTmpDir();
+    const toolsPath = path.join(ws, "TOOLS.md");
+    await fs.writeFile(
+      toolsPath,
+      "Intro\n\n<!-- DEVCLAW:START tools -->\nold block\n<!-- DEVCLAW:END tools -->\n\nOutro\n",
+      "utf-8",
+    );
+
+    await ensureDefaultFiles(ws);
+    await ensureDefaultFiles(ws);
+
+    const afterContent = await fs.readFile(toolsPath, "utf-8");
+    const blockCount = (afterContent.match(/<!-- DEVCLAW:START tools -->/g) ?? []).length;
+    assert.strictEqual(blockCount, 1, "managed block should not be duplicated");
+    assert.match(afterContent, /^Intro/m);
+    assert.match(afterContent, /^Outro/m);
+    assert.ok(!afterContent.includes("old block"), "managed block should be refreshed");
+  });
+
+  it("should preserve customized HEARTBEAT.md and TOOLS.md content outside managed blocks", async () => {
+    const ws = await makeTmpDir();
+    const heartbeatPath = path.join(ws, "HEARTBEAT.md");
+    const toolsPath = path.join(ws, "TOOLS.md");
+    await fs.writeFile(heartbeatPath, "Before\n\nAfter heartbeat\n", "utf-8");
+    await fs.writeFile(toolsPath, "Before tools\n\nAfter tools\n", "utf-8");
+
+    await ensureDefaultFiles(ws);
+
+    const heartbeat = await fs.readFile(heartbeatPath, "utf-8");
+    const tools = await fs.readFile(toolsPath, "utf-8");
+    assert.match(heartbeat, /^Before/m);
+    assert.match(heartbeat, /^After heartbeat$/m);
+    assert.match(heartbeat, /<!-- DEVCLAW:START heartbeat -->/);
+    assert.match(tools, /^Before tools/m);
+    assert.match(tools, /^After tools$/m);
+    assert.match(tools, /<!-- DEVCLAW:START tools -->/);
+  });
+
+  it("should let explicit reset/default-writing flows overwrite intentionally", async () => {
+    const ws = await makeTmpDir();
+    const agentsPath = path.join(ws, "AGENTS.md");
+    await fs.writeFile(agentsPath, "# Custom root file\n", "utf-8");
+
+    const written = await writeAllDefaults(ws, true);
+    const afterContent = await fs.readFile(agentsPath, "utf-8");
+
+    assert.ok(written.includes("AGENTS.md"));
+    assert.ok(!afterContent.includes("# Custom root file"), "reset-defaults should replace the full file");
+    assert.ok(afterContent.includes("DevClaw"), "reset-defaults should restore the package template");
+  });
+
+  it("should let eject-defaults skip existing customized root files", async () => {
+    const ws = await makeTmpDir();
+    const toolsPath = path.join(ws, "TOOLS.md");
+    await fs.writeFile(toolsPath, "# Custom tools\n", "utf-8");
+
+    const written = await writeAllDefaults(ws, false);
+    const afterContent = await fs.readFile(toolsPath, "utf-8");
+
+    assert.ok(!written.includes("TOOLS.md"));
+    assert.strictEqual(afterContent, "# Custom tools\n");
   });
 
   it("should write .version file", async () => {

--- a/lib/setup/workspace.test.ts
+++ b/lib/setup/workspace.test.ts
@@ -27,6 +27,10 @@ afterEach(async () => {
   if (tmpDir) await fs.rm(tmpDir, { recursive: true, force: true });
 });
 
+function escapeRegexForTest(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
 describe("ensureDefaultFiles — managed root-block behavior", () => {
   it("should create workflow.yaml when missing", async () => {
     const ws = await makeTmpDir();
@@ -111,23 +115,29 @@ describe("ensureDefaultFiles — managed root-block behavior", () => {
     assert.match(content, /<!-- DEVCLAW:END agents -->/);
   });
 
-  it("should insert a managed block into an existing AGENTS.md without destroying user content", async () => {
+  it("should insert a managed notice and block into an existing AGENTS.md without destroying user content", async () => {
     const ws = await makeTmpDir();
     const agentsPath = path.join(ws, "AGENTS.md");
     const before = "# My workspace rules\n\nKeep this.\n\n## After\nStill mine.\n";
     await fs.writeFile(agentsPath, before, "utf-8");
 
     await ensureDefaultFiles(ws);
+    await ensureDefaultFiles(ws);
 
     const afterContent = await fs.readFile(agentsPath, "utf-8");
+    const blockCount = (afterContent.match(/<!-- DEVCLAW:START agents -->/g) ?? []).length;
+    const noticeCount = (afterContent.match(/<!-- DEVCLAW:NOTICE:START agents -->/g) ?? []).length;
+    assert.strictEqual(blockCount, 1, "managed block should not be duplicated");
+    assert.strictEqual(noticeCount, 1, "managed notice should not be duplicated");
     assert.match(afterContent, /^# My workspace rules/m);
     assert.match(afterContent, /Keep this\./);
     assert.match(afterContent, /^## After$/m);
     assert.match(afterContent, /Still mine\./);
+    assert.match(afterContent, /<!-- DEVCLAW:NOTICE:START agents -->[\s\S]*may replace those changes the next time it refreshes defaults\.[\s\S]*<!-- DEVCLAW:NOTICE:END agents -->/);
     assert.match(afterContent, /<!-- DEVCLAW:START agents -->[\s\S]*<!-- DEVCLAW:END agents -->/);
   });
 
-  it("should update an existing managed block without duplicating it", async () => {
+  it("should update an existing managed block, seed its notice, and avoid duplication", async () => {
     const ws = await makeTmpDir();
     const toolsPath = path.join(ws, "TOOLS.md");
     await fs.writeFile(
@@ -141,29 +151,166 @@ describe("ensureDefaultFiles — managed root-block behavior", () => {
 
     const afterContent = await fs.readFile(toolsPath, "utf-8");
     const blockCount = (afterContent.match(/<!-- DEVCLAW:START tools -->/g) ?? []).length;
+    const noticeCount = (afterContent.match(/<!-- DEVCLAW:NOTICE:START tools -->/g) ?? []).length;
     assert.strictEqual(blockCount, 1, "managed block should not be duplicated");
+    assert.strictEqual(noticeCount, 1, "managed notice should not be duplicated");
     assert.match(afterContent, /^Intro/m);
     assert.match(afterContent, /^Outro/m);
+    assert.match(afterContent, /Add workspace-specific tool notes outside the managed block\./);
     assert.ok(!afterContent.includes("old block"), "managed block should be refreshed");
   });
 
-  it("should preserve customized HEARTBEAT.md and TOOLS.md content outside managed blocks", async () => {
+  it("should append only the missing block when the managed notice already exists", async () => {
+    const ws = await makeTmpDir();
+    const toolsPath = path.join(ws, "TOOLS.md");
+    await fs.writeFile(
+      toolsPath,
+      [
+        "Intro",
+        "",
+        "<!-- DEVCLAW:NOTICE:START tools -->",
+        "stale notice",
+        "<!-- DEVCLAW:NOTICE:END tools -->",
+        "",
+        "Outro",
+        "",
+      ].join("\n"),
+      "utf-8",
+    );
+
+    await ensureDefaultFiles(ws);
+    await ensureDefaultFiles(ws);
+
+    const afterContent = await fs.readFile(toolsPath, "utf-8");
+    const blockCount = (afterContent.match(/<!-- DEVCLAW:START tools -->/g) ?? []).length;
+    const noticeCount = (afterContent.match(/<!-- DEVCLAW:NOTICE:START tools -->/g) ?? []).length;
+
+    assert.strictEqual(blockCount, 1, "should insert exactly one managed block");
+    assert.strictEqual(noticeCount, 1, "should not duplicate the managed notice");
+    assert.match(afterContent, /^Intro/m);
+    assert.match(afterContent, /^Outro$/m);
+    assert.match(afterContent, /Add workspace-specific tool notes outside the managed block\./);
+    assert.ok(!afterContent.includes("stale notice"), "existing notice should be refreshed");
+  });
+
+  it("should normalize legacy full-file DevClaw root docs into a single managed block without duplication", async () => {
+    const ws = await makeTmpDir();
+    const legacyFiles = [
+      {
+        fileName: "AGENTS.md",
+        sectionId: "agents",
+        template: (await import("./templates.js")).AGENTS_MD_TEMPLATE,
+      },
+      {
+        fileName: "HEARTBEAT.md",
+        sectionId: "heartbeat",
+        template: (await import("./templates.js")).HEARTBEAT_MD_TEMPLATE,
+      },
+      {
+        fileName: "TOOLS.md",
+        sectionId: "tools",
+        template: (await import("./templates.js")).TOOLS_MD_TEMPLATE,
+      },
+    ];
+
+    for (const { fileName, sectionId, template } of legacyFiles) {
+      const filePath = path.join(ws, fileName);
+      const legacyContent = template.replace(/\n/g, "\r\n");
+      await fs.writeFile(filePath, legacyContent, "utf-8");
+
+      await ensureDefaultFiles(ws);
+      await ensureDefaultFiles(ws);
+
+      const afterContent = await fs.readFile(filePath, "utf-8");
+      const noticeCount = (afterContent.match(new RegExp(`<!-- DEVCLAW:NOTICE:START ${sectionId} -->`, "g")) ?? []).length;
+      const blockCount = (afterContent.match(new RegExp(`<!-- DEVCLAW:START ${sectionId} -->`, "g")) ?? []).length;
+
+      assert.strictEqual(noticeCount, 1, `${fileName} notice should be normalized exactly once`);
+      assert.strictEqual(blockCount, 1, `${fileName} block should be normalized exactly once`);
+      assert.doesNotMatch(afterContent, new RegExp(`${escapeRegexForTest(template.trim())}\\s*<!-- DEVCLAW:START ${sectionId} -->`), `${fileName} should not retain the legacy full-file template above the managed block`);
+    }
+  });
+
+  it("should collapse the real legacy-plus-tagged duplicate shape into one managed section", async () => {
+    const ws = await makeTmpDir();
+    const legacyFiles = [
+      {
+        fileName: "AGENTS.md",
+        sectionId: "agents",
+        template: (await import("./templates.js")).AGENTS_MD_TEMPLATE,
+      },
+      {
+        fileName: "HEARTBEAT.md",
+        sectionId: "heartbeat",
+        template: (await import("./templates.js")).HEARTBEAT_MD_TEMPLATE,
+      },
+      {
+        fileName: "TOOLS.md",
+        sectionId: "tools",
+        template: (await import("./templates.js")).TOOLS_MD_TEMPLATE,
+      },
+    ];
+
+    for (const { fileName, sectionId, template } of legacyFiles) {
+      const filePath = path.join(ws, fileName);
+      const duplicatedLegacy = `${template.trimEnd()}\n\n<!-- DEVCLAW:NOTICE:START ${sectionId} -->\nstale notice\n<!-- DEVCLAW:NOTICE:END ${sectionId} -->\n\n<!-- DEVCLAW:START ${sectionId} -->\nstale block\n<!-- DEVCLAW:END ${sectionId} -->\n`;
+      await fs.writeFile(filePath, duplicatedLegacy, "utf-8");
+
+      await ensureDefaultFiles(ws);
+      await ensureDefaultFiles(ws);
+
+      const afterContent = await fs.readFile(filePath, "utf-8");
+      const noticeCount = (afterContent.match(new RegExp(`<!-- DEVCLAW:NOTICE:START ${sectionId} -->`, "g")) ?? []).length;
+      const blockCount = (afterContent.match(new RegExp(`<!-- DEVCLAW:START ${sectionId} -->`, "g")) ?? []).length;
+
+      assert.strictEqual(noticeCount, 1, `${fileName} should keep one managed notice after normalization`);
+      assert.strictEqual(blockCount, 1, `${fileName} should keep one managed block after normalization`);
+      assert.doesNotMatch(afterContent, new RegExp(`^${escapeRegexForTest(template.trim())}\\s*<!-- DEVCLAW:NOTICE:START ${sectionId} -->`, "m"), `${fileName} should not keep the legacy template above the managed section`);
+      assert.ok(!afterContent.includes("stale notice"), `${fileName} should refresh any stale notice`);
+      assert.ok(!afterContent.includes("stale block"), `${fileName} should refresh any stale block`);
+    }
+  });
+
+  it("should preserve customized HEARTBEAT.md content outside managed sections across restarts", async () => {
     const ws = await makeTmpDir();
     const heartbeatPath = path.join(ws, "HEARTBEAT.md");
-    const toolsPath = path.join(ws, "TOOLS.md");
-    await fs.writeFile(heartbeatPath, "Before\n\nAfter heartbeat\n", "utf-8");
-    await fs.writeFile(toolsPath, "Before tools\n\nAfter tools\n", "utf-8");
+    const customHeartbeat = "Before\n\nAfter heartbeat\n";
+    await fs.writeFile(heartbeatPath, customHeartbeat, "utf-8");
 
+    await ensureDefaultFiles(ws);
     await ensureDefaultFiles(ws);
 
     const heartbeat = await fs.readFile(heartbeatPath, "utf-8");
-    const tools = await fs.readFile(toolsPath, "utf-8");
+    const noticeCount = (heartbeat.match(/<!-- DEVCLAW:NOTICE:START heartbeat -->/g) ?? []).length;
+    const blockCount = (heartbeat.match(/<!-- DEVCLAW:START heartbeat -->/g) ?? []).length;
+    assert.strictEqual(noticeCount, 1, "managed notice should not be duplicated");
+    assert.strictEqual(blockCount, 1, "managed block should not be duplicated");
     assert.match(heartbeat, /^Before/m);
     assert.match(heartbeat, /^After heartbeat$/m);
+    assert.match(heartbeat, /<!-- DEVCLAW:NOTICE:START heartbeat -->/);
     assert.match(heartbeat, /<!-- DEVCLAW:START heartbeat -->/);
+    assert.ok(heartbeat.includes("Before\n\nAfter heartbeat"), "custom heartbeat content should survive restart");
+  });
+
+  it("should preserve customized TOOLS.md content outside managed sections across restarts", async () => {
+    const ws = await makeTmpDir();
+    const toolsPath = path.join(ws, "TOOLS.md");
+    const customTools = "Before tools\n\nAfter tools\n";
+    await fs.writeFile(toolsPath, customTools, "utf-8");
+
+    await ensureDefaultFiles(ws);
+    await ensureDefaultFiles(ws);
+
+    const tools = await fs.readFile(toolsPath, "utf-8");
+    const noticeCount = (tools.match(/<!-- DEVCLAW:NOTICE:START tools -->/g) ?? []).length;
+    const blockCount = (tools.match(/<!-- DEVCLAW:START tools -->/g) ?? []).length;
+    assert.strictEqual(noticeCount, 1, "managed notice should not be duplicated");
+    assert.strictEqual(blockCount, 1, "managed block should not be duplicated");
     assert.match(tools, /^Before tools/m);
     assert.match(tools, /^After tools$/m);
+    assert.match(tools, /<!-- DEVCLAW:NOTICE:START tools -->/);
     assert.match(tools, /<!-- DEVCLAW:START tools -->/);
+    assert.ok(tools.includes("Before tools\n\nAfter tools"), "custom tools content should survive restart");
   });
 
   it("should let explicit reset/default-writing flows overwrite intentionally", async () => {

--- a/lib/setup/workspace.test.ts
+++ b/lib/setup/workspace.test.ts
@@ -27,6 +27,10 @@ afterEach(async () => {
   if (tmpDir) await fs.rm(tmpDir, { recursive: true, force: true });
 });
 
+function escapeRegexForTest(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
 describe("ensureDefaultFiles — managed root-block behavior", () => {
   it("should create workflow.yaml when missing", async () => {
     const ws = await makeTmpDir();
@@ -111,23 +115,29 @@ describe("ensureDefaultFiles — managed root-block behavior", () => {
     assert.match(content, /<!-- DEVCLAW:END agents -->/);
   });
 
-  it("should insert a managed block into an existing AGENTS.md without destroying user content", async () => {
+  it("should insert a managed notice and block into an existing AGENTS.md without destroying user content", async () => {
     const ws = await makeTmpDir();
     const agentsPath = path.join(ws, "AGENTS.md");
     const before = "# My workspace rules\n\nKeep this.\n\n## After\nStill mine.\n";
     await fs.writeFile(agentsPath, before, "utf-8");
 
     await ensureDefaultFiles(ws);
+    await ensureDefaultFiles(ws);
 
     const afterContent = await fs.readFile(agentsPath, "utf-8");
+    const blockCount = (afterContent.match(/<!-- DEVCLAW:START agents -->/g) ?? []).length;
+    const noticeCount = (afterContent.match(/<!-- DEVCLAW:NOTICE:START agents -->/g) ?? []).length;
+    assert.strictEqual(blockCount, 1, "managed block should not be duplicated");
+    assert.strictEqual(noticeCount, 1, "managed notice should not be duplicated");
     assert.match(afterContent, /^# My workspace rules/m);
     assert.match(afterContent, /Keep this\./);
     assert.match(afterContent, /^## After$/m);
     assert.match(afterContent, /Still mine\./);
+    assert.match(afterContent, /<!-- DEVCLAW:NOTICE:START agents -->[\s\S]*may replace those changes the next time it refreshes defaults\.[\s\S]*<!-- DEVCLAW:NOTICE:END agents -->/);
     assert.match(afterContent, /<!-- DEVCLAW:START agents -->[\s\S]*<!-- DEVCLAW:END agents -->/);
   });
 
-  it("should update an existing managed block without duplicating it", async () => {
+  it("should update an existing managed block, seed its notice, and avoid duplication", async () => {
     const ws = await makeTmpDir();
     const toolsPath = path.join(ws, "TOOLS.md");
     await fs.writeFile(
@@ -141,29 +151,126 @@ describe("ensureDefaultFiles — managed root-block behavior", () => {
 
     const afterContent = await fs.readFile(toolsPath, "utf-8");
     const blockCount = (afterContent.match(/<!-- DEVCLAW:START tools -->/g) ?? []).length;
+    const noticeCount = (afterContent.match(/<!-- DEVCLAW:NOTICE:START tools -->/g) ?? []).length;
     assert.strictEqual(blockCount, 1, "managed block should not be duplicated");
+    assert.strictEqual(noticeCount, 1, "managed notice should not be duplicated");
     assert.match(afterContent, /^Intro/m);
     assert.match(afterContent, /^Outro/m);
+    assert.match(afterContent, /Add workspace-specific tool notes outside the managed block\./);
     assert.ok(!afterContent.includes("old block"), "managed block should be refreshed");
   });
 
-  it("should preserve customized HEARTBEAT.md and TOOLS.md content outside managed blocks", async () => {
+  it("should append only the missing block when the managed notice already exists", async () => {
+    const ws = await makeTmpDir();
+    const toolsPath = path.join(ws, "TOOLS.md");
+    await fs.writeFile(
+      toolsPath,
+      [
+        "Intro",
+        "",
+        "<!-- DEVCLAW:NOTICE:START tools -->",
+        "stale notice",
+        "<!-- DEVCLAW:NOTICE:END tools -->",
+        "",
+        "Outro",
+        "",
+      ].join("\n"),
+      "utf-8",
+    );
+
+    await ensureDefaultFiles(ws);
+    await ensureDefaultFiles(ws);
+
+    const afterContent = await fs.readFile(toolsPath, "utf-8");
+    const blockCount = (afterContent.match(/<!-- DEVCLAW:START tools -->/g) ?? []).length;
+    const noticeCount = (afterContent.match(/<!-- DEVCLAW:NOTICE:START tools -->/g) ?? []).length;
+
+    assert.strictEqual(blockCount, 1, "should insert exactly one managed block");
+    assert.strictEqual(noticeCount, 1, "should not duplicate the managed notice");
+    assert.match(afterContent, /^Intro/m);
+    assert.match(afterContent, /^Outro$/m);
+    assert.match(afterContent, /Add workspace-specific tool notes outside the managed block\./);
+    assert.ok(!afterContent.includes("stale notice"), "existing notice should be refreshed");
+  });
+
+  it("should normalize legacy full-file DevClaw root docs into a single managed block without duplication", async () => {
+    const ws = await makeTmpDir();
+    const legacyFiles = [
+      {
+        fileName: "AGENTS.md",
+        sectionId: "agents",
+        template: (await import("./templates.js")).AGENTS_MD_TEMPLATE,
+      },
+      {
+        fileName: "HEARTBEAT.md",
+        sectionId: "heartbeat",
+        template: (await import("./templates.js")).HEARTBEAT_MD_TEMPLATE,
+      },
+      {
+        fileName: "TOOLS.md",
+        sectionId: "tools",
+        template: (await import("./templates.js")).TOOLS_MD_TEMPLATE,
+      },
+    ];
+
+    for (const { fileName, sectionId, template } of legacyFiles) {
+      const filePath = path.join(ws, fileName);
+      const legacyContent = template.replace(/\n/g, "\r\n");
+      await fs.writeFile(filePath, legacyContent, "utf-8");
+
+      await ensureDefaultFiles(ws);
+      await ensureDefaultFiles(ws);
+
+      const afterContent = await fs.readFile(filePath, "utf-8");
+      const noticeCount = (afterContent.match(new RegExp(`<!-- DEVCLAW:NOTICE:START ${sectionId} -->`, "g")) ?? []).length;
+      const blockCount = (afterContent.match(new RegExp(`<!-- DEVCLAW:START ${sectionId} -->`, "g")) ?? []).length;
+
+      assert.strictEqual(noticeCount, 1, `${fileName} notice should be normalized exactly once`);
+      assert.strictEqual(blockCount, 1, `${fileName} block should be normalized exactly once`);
+      assert.doesNotMatch(afterContent, new RegExp(`${escapeRegexForTest(template.trim())}\\s*<!-- DEVCLAW:START ${sectionId} -->`), `${fileName} should not retain the legacy full-file template above the managed block`);
+    }
+  });
+
+  it("should preserve customized HEARTBEAT.md content outside managed sections across restarts", async () => {
     const ws = await makeTmpDir();
     const heartbeatPath = path.join(ws, "HEARTBEAT.md");
-    const toolsPath = path.join(ws, "TOOLS.md");
-    await fs.writeFile(heartbeatPath, "Before\n\nAfter heartbeat\n", "utf-8");
-    await fs.writeFile(toolsPath, "Before tools\n\nAfter tools\n", "utf-8");
+    const customHeartbeat = "Before\n\nAfter heartbeat\n";
+    await fs.writeFile(heartbeatPath, customHeartbeat, "utf-8");
 
+    await ensureDefaultFiles(ws);
     await ensureDefaultFiles(ws);
 
     const heartbeat = await fs.readFile(heartbeatPath, "utf-8");
-    const tools = await fs.readFile(toolsPath, "utf-8");
+    const noticeCount = (heartbeat.match(/<!-- DEVCLAW:NOTICE:START heartbeat -->/g) ?? []).length;
+    const blockCount = (heartbeat.match(/<!-- DEVCLAW:START heartbeat -->/g) ?? []).length;
+    assert.strictEqual(noticeCount, 1, "managed notice should not be duplicated");
+    assert.strictEqual(blockCount, 1, "managed block should not be duplicated");
     assert.match(heartbeat, /^Before/m);
     assert.match(heartbeat, /^After heartbeat$/m);
+    assert.match(heartbeat, /<!-- DEVCLAW:NOTICE:START heartbeat -->/);
     assert.match(heartbeat, /<!-- DEVCLAW:START heartbeat -->/);
+    assert.ok(heartbeat.includes("Before\n\nAfter heartbeat"), "custom heartbeat content should survive restart");
+  });
+
+  it("should preserve customized TOOLS.md content outside managed sections across restarts", async () => {
+    const ws = await makeTmpDir();
+    const toolsPath = path.join(ws, "TOOLS.md");
+    const customTools = "Before tools\n\nAfter tools\n";
+    await fs.writeFile(toolsPath, customTools, "utf-8");
+
+    await ensureDefaultFiles(ws);
+    await ensureDefaultFiles(ws);
+
+    const tools = await fs.readFile(toolsPath, "utf-8");
+    const noticeCount = (tools.match(/<!-- DEVCLAW:NOTICE:START tools -->/g) ?? []).length;
+    const blockCount = (tools.match(/<!-- DEVCLAW:START tools -->/g) ?? []).length;
+    assert.strictEqual(noticeCount, 1, "managed notice should not be duplicated");
+    assert.strictEqual(blockCount, 1, "managed block should not be duplicated");
     assert.match(tools, /^Before tools/m);
     assert.match(tools, /^After tools$/m);
+    assert.match(tools, /<!-- DEVCLAW:NOTICE:START tools -->/);
     assert.match(tools, /<!-- DEVCLAW:START tools -->/);
+    assert.ok(tools.includes("Before tools\n\nAfter tools"), "custom tools content should survive restart");
   });
 
   it("should let explicit reset/default-writing flows overwrite intentionally", async () => {

--- a/lib/setup/workspace.test.ts
+++ b/lib/setup/workspace.test.ts
@@ -56,7 +56,9 @@ describe("ensureDefaultFiles — managed root-block behavior", () => {
     const ws = await makeTmpDir();
     await ensureDefaultFiles(ws);
     const devPrompt = path.join(ws, DATA_DIR, "prompts", "developer.md");
+    const orchestratorPrompt = path.join(ws, DATA_DIR, "prompts", "orchestrator.md");
     assert.ok(await fileExists(devPrompt), "developer.md prompt should be created");
+    assert.ok(await fileExists(orchestratorPrompt), "orchestrator.md prompt should be created");
   });
 
   it("should NOT overwrite existing prompt files", async () => {

--- a/lib/setup/workspace.test.ts
+++ b/lib/setup/workspace.test.ts
@@ -27,10 +27,6 @@ afterEach(async () => {
   if (tmpDir) await fs.rm(tmpDir, { recursive: true, force: true });
 });
 
-function escapeRegexForTest(value: string): string {
-  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-}
-
 describe("ensureDefaultFiles — managed root-block behavior", () => {
   it("should create workflow.yaml when missing", async () => {
     const ws = await makeTmpDir();
@@ -115,29 +111,23 @@ describe("ensureDefaultFiles — managed root-block behavior", () => {
     assert.match(content, /<!-- DEVCLAW:END agents -->/);
   });
 
-  it("should insert a managed notice and block into an existing AGENTS.md without destroying user content", async () => {
+  it("should insert a managed block into an existing AGENTS.md without destroying user content", async () => {
     const ws = await makeTmpDir();
     const agentsPath = path.join(ws, "AGENTS.md");
     const before = "# My workspace rules\n\nKeep this.\n\n## After\nStill mine.\n";
     await fs.writeFile(agentsPath, before, "utf-8");
 
     await ensureDefaultFiles(ws);
-    await ensureDefaultFiles(ws);
 
     const afterContent = await fs.readFile(agentsPath, "utf-8");
-    const blockCount = (afterContent.match(/<!-- DEVCLAW:START agents -->/g) ?? []).length;
-    const noticeCount = (afterContent.match(/<!-- DEVCLAW:NOTICE:START agents -->/g) ?? []).length;
-    assert.strictEqual(blockCount, 1, "managed block should not be duplicated");
-    assert.strictEqual(noticeCount, 1, "managed notice should not be duplicated");
     assert.match(afterContent, /^# My workspace rules/m);
     assert.match(afterContent, /Keep this\./);
     assert.match(afterContent, /^## After$/m);
     assert.match(afterContent, /Still mine\./);
-    assert.match(afterContent, /<!-- DEVCLAW:NOTICE:START agents -->[\s\S]*may replace those changes the next time it refreshes defaults\.[\s\S]*<!-- DEVCLAW:NOTICE:END agents -->/);
     assert.match(afterContent, /<!-- DEVCLAW:START agents -->[\s\S]*<!-- DEVCLAW:END agents -->/);
   });
 
-  it("should update an existing managed block, seed its notice, and avoid duplication", async () => {
+  it("should update an existing managed block without duplicating it", async () => {
     const ws = await makeTmpDir();
     const toolsPath = path.join(ws, "TOOLS.md");
     await fs.writeFile(
@@ -151,126 +141,29 @@ describe("ensureDefaultFiles — managed root-block behavior", () => {
 
     const afterContent = await fs.readFile(toolsPath, "utf-8");
     const blockCount = (afterContent.match(/<!-- DEVCLAW:START tools -->/g) ?? []).length;
-    const noticeCount = (afterContent.match(/<!-- DEVCLAW:NOTICE:START tools -->/g) ?? []).length;
     assert.strictEqual(blockCount, 1, "managed block should not be duplicated");
-    assert.strictEqual(noticeCount, 1, "managed notice should not be duplicated");
     assert.match(afterContent, /^Intro/m);
     assert.match(afterContent, /^Outro/m);
-    assert.match(afterContent, /Add workspace-specific tool notes outside the managed block\./);
     assert.ok(!afterContent.includes("old block"), "managed block should be refreshed");
   });
 
-  it("should append only the missing block when the managed notice already exists", async () => {
-    const ws = await makeTmpDir();
-    const toolsPath = path.join(ws, "TOOLS.md");
-    await fs.writeFile(
-      toolsPath,
-      [
-        "Intro",
-        "",
-        "<!-- DEVCLAW:NOTICE:START tools -->",
-        "stale notice",
-        "<!-- DEVCLAW:NOTICE:END tools -->",
-        "",
-        "Outro",
-        "",
-      ].join("\n"),
-      "utf-8",
-    );
-
-    await ensureDefaultFiles(ws);
-    await ensureDefaultFiles(ws);
-
-    const afterContent = await fs.readFile(toolsPath, "utf-8");
-    const blockCount = (afterContent.match(/<!-- DEVCLAW:START tools -->/g) ?? []).length;
-    const noticeCount = (afterContent.match(/<!-- DEVCLAW:NOTICE:START tools -->/g) ?? []).length;
-
-    assert.strictEqual(blockCount, 1, "should insert exactly one managed block");
-    assert.strictEqual(noticeCount, 1, "should not duplicate the managed notice");
-    assert.match(afterContent, /^Intro/m);
-    assert.match(afterContent, /^Outro$/m);
-    assert.match(afterContent, /Add workspace-specific tool notes outside the managed block\./);
-    assert.ok(!afterContent.includes("stale notice"), "existing notice should be refreshed");
-  });
-
-  it("should normalize legacy full-file DevClaw root docs into a single managed block without duplication", async () => {
-    const ws = await makeTmpDir();
-    const legacyFiles = [
-      {
-        fileName: "AGENTS.md",
-        sectionId: "agents",
-        template: (await import("./templates.js")).AGENTS_MD_TEMPLATE,
-      },
-      {
-        fileName: "HEARTBEAT.md",
-        sectionId: "heartbeat",
-        template: (await import("./templates.js")).HEARTBEAT_MD_TEMPLATE,
-      },
-      {
-        fileName: "TOOLS.md",
-        sectionId: "tools",
-        template: (await import("./templates.js")).TOOLS_MD_TEMPLATE,
-      },
-    ];
-
-    for (const { fileName, sectionId, template } of legacyFiles) {
-      const filePath = path.join(ws, fileName);
-      const legacyContent = template.replace(/\n/g, "\r\n");
-      await fs.writeFile(filePath, legacyContent, "utf-8");
-
-      await ensureDefaultFiles(ws);
-      await ensureDefaultFiles(ws);
-
-      const afterContent = await fs.readFile(filePath, "utf-8");
-      const noticeCount = (afterContent.match(new RegExp(`<!-- DEVCLAW:NOTICE:START ${sectionId} -->`, "g")) ?? []).length;
-      const blockCount = (afterContent.match(new RegExp(`<!-- DEVCLAW:START ${sectionId} -->`, "g")) ?? []).length;
-
-      assert.strictEqual(noticeCount, 1, `${fileName} notice should be normalized exactly once`);
-      assert.strictEqual(blockCount, 1, `${fileName} block should be normalized exactly once`);
-      assert.doesNotMatch(afterContent, new RegExp(`${escapeRegexForTest(template.trim())}\\s*<!-- DEVCLAW:START ${sectionId} -->`), `${fileName} should not retain the legacy full-file template above the managed block`);
-    }
-  });
-
-  it("should preserve customized HEARTBEAT.md content outside managed sections across restarts", async () => {
+  it("should preserve customized HEARTBEAT.md and TOOLS.md content outside managed blocks", async () => {
     const ws = await makeTmpDir();
     const heartbeatPath = path.join(ws, "HEARTBEAT.md");
-    const customHeartbeat = "Before\n\nAfter heartbeat\n";
-    await fs.writeFile(heartbeatPath, customHeartbeat, "utf-8");
+    const toolsPath = path.join(ws, "TOOLS.md");
+    await fs.writeFile(heartbeatPath, "Before\n\nAfter heartbeat\n", "utf-8");
+    await fs.writeFile(toolsPath, "Before tools\n\nAfter tools\n", "utf-8");
 
-    await ensureDefaultFiles(ws);
     await ensureDefaultFiles(ws);
 
     const heartbeat = await fs.readFile(heartbeatPath, "utf-8");
-    const noticeCount = (heartbeat.match(/<!-- DEVCLAW:NOTICE:START heartbeat -->/g) ?? []).length;
-    const blockCount = (heartbeat.match(/<!-- DEVCLAW:START heartbeat -->/g) ?? []).length;
-    assert.strictEqual(noticeCount, 1, "managed notice should not be duplicated");
-    assert.strictEqual(blockCount, 1, "managed block should not be duplicated");
+    const tools = await fs.readFile(toolsPath, "utf-8");
     assert.match(heartbeat, /^Before/m);
     assert.match(heartbeat, /^After heartbeat$/m);
-    assert.match(heartbeat, /<!-- DEVCLAW:NOTICE:START heartbeat -->/);
     assert.match(heartbeat, /<!-- DEVCLAW:START heartbeat -->/);
-    assert.ok(heartbeat.includes("Before\n\nAfter heartbeat"), "custom heartbeat content should survive restart");
-  });
-
-  it("should preserve customized TOOLS.md content outside managed sections across restarts", async () => {
-    const ws = await makeTmpDir();
-    const toolsPath = path.join(ws, "TOOLS.md");
-    const customTools = "Before tools\n\nAfter tools\n";
-    await fs.writeFile(toolsPath, customTools, "utf-8");
-
-    await ensureDefaultFiles(ws);
-    await ensureDefaultFiles(ws);
-
-    const tools = await fs.readFile(toolsPath, "utf-8");
-    const noticeCount = (tools.match(/<!-- DEVCLAW:NOTICE:START tools -->/g) ?? []).length;
-    const blockCount = (tools.match(/<!-- DEVCLAW:START tools -->/g) ?? []).length;
-    assert.strictEqual(noticeCount, 1, "managed notice should not be duplicated");
-    assert.strictEqual(blockCount, 1, "managed block should not be duplicated");
     assert.match(tools, /^Before tools/m);
     assert.match(tools, /^After tools$/m);
-    assert.match(tools, /<!-- DEVCLAW:NOTICE:START tools -->/);
     assert.match(tools, /<!-- DEVCLAW:START tools -->/);
-    assert.ok(tools.includes("Before tools\n\nAfter tools"), "custom tools content should survive restart");
   });
 
   it("should let explicit reset/default-writing flows overwrite intentionally", async () => {

--- a/lib/setup/workspace.test.ts
+++ b/lib/setup/workspace.test.ts
@@ -27,10 +27,6 @@ afterEach(async () => {
   if (tmpDir) await fs.rm(tmpDir, { recursive: true, force: true });
 });
 
-function escapeRegexForTest(value: string): string {
-  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-}
-
 describe("ensureDefaultFiles — managed root-block behavior", () => {
   it("should create workflow.yaml when missing", async () => {
     const ws = await makeTmpDir();
@@ -115,29 +111,23 @@ describe("ensureDefaultFiles — managed root-block behavior", () => {
     assert.match(content, /<!-- DEVCLAW:END agents -->/);
   });
 
-  it("should insert a managed notice and block into an existing AGENTS.md without destroying user content", async () => {
+  it("should insert a managed block into an existing AGENTS.md without destroying user content", async () => {
     const ws = await makeTmpDir();
     const agentsPath = path.join(ws, "AGENTS.md");
     const before = "# My workspace rules\n\nKeep this.\n\n## After\nStill mine.\n";
     await fs.writeFile(agentsPath, before, "utf-8");
 
     await ensureDefaultFiles(ws);
-    await ensureDefaultFiles(ws);
 
     const afterContent = await fs.readFile(agentsPath, "utf-8");
-    const blockCount = (afterContent.match(/<!-- DEVCLAW:START agents -->/g) ?? []).length;
-    const noticeCount = (afterContent.match(/<!-- DEVCLAW:NOTICE:START agents -->/g) ?? []).length;
-    assert.strictEqual(blockCount, 1, "managed block should not be duplicated");
-    assert.strictEqual(noticeCount, 1, "managed notice should not be duplicated");
     assert.match(afterContent, /^# My workspace rules/m);
     assert.match(afterContent, /Keep this\./);
     assert.match(afterContent, /^## After$/m);
     assert.match(afterContent, /Still mine\./);
-    assert.match(afterContent, /<!-- DEVCLAW:NOTICE:START agents -->[\s\S]*may replace those changes the next time it refreshes defaults\.[\s\S]*<!-- DEVCLAW:NOTICE:END agents -->/);
     assert.match(afterContent, /<!-- DEVCLAW:START agents -->[\s\S]*<!-- DEVCLAW:END agents -->/);
   });
 
-  it("should update an existing managed block, seed its notice, and avoid duplication", async () => {
+  it("should update an existing managed block without duplicating it", async () => {
     const ws = await makeTmpDir();
     const toolsPath = path.join(ws, "TOOLS.md");
     await fs.writeFile(
@@ -151,166 +141,29 @@ describe("ensureDefaultFiles — managed root-block behavior", () => {
 
     const afterContent = await fs.readFile(toolsPath, "utf-8");
     const blockCount = (afterContent.match(/<!-- DEVCLAW:START tools -->/g) ?? []).length;
-    const noticeCount = (afterContent.match(/<!-- DEVCLAW:NOTICE:START tools -->/g) ?? []).length;
     assert.strictEqual(blockCount, 1, "managed block should not be duplicated");
-    assert.strictEqual(noticeCount, 1, "managed notice should not be duplicated");
     assert.match(afterContent, /^Intro/m);
     assert.match(afterContent, /^Outro/m);
-    assert.match(afterContent, /Add workspace-specific tool notes outside the managed block\./);
     assert.ok(!afterContent.includes("old block"), "managed block should be refreshed");
   });
 
-  it("should append only the missing block when the managed notice already exists", async () => {
-    const ws = await makeTmpDir();
-    const toolsPath = path.join(ws, "TOOLS.md");
-    await fs.writeFile(
-      toolsPath,
-      [
-        "Intro",
-        "",
-        "<!-- DEVCLAW:NOTICE:START tools -->",
-        "stale notice",
-        "<!-- DEVCLAW:NOTICE:END tools -->",
-        "",
-        "Outro",
-        "",
-      ].join("\n"),
-      "utf-8",
-    );
-
-    await ensureDefaultFiles(ws);
-    await ensureDefaultFiles(ws);
-
-    const afterContent = await fs.readFile(toolsPath, "utf-8");
-    const blockCount = (afterContent.match(/<!-- DEVCLAW:START tools -->/g) ?? []).length;
-    const noticeCount = (afterContent.match(/<!-- DEVCLAW:NOTICE:START tools -->/g) ?? []).length;
-
-    assert.strictEqual(blockCount, 1, "should insert exactly one managed block");
-    assert.strictEqual(noticeCount, 1, "should not duplicate the managed notice");
-    assert.match(afterContent, /^Intro/m);
-    assert.match(afterContent, /^Outro$/m);
-    assert.match(afterContent, /Add workspace-specific tool notes outside the managed block\./);
-    assert.ok(!afterContent.includes("stale notice"), "existing notice should be refreshed");
-  });
-
-  it("should normalize legacy full-file DevClaw root docs into a single managed block without duplication", async () => {
-    const ws = await makeTmpDir();
-    const legacyFiles = [
-      {
-        fileName: "AGENTS.md",
-        sectionId: "agents",
-        template: (await import("./templates.js")).AGENTS_MD_TEMPLATE,
-      },
-      {
-        fileName: "HEARTBEAT.md",
-        sectionId: "heartbeat",
-        template: (await import("./templates.js")).HEARTBEAT_MD_TEMPLATE,
-      },
-      {
-        fileName: "TOOLS.md",
-        sectionId: "tools",
-        template: (await import("./templates.js")).TOOLS_MD_TEMPLATE,
-      },
-    ];
-
-    for (const { fileName, sectionId, template } of legacyFiles) {
-      const filePath = path.join(ws, fileName);
-      const legacyContent = template.replace(/\n/g, "\r\n");
-      await fs.writeFile(filePath, legacyContent, "utf-8");
-
-      await ensureDefaultFiles(ws);
-      await ensureDefaultFiles(ws);
-
-      const afterContent = await fs.readFile(filePath, "utf-8");
-      const noticeCount = (afterContent.match(new RegExp(`<!-- DEVCLAW:NOTICE:START ${sectionId} -->`, "g")) ?? []).length;
-      const blockCount = (afterContent.match(new RegExp(`<!-- DEVCLAW:START ${sectionId} -->`, "g")) ?? []).length;
-
-      assert.strictEqual(noticeCount, 1, `${fileName} notice should be normalized exactly once`);
-      assert.strictEqual(blockCount, 1, `${fileName} block should be normalized exactly once`);
-      assert.doesNotMatch(afterContent, new RegExp(`${escapeRegexForTest(template.trim())}\\s*<!-- DEVCLAW:START ${sectionId} -->`), `${fileName} should not retain the legacy full-file template above the managed block`);
-    }
-  });
-
-  it("should collapse the real legacy-plus-tagged duplicate shape into one managed section", async () => {
-    const ws = await makeTmpDir();
-    const legacyFiles = [
-      {
-        fileName: "AGENTS.md",
-        sectionId: "agents",
-        template: (await import("./templates.js")).AGENTS_MD_TEMPLATE,
-      },
-      {
-        fileName: "HEARTBEAT.md",
-        sectionId: "heartbeat",
-        template: (await import("./templates.js")).HEARTBEAT_MD_TEMPLATE,
-      },
-      {
-        fileName: "TOOLS.md",
-        sectionId: "tools",
-        template: (await import("./templates.js")).TOOLS_MD_TEMPLATE,
-      },
-    ];
-
-    for (const { fileName, sectionId, template } of legacyFiles) {
-      const filePath = path.join(ws, fileName);
-      const duplicatedLegacy = `${template.trimEnd()}\n\n<!-- DEVCLAW:NOTICE:START ${sectionId} -->\nstale notice\n<!-- DEVCLAW:NOTICE:END ${sectionId} -->\n\n<!-- DEVCLAW:START ${sectionId} -->\nstale block\n<!-- DEVCLAW:END ${sectionId} -->\n`;
-      await fs.writeFile(filePath, duplicatedLegacy, "utf-8");
-
-      await ensureDefaultFiles(ws);
-      await ensureDefaultFiles(ws);
-
-      const afterContent = await fs.readFile(filePath, "utf-8");
-      const noticeCount = (afterContent.match(new RegExp(`<!-- DEVCLAW:NOTICE:START ${sectionId} -->`, "g")) ?? []).length;
-      const blockCount = (afterContent.match(new RegExp(`<!-- DEVCLAW:START ${sectionId} -->`, "g")) ?? []).length;
-
-      assert.strictEqual(noticeCount, 1, `${fileName} should keep one managed notice after normalization`);
-      assert.strictEqual(blockCount, 1, `${fileName} should keep one managed block after normalization`);
-      assert.doesNotMatch(afterContent, new RegExp(`^${escapeRegexForTest(template.trim())}\\s*<!-- DEVCLAW:NOTICE:START ${sectionId} -->`, "m"), `${fileName} should not keep the legacy template above the managed section`);
-      assert.ok(!afterContent.includes("stale notice"), `${fileName} should refresh any stale notice`);
-      assert.ok(!afterContent.includes("stale block"), `${fileName} should refresh any stale block`);
-    }
-  });
-
-  it("should preserve customized HEARTBEAT.md content outside managed sections across restarts", async () => {
+  it("should preserve customized HEARTBEAT.md and TOOLS.md content outside managed blocks", async () => {
     const ws = await makeTmpDir();
     const heartbeatPath = path.join(ws, "HEARTBEAT.md");
-    const customHeartbeat = "Before\n\nAfter heartbeat\n";
-    await fs.writeFile(heartbeatPath, customHeartbeat, "utf-8");
+    const toolsPath = path.join(ws, "TOOLS.md");
+    await fs.writeFile(heartbeatPath, "Before\n\nAfter heartbeat\n", "utf-8");
+    await fs.writeFile(toolsPath, "Before tools\n\nAfter tools\n", "utf-8");
 
-    await ensureDefaultFiles(ws);
     await ensureDefaultFiles(ws);
 
     const heartbeat = await fs.readFile(heartbeatPath, "utf-8");
-    const noticeCount = (heartbeat.match(/<!-- DEVCLAW:NOTICE:START heartbeat -->/g) ?? []).length;
-    const blockCount = (heartbeat.match(/<!-- DEVCLAW:START heartbeat -->/g) ?? []).length;
-    assert.strictEqual(noticeCount, 1, "managed notice should not be duplicated");
-    assert.strictEqual(blockCount, 1, "managed block should not be duplicated");
+    const tools = await fs.readFile(toolsPath, "utf-8");
     assert.match(heartbeat, /^Before/m);
     assert.match(heartbeat, /^After heartbeat$/m);
-    assert.match(heartbeat, /<!-- DEVCLAW:NOTICE:START heartbeat -->/);
     assert.match(heartbeat, /<!-- DEVCLAW:START heartbeat -->/);
-    assert.ok(heartbeat.includes("Before\n\nAfter heartbeat"), "custom heartbeat content should survive restart");
-  });
-
-  it("should preserve customized TOOLS.md content outside managed sections across restarts", async () => {
-    const ws = await makeTmpDir();
-    const toolsPath = path.join(ws, "TOOLS.md");
-    const customTools = "Before tools\n\nAfter tools\n";
-    await fs.writeFile(toolsPath, customTools, "utf-8");
-
-    await ensureDefaultFiles(ws);
-    await ensureDefaultFiles(ws);
-
-    const tools = await fs.readFile(toolsPath, "utf-8");
-    const noticeCount = (tools.match(/<!-- DEVCLAW:NOTICE:START tools -->/g) ?? []).length;
-    const blockCount = (tools.match(/<!-- DEVCLAW:START tools -->/g) ?? []).length;
-    assert.strictEqual(noticeCount, 1, "managed notice should not be duplicated");
-    assert.strictEqual(blockCount, 1, "managed block should not be duplicated");
     assert.match(tools, /^Before tools/m);
     assert.match(tools, /^After tools$/m);
-    assert.match(tools, /<!-- DEVCLAW:NOTICE:START tools -->/);
     assert.match(tools, /<!-- DEVCLAW:START tools -->/);
-    assert.ok(tools.includes("Before tools\n\nAfter tools"), "custom tools content should survive restart");
   });
 
   it("should let explicit reset/default-writing flows overwrite intentionally", async () => {

--- a/lib/setup/workspace.ts
+++ b/lib/setup/workspace.ts
@@ -60,13 +60,7 @@ const MANAGED_BLOCKS = {
  *   - Runtime state (projects.json): create-only
  */
 export async function ensureDefaultFiles(workspacePath: string): Promise<void> {
-  const dataDir = path.join(workspacePath, DATA_DIR);
-  await fs.mkdir(dataDir, { recursive: true });
-
-  // Ensure directories exist
-  await fs.mkdir(path.join(dataDir, "projects"), { recursive: true });
-  await fs.mkdir(path.join(dataDir, "prompts"), { recursive: true });
-  await fs.mkdir(path.join(dataDir, "log"), { recursive: true });
+  await ensureWorkspaceDataFiles(workspacePath);
 
   // --- Workspace-root guidance files — manage tagged DevClaw blocks only ---
   for (const [fileName, config] of Object.entries(MANAGED_BLOCKS)) {
@@ -83,6 +77,20 @@ export async function ensureDefaultFiles(workspacePath: string): Promise<void> {
 
   // Remove BOOTSTRAP.md — one-time onboarding file, not needed after setup
   try { await fs.unlink(path.join(workspacePath, "BOOTSTRAP.md")); } catch { /* already gone */ }
+}
+
+/**
+ * Ensure DevClaw-owned data files exist without touching workspace-root guidance files.
+ * Safe for generic runtime code paths like project reads.
+ */
+export async function ensureWorkspaceDataFiles(workspacePath: string): Promise<void> {
+  const dataDir = path.join(workspacePath, DATA_DIR);
+  await fs.mkdir(dataDir, { recursive: true });
+
+  // Ensure directories exist
+  await fs.mkdir(path.join(dataDir, "projects"), { recursive: true });
+  await fs.mkdir(path.join(dataDir, "prompts"), { recursive: true });
+  await fs.mkdir(path.join(dataDir, "log"), { recursive: true });
 
   // devclaw/workflow.yaml — create-only (three-layer merge handles defaults for missing keys)
   const workflowPath = path.join(dataDir, "workflow.yaml");
@@ -219,28 +227,81 @@ function buildManagedBlock(sectionId: string, content: string): string {
   return `${start}\n${content.trimEnd()}\n${end}`;
 }
 
+function buildManagedNotice(sectionId: string, intro: string): string {
+  return [
+    `<!-- DEVCLAW:NOTICE:START ${sectionId} -->`,
+    intro,
+    `<!-- DEVCLAW:NOTICE:END ${sectionId} -->`,
+  ].join("\n");
+}
+
+function buildManagedSection(sectionId: string, content: string, intro: string): string {
+  return `${buildManagedNotice(sectionId, intro)}\n\n${buildManagedBlock(sectionId, content)}`;
+}
+
 function buildManagedFile(sectionId: string, content: string, intro: string): string {
-  return `${intro}\n\n${buildManagedBlock(sectionId, content)}\n`;
+  return `${buildManagedSection(sectionId, content, intro)}\n`;
+}
+
+function normalizeForManagedComparison(content: string): string {
+  return content
+    .replace(/^\uFEFF/, "")
+    .replace(/\r\n?/g, "\n")
+    .trim();
+}
+
+function isLegacyManagedFullFile(originalContent: string, template: string): boolean {
+  return normalizeForManagedComparison(originalContent) === normalizeForManagedComparison(template);
 }
 
 function upsertManagedContent(originalContent: string, sectionId: string, content: string, intro: string): string {
   const managedBlock = buildManagedBlock(sectionId, content);
+  const managedNotice = buildManagedNotice(sectionId, intro);
+  const managedSection = buildManagedSection(sectionId, content, intro);
   const blockPattern = new RegExp(
     `<!-- DEVCLAW:START ${escapeRegExp(sectionId)} -->[\\s\\S]*?<!-- DEVCLAW:END ${escapeRegExp(sectionId)} -->`,
     "m",
   );
+  const noticePattern = new RegExp(
+    `<!-- DEVCLAW:NOTICE:START ${escapeRegExp(sectionId)} -->[\\s\\S]*?<!-- DEVCLAW:NOTICE:END ${escapeRegExp(sectionId)} -->\\n*`,
+    "m",
+  );
 
-  if (!originalContent.trim()) {
+  if (!originalContent.trim() || isLegacyManagedFullFile(originalContent, content)) {
     return buildManagedFile(sectionId, content, intro);
   }
 
-  if (blockPattern.test(originalContent)) {
-    const updated = originalContent.replace(blockPattern, managedBlock);
-    return updated.endsWith("\n") ? updated : `${updated}\n`;
+  const hasNotice = noticePattern.test(originalContent);
+  const hasBlock = blockPattern.test(originalContent);
+
+  // Step 1: seed or refresh the explanatory notice independently from block insertion.
+  let nextContent = hasNotice
+    ? originalContent.replace(noticePattern, `${managedNotice}\n\n`)
+    : originalContent;
+
+  if (!hasNotice && hasBlock) {
+    const blockMatch = nextContent.match(blockPattern);
+    if (!blockMatch || typeof blockMatch.index !== "number") {
+      return nextContent.endsWith("\n") ? nextContent : `${nextContent}\n`;
+    }
+
+    const beforeBlock = nextContent.slice(0, blockMatch.index).replace(/\n+$/, "");
+    const afterBlock = nextContent.slice(blockMatch.index);
+    nextContent = beforeBlock
+      ? `${beforeBlock}\n\n${managedNotice}\n\n${afterBlock}`
+      : `${managedNotice}\n\n${afterBlock}`;
   }
 
-  const separator = originalContent.endsWith("\n") ? "\n" : "\n\n";
-  return `${originalContent}${separator}${managedBlock}\n`;
+  // Step 2: replace or append the managed block, preserving user-owned content.
+  if (hasBlock) {
+    nextContent = nextContent.replace(blockPattern, managedBlock);
+    return nextContent.endsWith("\n") ? nextContent : `${nextContent}\n`;
+  }
+
+  const baseContent = nextContent.replace(/\n+$/, "");
+  const separator = baseContent.endsWith("\n") ? "\n" : "\n\n";
+  const insertedContent = hasNotice ? managedBlock : managedSection;
+  return `${baseContent}${separator}${insertedContent}\n`;
 }
 
 async function upsertManagedBlock(filePath: string, sectionId: string, content: string, intro: string): Promise<void> {

--- a/lib/setup/workspace.ts
+++ b/lib/setup/workspace.ts
@@ -60,7 +60,13 @@ const MANAGED_BLOCKS = {
  *   - Runtime state (projects.json): create-only
  */
 export async function ensureDefaultFiles(workspacePath: string): Promise<void> {
-  await ensureWorkspaceDataFiles(workspacePath);
+  const dataDir = path.join(workspacePath, DATA_DIR);
+  await fs.mkdir(dataDir, { recursive: true });
+
+  // Ensure directories exist
+  await fs.mkdir(path.join(dataDir, "projects"), { recursive: true });
+  await fs.mkdir(path.join(dataDir, "prompts"), { recursive: true });
+  await fs.mkdir(path.join(dataDir, "log"), { recursive: true });
 
   // --- Workspace-root guidance files — manage tagged DevClaw blocks only ---
   for (const [fileName, config] of Object.entries(MANAGED_BLOCKS)) {
@@ -77,20 +83,6 @@ export async function ensureDefaultFiles(workspacePath: string): Promise<void> {
 
   // Remove BOOTSTRAP.md — one-time onboarding file, not needed after setup
   try { await fs.unlink(path.join(workspacePath, "BOOTSTRAP.md")); } catch { /* already gone */ }
-}
-
-/**
- * Ensure DevClaw-owned data files exist without touching workspace-root guidance files.
- * Safe for generic runtime code paths like project reads.
- */
-export async function ensureWorkspaceDataFiles(workspacePath: string): Promise<void> {
-  const dataDir = path.join(workspacePath, DATA_DIR);
-  await fs.mkdir(dataDir, { recursive: true });
-
-  // Ensure directories exist
-  await fs.mkdir(path.join(dataDir, "projects"), { recursive: true });
-  await fs.mkdir(path.join(dataDir, "prompts"), { recursive: true });
-  await fs.mkdir(path.join(dataDir, "log"), { recursive: true });
 
   // devclaw/workflow.yaml — create-only (three-layer merge handles defaults for missing keys)
   const workflowPath = path.join(dataDir, "workflow.yaml");
@@ -227,97 +219,28 @@ function buildManagedBlock(sectionId: string, content: string): string {
   return `${start}\n${content.trimEnd()}\n${end}`;
 }
 
-function buildManagedNotice(sectionId: string, intro: string): string {
-  return [
-    `<!-- DEVCLAW:NOTICE:START ${sectionId} -->`,
-    intro,
-    `<!-- DEVCLAW:NOTICE:END ${sectionId} -->`,
-  ].join("\n");
-}
-
-function buildManagedSection(sectionId: string, content: string, intro: string): string {
-  return `${buildManagedNotice(sectionId, intro)}\n\n${buildManagedBlock(sectionId, content)}`;
-}
-
 function buildManagedFile(sectionId: string, content: string, intro: string): string {
-  return `${buildManagedSection(sectionId, content, intro)}\n`;
-}
-
-function normalizeForManagedComparison(content: string): string {
-  return content
-    .replace(/^\uFEFF/, "")
-    .replace(/\r\n?/g, "\n")
-    .trim();
-}
-
-function isLegacyManagedFullFile(originalContent: string, template: string): boolean {
-  return normalizeForManagedComparison(originalContent) === normalizeForManagedComparison(template);
-}
-
-function stripManagedSection(originalContent: string, sectionId: string): string {
-  const managedSectionPattern = new RegExp(
-    `\n*<!-- DEVCLAW:NOTICE:START ${escapeRegExp(sectionId)} -->[\\s\\S]*?<!-- DEVCLAW:END ${escapeRegExp(sectionId)} -->\n*`,
-    "m",
-  );
-  return originalContent.replace(managedSectionPattern, "\n");
-}
-
-function isLegacyManagedFileWithTaggedDuplicate(originalContent: string, sectionId: string, template: string): boolean {
-  return isLegacyManagedFullFile(stripManagedSection(originalContent, sectionId), template);
+  return `${intro}\n\n${buildManagedBlock(sectionId, content)}\n`;
 }
 
 function upsertManagedContent(originalContent: string, sectionId: string, content: string, intro: string): string {
   const managedBlock = buildManagedBlock(sectionId, content);
-  const managedNotice = buildManagedNotice(sectionId, intro);
-  const managedSection = buildManagedSection(sectionId, content, intro);
   const blockPattern = new RegExp(
     `<!-- DEVCLAW:START ${escapeRegExp(sectionId)} -->[\\s\\S]*?<!-- DEVCLAW:END ${escapeRegExp(sectionId)} -->`,
     "m",
   );
-  const noticePattern = new RegExp(
-    `<!-- DEVCLAW:NOTICE:START ${escapeRegExp(sectionId)} -->[\\s\\S]*?<!-- DEVCLAW:NOTICE:END ${escapeRegExp(sectionId)} -->\\n*`,
-    "m",
-  );
 
-  if (
-    !originalContent.trim()
-    || isLegacyManagedFullFile(originalContent, content)
-    || isLegacyManagedFileWithTaggedDuplicate(originalContent, sectionId, content)
-  ) {
+  if (!originalContent.trim()) {
     return buildManagedFile(sectionId, content, intro);
   }
 
-  const hasNotice = noticePattern.test(originalContent);
-  const hasBlock = blockPattern.test(originalContent);
-
-  // Step 1: seed or refresh the explanatory notice independently from block insertion.
-  let nextContent = hasNotice
-    ? originalContent.replace(noticePattern, `${managedNotice}\n\n`)
-    : originalContent;
-
-  if (!hasNotice && hasBlock) {
-    const blockMatch = nextContent.match(blockPattern);
-    if (!blockMatch || typeof blockMatch.index !== "number") {
-      return nextContent.endsWith("\n") ? nextContent : `${nextContent}\n`;
-    }
-
-    const beforeBlock = nextContent.slice(0, blockMatch.index).replace(/\n+$/, "");
-    const afterBlock = nextContent.slice(blockMatch.index);
-    nextContent = beforeBlock
-      ? `${beforeBlock}\n\n${managedNotice}\n\n${afterBlock}`
-      : `${managedNotice}\n\n${afterBlock}`;
+  if (blockPattern.test(originalContent)) {
+    const updated = originalContent.replace(blockPattern, managedBlock);
+    return updated.endsWith("\n") ? updated : `${updated}\n`;
   }
 
-  // Step 2: replace or append the managed block, preserving user-owned content.
-  if (hasBlock) {
-    nextContent = nextContent.replace(blockPattern, managedBlock);
-    return nextContent.endsWith("\n") ? nextContent : `${nextContent}\n`;
-  }
-
-  const baseContent = nextContent.replace(/\n+$/, "");
-  const separator = baseContent.endsWith("\n") ? "\n" : "\n\n";
-  const insertedContent = hasNotice ? managedBlock : managedSection;
-  return `${baseContent}${separator}${insertedContent}\n`;
+  const separator = originalContent.endsWith("\n") ? "\n" : "\n\n";
+  return `${originalContent}${separator}${managedBlock}\n`;
 }
 
 async function upsertManagedBlock(filePath: string, sectionId: string, content: string, intro: string): Promise<void> {

--- a/lib/setup/workspace.ts
+++ b/lib/setup/workspace.ts
@@ -3,8 +3,9 @@
  *
  * On startup, ensureDefaultFiles() creates missing workspace files with curated
  * defaults. User-owned config files (workflow.yaml, prompts, IDENTITY.md) are
- * write-once: created if missing, never overwritten. System instruction files
- * (AGENTS.md, HEARTBEAT.md, TOOLS.md) are always refreshed.
+ * write-once: created if missing, never overwritten. Workspace-root guidance
+ * files (AGENTS.md, HEARTBEAT.md, TOOLS.md) remain user-owned documents; on
+ * startup DevClaw only manages its tagged section inside each file.
  *
  * The runtime config loader (lib/config/loader.ts) uses a three-layer merge with
  * built-in fallbacks, so missing keys in workflow.yaml are handled automatically.
@@ -30,13 +31,31 @@ import { log as auditLog } from "../audit.js";
 /** Sentinel file indicating the workspace has been initialized. */
 const INITIALIZED_SENTINEL = ".initialized";
 
+const MANAGED_BLOCKS = {
+  "AGENTS.md": {
+    sectionId: "agents",
+    template: AGENTS_MD_TEMPLATE,
+    intro: "DevClaw manages only the tagged block below on startup. You may edit any content outside that block. If you edit inside it, DevClaw may replace those changes the next time it refreshes defaults.",
+  },
+  "HEARTBEAT.md": {
+    sectionId: "heartbeat",
+    template: HEARTBEAT_MD_TEMPLATE,
+    intro: "DevClaw manages only the tagged block below on startup. Keep any custom heartbeat notes outside the managed block.",
+  },
+  "TOOLS.md": {
+    sectionId: "tools",
+    template: TOOLS_MD_TEMPLATE,
+    intro: "DevClaw manages only the tagged block below on startup. Add workspace-specific tool notes outside the managed block.",
+  },
+} as const;
+
 /**
  * Ensure all workspace data files are up to date.
  *
  * Called on every heartbeat startup.
  *
  * File categories:
- *   - System instructions (AGENTS.md, HEARTBEAT.md, TOOLS.md): always overwrite
+ *   - Root guidance (AGENTS.md, HEARTBEAT.md, TOOLS.md): update/create DevClaw tagged block only
  *   - User-owned config (workflow.yaml, prompts, IDENTITY.md): create-only
  *   - Runtime state (projects.json): create-only
  */
@@ -49,10 +68,10 @@ export async function ensureDefaultFiles(workspacePath: string): Promise<void> {
   await fs.mkdir(path.join(dataDir, "prompts"), { recursive: true });
   await fs.mkdir(path.join(dataDir, "log"), { recursive: true });
 
-  // --- System instruction files — always overwrite with latest ---
-  await backupAndWrite(path.join(workspacePath, "AGENTS.md"), AGENTS_MD_TEMPLATE);
-  await backupAndWrite(path.join(workspacePath, "HEARTBEAT.md"), HEARTBEAT_MD_TEMPLATE);
-  await backupAndWrite(path.join(workspacePath, "TOOLS.md"), TOOLS_MD_TEMPLATE);
+  // --- Workspace-root guidance files — manage tagged DevClaw blocks only ---
+  for (const [fileName, config] of Object.entries(MANAGED_BLOCKS)) {
+    await upsertManagedBlock(path.join(workspacePath, fileName), config.sectionId, config.template, config.intro);
+  }
 
   // --- User-owned files — create-only, never overwrite ---
 
@@ -192,6 +211,50 @@ export async function backupAndWrite(filePath: string, content: string): Promise
     await fs.mkdir(path.dirname(filePath), { recursive: true });
   }
   await fs.writeFile(filePath, content, "utf-8");
+}
+
+function buildManagedBlock(sectionId: string, content: string): string {
+  const start = `<!-- DEVCLAW:START ${sectionId} -->`;
+  const end = `<!-- DEVCLAW:END ${sectionId} -->`;
+  return `${start}\n${content.trimEnd()}\n${end}`;
+}
+
+function buildManagedFile(sectionId: string, content: string, intro: string): string {
+  return `${intro}\n\n${buildManagedBlock(sectionId, content)}\n`;
+}
+
+function upsertManagedContent(originalContent: string, sectionId: string, content: string, intro: string): string {
+  const managedBlock = buildManagedBlock(sectionId, content);
+  const blockPattern = new RegExp(
+    `<!-- DEVCLAW:START ${escapeRegExp(sectionId)} -->[\\s\\S]*?<!-- DEVCLAW:END ${escapeRegExp(sectionId)} -->`,
+    "m",
+  );
+
+  if (!originalContent.trim()) {
+    return buildManagedFile(sectionId, content, intro);
+  }
+
+  if (blockPattern.test(originalContent)) {
+    const updated = originalContent.replace(blockPattern, managedBlock);
+    return updated.endsWith("\n") ? updated : `${updated}\n`;
+  }
+
+  const separator = originalContent.endsWith("\n") ? "\n" : "\n\n";
+  return `${originalContent}${separator}${managedBlock}\n`;
+}
+
+async function upsertManagedBlock(filePath: string, sectionId: string, content: string, intro: string): Promise<void> {
+  await fs.mkdir(path.dirname(filePath), { recursive: true });
+
+  const existingContent = await fs.readFile(filePath, "utf-8").catch(() => "");
+  const nextContent = upsertManagedContent(existingContent, sectionId, content, intro);
+
+  if (existingContent === nextContent) return;
+  await fs.writeFile(filePath, nextContent, "utf-8");
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
 /**

--- a/lib/setup/workspace.ts
+++ b/lib/setup/workspace.ts
@@ -60,13 +60,7 @@ const MANAGED_BLOCKS = {
  *   - Runtime state (projects.json): create-only
  */
 export async function ensureDefaultFiles(workspacePath: string): Promise<void> {
-  const dataDir = path.join(workspacePath, DATA_DIR);
-  await fs.mkdir(dataDir, { recursive: true });
-
-  // Ensure directories exist
-  await fs.mkdir(path.join(dataDir, "projects"), { recursive: true });
-  await fs.mkdir(path.join(dataDir, "prompts"), { recursive: true });
-  await fs.mkdir(path.join(dataDir, "log"), { recursive: true });
+  await ensureWorkspaceDataFiles(workspacePath);
 
   // --- Workspace-root guidance files — manage tagged DevClaw blocks only ---
   for (const [fileName, config] of Object.entries(MANAGED_BLOCKS)) {
@@ -83,6 +77,20 @@ export async function ensureDefaultFiles(workspacePath: string): Promise<void> {
 
   // Remove BOOTSTRAP.md — one-time onboarding file, not needed after setup
   try { await fs.unlink(path.join(workspacePath, "BOOTSTRAP.md")); } catch { /* already gone */ }
+}
+
+/**
+ * Ensure DevClaw-owned data files exist without touching workspace-root guidance files.
+ * Safe for generic runtime code paths like project reads.
+ */
+export async function ensureWorkspaceDataFiles(workspacePath: string): Promise<void> {
+  const dataDir = path.join(workspacePath, DATA_DIR);
+  await fs.mkdir(dataDir, { recursive: true });
+
+  // Ensure directories exist
+  await fs.mkdir(path.join(dataDir, "projects"), { recursive: true });
+  await fs.mkdir(path.join(dataDir, "prompts"), { recursive: true });
+  await fs.mkdir(path.join(dataDir, "log"), { recursive: true });
 
   // devclaw/workflow.yaml — create-only (three-layer merge handles defaults for missing keys)
   const workflowPath = path.join(dataDir, "workflow.yaml");
@@ -219,28 +227,97 @@ function buildManagedBlock(sectionId: string, content: string): string {
   return `${start}\n${content.trimEnd()}\n${end}`;
 }
 
+function buildManagedNotice(sectionId: string, intro: string): string {
+  return [
+    `<!-- DEVCLAW:NOTICE:START ${sectionId} -->`,
+    intro,
+    `<!-- DEVCLAW:NOTICE:END ${sectionId} -->`,
+  ].join("\n");
+}
+
+function buildManagedSection(sectionId: string, content: string, intro: string): string {
+  return `${buildManagedNotice(sectionId, intro)}\n\n${buildManagedBlock(sectionId, content)}`;
+}
+
 function buildManagedFile(sectionId: string, content: string, intro: string): string {
-  return `${intro}\n\n${buildManagedBlock(sectionId, content)}\n`;
+  return `${buildManagedSection(sectionId, content, intro)}\n`;
+}
+
+function normalizeForManagedComparison(content: string): string {
+  return content
+    .replace(/^\uFEFF/, "")
+    .replace(/\r\n?/g, "\n")
+    .trim();
+}
+
+function isLegacyManagedFullFile(originalContent: string, template: string): boolean {
+  return normalizeForManagedComparison(originalContent) === normalizeForManagedComparison(template);
+}
+
+function stripManagedSection(originalContent: string, sectionId: string): string {
+  const managedSectionPattern = new RegExp(
+    `\n*<!-- DEVCLAW:NOTICE:START ${escapeRegExp(sectionId)} -->[\\s\\S]*?<!-- DEVCLAW:END ${escapeRegExp(sectionId)} -->\n*`,
+    "m",
+  );
+  return originalContent.replace(managedSectionPattern, "\n");
+}
+
+function isLegacyManagedFileWithTaggedDuplicate(originalContent: string, sectionId: string, template: string): boolean {
+  return isLegacyManagedFullFile(stripManagedSection(originalContent, sectionId), template);
 }
 
 function upsertManagedContent(originalContent: string, sectionId: string, content: string, intro: string): string {
   const managedBlock = buildManagedBlock(sectionId, content);
+  const managedNotice = buildManagedNotice(sectionId, intro);
+  const managedSection = buildManagedSection(sectionId, content, intro);
   const blockPattern = new RegExp(
     `<!-- DEVCLAW:START ${escapeRegExp(sectionId)} -->[\\s\\S]*?<!-- DEVCLAW:END ${escapeRegExp(sectionId)} -->`,
     "m",
   );
+  const noticePattern = new RegExp(
+    `<!-- DEVCLAW:NOTICE:START ${escapeRegExp(sectionId)} -->[\\s\\S]*?<!-- DEVCLAW:NOTICE:END ${escapeRegExp(sectionId)} -->\\n*`,
+    "m",
+  );
 
-  if (!originalContent.trim()) {
+  if (
+    !originalContent.trim()
+    || isLegacyManagedFullFile(originalContent, content)
+    || isLegacyManagedFileWithTaggedDuplicate(originalContent, sectionId, content)
+  ) {
     return buildManagedFile(sectionId, content, intro);
   }
 
-  if (blockPattern.test(originalContent)) {
-    const updated = originalContent.replace(blockPattern, managedBlock);
-    return updated.endsWith("\n") ? updated : `${updated}\n`;
+  const hasNotice = noticePattern.test(originalContent);
+  const hasBlock = blockPattern.test(originalContent);
+
+  // Step 1: seed or refresh the explanatory notice independently from block insertion.
+  let nextContent = hasNotice
+    ? originalContent.replace(noticePattern, `${managedNotice}\n\n`)
+    : originalContent;
+
+  if (!hasNotice && hasBlock) {
+    const blockMatch = nextContent.match(blockPattern);
+    if (!blockMatch || typeof blockMatch.index !== "number") {
+      return nextContent.endsWith("\n") ? nextContent : `${nextContent}\n`;
+    }
+
+    const beforeBlock = nextContent.slice(0, blockMatch.index).replace(/\n+$/, "");
+    const afterBlock = nextContent.slice(blockMatch.index);
+    nextContent = beforeBlock
+      ? `${beforeBlock}\n\n${managedNotice}\n\n${afterBlock}`
+      : `${managedNotice}\n\n${afterBlock}`;
   }
 
-  const separator = originalContent.endsWith("\n") ? "\n" : "\n\n";
-  return `${originalContent}${separator}${managedBlock}\n`;
+  // Step 2: replace or append the managed block, preserving user-owned content.
+  if (hasBlock) {
+    nextContent = nextContent.replace(blockPattern, managedBlock);
+    return nextContent.endsWith("\n") ? nextContent : `${nextContent}\n`;
+  }
+
+  const baseContent = nextContent.replace(/\n+$/, "");
+  const separator = baseContent.endsWith("\n") ? "\n" : "\n\n";
+  const insertedContent = hasNotice ? managedBlock : managedSection;
+  return `${baseContent}${separator}${insertedContent}\n`;
 }
 
 async function upsertManagedBlock(filePath: string, sectionId: string, content: string, intro: string): Promise<void> {

--- a/lib/setup/workspace.ts
+++ b/lib/setup/workspace.ts
@@ -21,9 +21,8 @@ import {
   SOUL_MD_TEMPLATE,
   TOOLS_MD_TEMPLATE,
   WORKFLOW_YAML_TEMPLATE,
-  DEFAULT_ROLE_INSTRUCTIONS,
+  DEFAULT_PROMPT_INSTRUCTIONS,
 } from "./templates.js";
-import { getAllRoleIds } from "../roles/index.js";
 import { migrateWorkspaceLayout, DATA_DIR } from "./migrate-layout.js";
 import { writeVersionFile, detectUpgrade } from "./version.js";
 import { log as auditLog } from "../audit.js";
@@ -100,11 +99,10 @@ export async function ensureWorkspaceDataFiles(workspacePath: string): Promise<v
   const projectsJsonPath = path.join(dataDir, "projects.json");
   await writeIfMissing(projectsJsonPath, JSON.stringify({ projects: {} }, null, 2) + "\n");
 
-  // devclaw/prompts/ — create-only per role (user customizations are preserved)
-  for (const role of getAllRoleIds()) {
-    const rolePath = path.join(dataDir, "prompts", `${role}.md`);
-    const content = DEFAULT_ROLE_INSTRUCTIONS[role];
-    if (content) await writeIfMissing(rolePath, content);
+  // devclaw/prompts/ — create-only per prompt target (user customizations are preserved)
+  for (const [promptName, content] of Object.entries(DEFAULT_PROMPT_INSTRUCTIONS)) {
+    const promptPath = path.join(dataDir, "prompts", `${promptName}.md`);
+    if (content) await writeIfMissing(promptPath, content);
   }
 
   // Version tracking
@@ -147,9 +145,8 @@ export async function writeAllDefaults(workspacePath: string, force = false): Pr
     [path.join(dataDir, "workflow.yaml"), WORKFLOW_YAML_TEMPLATE],
   ];
 
-  for (const role of getAllRoleIds()) {
-    const content = DEFAULT_ROLE_INSTRUCTIONS[role];
-    if (content) files.push([path.join(dataDir, "prompts", `${role}.md`), content]);
+  for (const [promptName, content] of Object.entries(DEFAULT_PROMPT_INSTRUCTIONS)) {
+    if (content) files.push([path.join(dataDir, "prompts", `${promptName}.md`), content]);
   }
 
   for (const [filePath, content] of files) {

--- a/lib/setup/workspace.ts
+++ b/lib/setup/workspace.ts
@@ -60,7 +60,13 @@ const MANAGED_BLOCKS = {
  *   - Runtime state (projects.json): create-only
  */
 export async function ensureDefaultFiles(workspacePath: string): Promise<void> {
-  await ensureWorkspaceDataFiles(workspacePath);
+  const dataDir = path.join(workspacePath, DATA_DIR);
+  await fs.mkdir(dataDir, { recursive: true });
+
+  // Ensure directories exist
+  await fs.mkdir(path.join(dataDir, "projects"), { recursive: true });
+  await fs.mkdir(path.join(dataDir, "prompts"), { recursive: true });
+  await fs.mkdir(path.join(dataDir, "log"), { recursive: true });
 
   // --- Workspace-root guidance files — manage tagged DevClaw blocks only ---
   for (const [fileName, config] of Object.entries(MANAGED_BLOCKS)) {
@@ -77,20 +83,6 @@ export async function ensureDefaultFiles(workspacePath: string): Promise<void> {
 
   // Remove BOOTSTRAP.md — one-time onboarding file, not needed after setup
   try { await fs.unlink(path.join(workspacePath, "BOOTSTRAP.md")); } catch { /* already gone */ }
-}
-
-/**
- * Ensure DevClaw-owned data files exist without touching workspace-root guidance files.
- * Safe for generic runtime code paths like project reads.
- */
-export async function ensureWorkspaceDataFiles(workspacePath: string): Promise<void> {
-  const dataDir = path.join(workspacePath, DATA_DIR);
-  await fs.mkdir(dataDir, { recursive: true });
-
-  // Ensure directories exist
-  await fs.mkdir(path.join(dataDir, "projects"), { recursive: true });
-  await fs.mkdir(path.join(dataDir, "prompts"), { recursive: true });
-  await fs.mkdir(path.join(dataDir, "log"), { recursive: true });
 
   // devclaw/workflow.yaml — create-only (three-layer merge handles defaults for missing keys)
   const workflowPath = path.join(dataDir, "workflow.yaml");
@@ -227,81 +219,28 @@ function buildManagedBlock(sectionId: string, content: string): string {
   return `${start}\n${content.trimEnd()}\n${end}`;
 }
 
-function buildManagedNotice(sectionId: string, intro: string): string {
-  return [
-    `<!-- DEVCLAW:NOTICE:START ${sectionId} -->`,
-    intro,
-    `<!-- DEVCLAW:NOTICE:END ${sectionId} -->`,
-  ].join("\n");
-}
-
-function buildManagedSection(sectionId: string, content: string, intro: string): string {
-  return `${buildManagedNotice(sectionId, intro)}\n\n${buildManagedBlock(sectionId, content)}`;
-}
-
 function buildManagedFile(sectionId: string, content: string, intro: string): string {
-  return `${buildManagedSection(sectionId, content, intro)}\n`;
-}
-
-function normalizeForManagedComparison(content: string): string {
-  return content
-    .replace(/^\uFEFF/, "")
-    .replace(/\r\n?/g, "\n")
-    .trim();
-}
-
-function isLegacyManagedFullFile(originalContent: string, template: string): boolean {
-  return normalizeForManagedComparison(originalContent) === normalizeForManagedComparison(template);
+  return `${intro}\n\n${buildManagedBlock(sectionId, content)}\n`;
 }
 
 function upsertManagedContent(originalContent: string, sectionId: string, content: string, intro: string): string {
   const managedBlock = buildManagedBlock(sectionId, content);
-  const managedNotice = buildManagedNotice(sectionId, intro);
-  const managedSection = buildManagedSection(sectionId, content, intro);
   const blockPattern = new RegExp(
     `<!-- DEVCLAW:START ${escapeRegExp(sectionId)} -->[\\s\\S]*?<!-- DEVCLAW:END ${escapeRegExp(sectionId)} -->`,
     "m",
   );
-  const noticePattern = new RegExp(
-    `<!-- DEVCLAW:NOTICE:START ${escapeRegExp(sectionId)} -->[\\s\\S]*?<!-- DEVCLAW:NOTICE:END ${escapeRegExp(sectionId)} -->\\n*`,
-    "m",
-  );
 
-  if (!originalContent.trim() || isLegacyManagedFullFile(originalContent, content)) {
+  if (!originalContent.trim()) {
     return buildManagedFile(sectionId, content, intro);
   }
 
-  const hasNotice = noticePattern.test(originalContent);
-  const hasBlock = blockPattern.test(originalContent);
-
-  // Step 1: seed or refresh the explanatory notice independently from block insertion.
-  let nextContent = hasNotice
-    ? originalContent.replace(noticePattern, `${managedNotice}\n\n`)
-    : originalContent;
-
-  if (!hasNotice && hasBlock) {
-    const blockMatch = nextContent.match(blockPattern);
-    if (!blockMatch || typeof blockMatch.index !== "number") {
-      return nextContent.endsWith("\n") ? nextContent : `${nextContent}\n`;
-    }
-
-    const beforeBlock = nextContent.slice(0, blockMatch.index).replace(/\n+$/, "");
-    const afterBlock = nextContent.slice(blockMatch.index);
-    nextContent = beforeBlock
-      ? `${beforeBlock}\n\n${managedNotice}\n\n${afterBlock}`
-      : `${managedNotice}\n\n${afterBlock}`;
+  if (blockPattern.test(originalContent)) {
+    const updated = originalContent.replace(blockPattern, managedBlock);
+    return updated.endsWith("\n") ? updated : `${updated}\n`;
   }
 
-  // Step 2: replace or append the managed block, preserving user-owned content.
-  if (hasBlock) {
-    nextContent = nextContent.replace(blockPattern, managedBlock);
-    return nextContent.endsWith("\n") ? nextContent : `${nextContent}\n`;
-  }
-
-  const baseContent = nextContent.replace(/\n+$/, "");
-  const separator = baseContent.endsWith("\n") ? "\n" : "\n\n";
-  const insertedContent = hasNotice ? managedBlock : managedSection;
-  return `${baseContent}${separator}${insertedContent}\n`;
+  const separator = originalContent.endsWith("\n") ? "\n" : "\n\n";
+  return `${originalContent}${separator}${managedBlock}\n`;
 }
 
 async function upsertManagedBlock(filePath: string, sectionId: string, content: string, intro: string): Promise<void> {

--- a/lib/testing/harness.ts
+++ b/lib/testing/harness.ts
@@ -23,6 +23,8 @@ import type { PluginContext } from "../context.js";
 export type BootstrapResult = {
   /** Whether AGENTS.md was stripped from bootstrap files. */
   agentsMdStripped: boolean;
+  /** Final AGENTS.md content after bootstrap hook mutation. */
+  agentsMdContent: string;
 };
 
 // ---------------------------------------------------------------------------
@@ -170,7 +172,7 @@ export type TestHarness = {
    * Simulate the agent:bootstrap hook firing for a session key.
    * Tests that AGENTS.md is stripped from bootstrap files for DevClaw workers.
    */
-  simulateBootstrap(sessionKey: string): Promise<BootstrapResult>;
+  simulateBootstrap(sessionKey: string, context?: Record<string, unknown>): Promise<BootstrapResult>;
   /** Clean up temp directory. */
   cleanup(): Promise<void>;
 };
@@ -284,7 +286,7 @@ export async function createTestHarness(opts?: HarnessOptions): Promise<TestHarn
       await fs.mkdir(dir, { recursive: true });
       await fs.writeFile(path.join(dir, `${role}.md`), content, "utf-8");
     },
-    async simulateBootstrap(sessionKey: string) {
+    async simulateBootstrap(sessionKey: string, extraContext?: Record<string, unknown>) {
       // Capture the agent:bootstrap hook callback
       let internalHookCb: ((event: any) => Promise<void>) | null = null;
       const mockApi = {
@@ -320,12 +322,13 @@ export async function createTestHarness(opts?: HarnessOptions): Promise<TestHarn
       if (hookCb) {
         await hookCb({
           sessionKey,
-          context: { bootstrapFiles },
+          context: { workspaceDir, conversationId: channelId, channelId, channel: "telegram", bootstrapFiles, ...extraContext },
         });
       }
 
       return {
         agentsMdStripped: bootstrapFiles[0].missing === true && bootstrapFiles[0].content === "",
+        agentsMdContent: bootstrapFiles[0].content ?? "",
       };
     },
     async cleanup() {

--- a/lib/tools/admin/autoconfigure-models.ts
+++ b/lib/tools/admin/autoconfigure-models.ts
@@ -3,7 +3,7 @@
  *
  * Queries available authenticated models and intelligently assigns them to DevClaw roles.
  */
-import { jsonResult } from "openclaw/plugin-sdk";
+import { jsonResult } from "../../json-result.js";
 import type { ToolContext } from "../../types.js";
 import type { PluginContext, RunCommand } from "../../context.js";
 import {

--- a/lib/tools/admin/autoconfigure-models.ts
+++ b/lib/tools/admin/autoconfigure-models.ts
@@ -3,7 +3,7 @@
  *
  * Queries available authenticated models and intelligently assigns them to DevClaw roles.
  */
-import { jsonResult } from "openclaw/plugin-sdk";
+import { jsonResult } from "../helpers.js";
 import type { ToolContext } from "../../types.js";
 import type { PluginContext, RunCommand } from "../../context.js";
 import {

--- a/lib/tools/admin/channel-link.ts
+++ b/lib/tools/admin/channel-link.ts
@@ -45,6 +45,11 @@ export function createChannelLinkTool(_ctx: PluginContext) {
           description:
             "Display name for this channel (e.g. 'general', 'dev-chat'). Auto-generated if omitted.",
         },
+        messageThreadId: {
+          type: "number",
+          description:
+            "Optional Telegram forum topic ID (message_thread_id). When provided, links this specific topic instead of the whole chat.",
+        },
       },
     },
 
@@ -53,6 +58,7 @@ export function createChannelLinkTool(_ctx: PluginContext) {
       const projectRef = params.project as string;
       const channelType = (params.channel as Channel["channel"]) ?? "telegram";
       const channelName = params.name as string | undefined;
+      const messageThreadId = params.messageThreadId as number | undefined;
       const workspaceDir = requireWorkspaceDir(toolCtx);
 
       if (!channelId) throw new Error("channelId is required.");
@@ -78,9 +84,11 @@ export function createChannelLinkTool(_ctx: PluginContext) {
         );
       }
 
-      // Already linked to this project?
-      const alreadyLinked = target.channels.some(
-        (ch) => ch.channelId === channelId,
+      // Already linked to this project for the same scope?
+      const alreadyLinked = target.channels.some((ch) =>
+        ch.channelId === channelId &&
+        ch.channel === channelType &&
+        (messageThreadId == null || ch.messageThreadId === messageThreadId)
       );
       if (alreadyLinked) {
         return jsonResult({
@@ -93,11 +101,13 @@ export function createChannelLinkTool(_ctx: PluginContext) {
         });
       }
 
-      // Auto-detach from any other project that has this channelId
+      // Auto-detach from any other project that has this exact scoped binding
       let detachedFrom: string | null = null;
       for (const project of Object.values(data.projects)) {
-        const idx = project.channels.findIndex(
-          (ch) => ch.channelId === channelId,
+        const idx = project.channels.findIndex((ch) =>
+          ch.channelId === channelId &&
+          ch.channel === channelType &&
+          (messageThreadId == null || ch.messageThreadId === messageThreadId)
         );
         if (idx !== -1) {
           detachedFrom = project.name;
@@ -112,6 +122,9 @@ export function createChannelLinkTool(_ctx: PluginContext) {
         channel: channelType,
         name: channelName ?? `channel-${target.channels.length + 1}`,
         events: ["*"],
+        ...(messageThreadId != null && channelType === "telegram"
+          ? { messageThreadId }
+          : {}),
       };
       target.channels.push(newChannel);
 
@@ -123,6 +136,7 @@ export function createChannelLinkTool(_ctx: PluginContext) {
         channelId,
         channelType,
         channelName: newChannel.name,
+        messageThreadId: messageThreadId ?? null,
         detachedFrom,
       });
 
@@ -136,8 +150,12 @@ export function createChannelLinkTool(_ctx: PluginContext) {
         projectSlug: target.slug,
         channelId,
         channelName: newChannel.name,
+        messageThreadId: messageThreadId ?? null,
         detachedFrom,
-        announcement: `Channel linked to "${target.name}"${detachNote}.`,
+        announcement:
+          messageThreadId != null && channelType === "telegram"
+            ? `Channel topic ${messageThreadId} linked to "${target.name}"${detachNote}.`
+            : `Channel linked to "${target.name}"${detachNote}.`,
       });
     },
   });

--- a/lib/tools/admin/channel-link.ts
+++ b/lib/tools/admin/channel-link.ts
@@ -6,7 +6,7 @@
  * (auto-detach). This is the primary way to switch which project a chat
  * controls.
  */
-import { jsonResult } from "openclaw/plugin-sdk";
+import { jsonResult } from "../../json-result.js";
 import type { PluginContext } from "../../context.js";
 import type { ToolContext } from "../../types.js";
 import { readProjects, writeProjects, type Channel } from "../../projects/index.js";

--- a/lib/tools/admin/channel-link.ts
+++ b/lib/tools/admin/channel-link.ts
@@ -6,12 +6,11 @@
  * (auto-detach). This is the primary way to switch which project a chat
  * controls.
  */
-import { jsonResult } from "openclaw/plugin-sdk";
 import type { PluginContext } from "../../context.js";
 import type { ToolContext } from "../../types.js";
 import { readProjects, writeProjects, type Channel } from "../../projects/index.js";
 import { log as auditLog } from "../../audit.js";
-import { requireWorkspaceDir } from "../helpers.js";
+import { jsonResult, requireWorkspaceDir } from "../helpers.js";
 
 export function createChannelLinkTool(_ctx: PluginContext) {
   return (toolCtx: ToolContext) => ({

--- a/lib/tools/admin/channel-list.ts
+++ b/lib/tools/admin/channel-list.ts
@@ -4,11 +4,10 @@
  * Shows registered channels with their type, ID, name, and event subscriptions.
  * Can list channels for a specific project or all projects.
  */
-import { jsonResult } from "openclaw/plugin-sdk";
 import type { PluginContext } from "../../context.js";
 import type { ToolContext } from "../../types.js";
 import { readProjects } from "../../projects/index.js";
-import { requireWorkspaceDir } from "../helpers.js";
+import { jsonResult, requireWorkspaceDir } from "../helpers.js";
 
 export function createChannelListTool(_ctx: PluginContext) {
   return (toolCtx: ToolContext) => ({

--- a/lib/tools/admin/channel-list.ts
+++ b/lib/tools/admin/channel-list.ts
@@ -4,7 +4,7 @@
  * Shows registered channels with their type, ID, name, and event subscriptions.
  * Can list channels for a specific project or all projects.
  */
-import { jsonResult } from "openclaw/plugin-sdk";
+import { jsonResult } from "../../json-result.js";
 import type { PluginContext } from "../../context.js";
 import type { ToolContext } from "../../types.js";
 import { readProjects } from "../../projects/index.js";

--- a/lib/tools/admin/channel-list.ts
+++ b/lib/tools/admin/channel-list.ts
@@ -57,6 +57,7 @@ export function createChannelListTool(_ctx: PluginContext) {
           name: ch.name,
           events: ch.events,
           accountId: ch.accountId,
+          messageThreadId: ch.messageThreadId ?? null,
         }));
 
         const announcement =
@@ -65,10 +66,16 @@ export function createChannelListTool(_ctx: PluginContext) {
             ? "_(none)_"
             : channels
                 .map(
-                  (ch) =>
-                    `• **${ch.name}** (${ch.type})\n  ID: \`${ch.channelId}\`\n  Events: ${ch.events.join(", ")}${
-                      ch.accountId ? `\n  Account: ${ch.accountId}` : ""
-                    }`,
+                  (ch) => {
+                    const topicSuffix =
+                      ch.type === "telegram" && ch.messageThreadId != null
+                        ? `\n  Topic: ${ch.messageThreadId}`
+                        : "";
+                    const accountSuffix = ch.accountId ? `\n  Account: ${ch.accountId}` : "";
+                    return `• **${ch.name}** (${ch.type})\n  ID: \`${ch.channelId}\`${topicSuffix}\n  Events: ${ch.events.join(
+                      ", ",
+                    )}${accountSuffix}`;
+                  },
                 )
                 .join("\n\n"));
 
@@ -100,6 +107,7 @@ export function createChannelListTool(_ctx: PluginContext) {
             name: ch.name,
             events: ch.events,
             accountId: ch.accountId,
+            messageThreadId: ch.messageThreadId ?? null,
           })),
         }));
 
@@ -111,10 +119,13 @@ export function createChannelListTool(_ctx: PluginContext) {
                 p.channels.length === 0
                   ? "  _(no channels)_"
                   : p.channels
-                      .map(
-                        (ch) =>
-                          `  • **${ch.name}** (${ch.type}) — \`${ch.channelId}\``,
-                      )
+                      .map((ch) => {
+                        const topicSuffix =
+                          ch.type === "telegram" && ch.messageThreadId != null
+                            ? ` topic:${ch.messageThreadId}`
+                            : "";
+                        return `  • **${ch.name}** (${ch.type}) — \`${ch.channelId}\`${topicSuffix}`;
+                      })
                       .join("\n");
               return `**${p.project}** (${p.projectSlug}):\n${channelList}`;
             })

--- a/lib/tools/admin/channel-unlink.ts
+++ b/lib/tools/admin/channel-unlink.ts
@@ -5,12 +5,11 @@
  * exists and prevents removing the last channel from a project (projects must
  * have at least one notification endpoint).
  */
-import { jsonResult } from "openclaw/plugin-sdk";
 import type { PluginContext } from "../../context.js";
 import type { ToolContext } from "../../types.js";
 import { readProjects, writeProjects } from "../../projects/index.js";
 import { log as auditLog } from "../../audit.js";
-import { requireWorkspaceDir } from "../helpers.js";
+import { jsonResult, requireWorkspaceDir } from "../helpers.js";
 
 export function createChannelUnlinkTool(_ctx: PluginContext) {
   return (toolCtx: ToolContext) => ({

--- a/lib/tools/admin/channel-unlink.ts
+++ b/lib/tools/admin/channel-unlink.ts
@@ -5,7 +5,7 @@
  * exists and prevents removing the last channel from a project (projects must
  * have at least one notification endpoint).
  */
-import { jsonResult } from "openclaw/plugin-sdk";
+import { jsonResult } from "../../json-result.js";
 import type { PluginContext } from "../../context.js";
 import type { ToolContext } from "../../types.js";
 import { readProjects, writeProjects } from "../../projects/index.js";

--- a/lib/tools/admin/channel-unlink.ts
+++ b/lib/tools/admin/channel-unlink.ts
@@ -35,6 +35,10 @@ export function createChannelUnlinkTool(_ctx: PluginContext) {
           type: "boolean",
           description: "Set to true to confirm the removal. Defaults to false (dry-run).",
         },
+        messageThreadId: {
+          type: "number",
+          description: "Optional Telegram forum topic ID. When provided, only unlinks the matching topic binding for this channel instead of all bindings for the chat.",
+        },
       },
     },
 
@@ -42,6 +46,7 @@ export function createChannelUnlinkTool(_ctx: PluginContext) {
       const channelId = params.channelId as string;
       const projectRef = params.project as string;
       const confirm = params.confirm as boolean | undefined;
+      const messageThreadId = params.messageThreadId as number | undefined;
       const workspaceDir = requireWorkspaceDir(toolCtx);
 
       if (!channelId) throw new Error("channelId is required.");
@@ -66,8 +71,11 @@ export function createChannelUnlinkTool(_ctx: PluginContext) {
         );
       }
 
-      // Find the channel
-      const idx = target.channels.findIndex((ch) => ch.channelId === channelId);
+      // Find the channel (optionally scoped by messageThreadId)
+      const idx = target.channels.findIndex((ch) =>
+        ch.channelId === channelId &&
+        (messageThreadId == null || ch.messageThreadId === messageThreadId)
+      );
       if (idx === -1) {
         throw new Error(
           `Channel ${channelId} not found in project "${target.name}".`,
@@ -93,9 +101,12 @@ export function createChannelUnlinkTool(_ctx: PluginContext) {
           channelId,
           channelName: channel.name,
           channelType: channel.channel,
+          messageThreadId: channel.messageThreadId ?? null,
           remainingChannels: target.channels.length - 1,
           announcement:
-            `DRY-RUN: Would remove channel "${channel.name}" (${channelId}) from project "${target.name}". ` +
+            `DRY-RUN: Would remove channel "${channel.name}" (${channelId}${
+              channel.messageThreadId != null ? ` topic ${channel.messageThreadId}` : ""
+            }) from project "${target.name}". ` +
             `${target.channels.length - 1} channel(s) would remain. Set confirm=true to proceed.`,
         });
       }
@@ -111,6 +122,7 @@ export function createChannelUnlinkTool(_ctx: PluginContext) {
         channelId,
         channelName: channel.name,
         channelType: channel.channel,
+        messageThreadId: channel.messageThreadId ?? null,
       });
 
       return jsonResult({
@@ -122,7 +134,9 @@ export function createChannelUnlinkTool(_ctx: PluginContext) {
         channelType: channel.channel,
         remainingChannels: target.channels.length,
         announcement:
-          `Channel "${channel.name}" (${channelId}) unlinked from project "${target.name}". ` +
+          `Channel "${channel.name}" (${channelId}${
+            channel.messageThreadId != null ? ` topic ${channel.messageThreadId}` : ""
+          }) unlinked from project "${target.name}". ` +
           `${target.channels.length} channel(s) remaining.`,
       });
     },

--- a/lib/tools/admin/config-diff.ts
+++ b/lib/tools/admin/config-diff.ts
@@ -6,7 +6,7 @@
  */
 import fs from "node:fs/promises";
 import path from "node:path";
-import { jsonResult } from "openclaw/plugin-sdk";
+import { jsonResult } from "../../json-result.js";
 import type { ToolContext } from "../../types.js";
 import type { PluginContext } from "../../context.js";
 import { requireWorkspaceDir } from "../helpers.js";

--- a/lib/tools/admin/config-diff.ts
+++ b/lib/tools/admin/config-diff.ts
@@ -6,10 +6,9 @@
  */
 import fs from "node:fs/promises";
 import path from "node:path";
-import { jsonResult } from "openclaw/plugin-sdk";
 import type { ToolContext } from "../../types.js";
 import type { PluginContext } from "../../context.js";
-import { requireWorkspaceDir } from "../helpers.js";
+import { jsonResult, requireWorkspaceDir } from "../helpers.js";
 import { WORKFLOW_YAML_TEMPLATE } from "../../setup/templates.js";
 import { DATA_DIR } from "../../setup/migrate-layout.js";
 

--- a/lib/tools/admin/config-reset.ts
+++ b/lib/tools/admin/config-reset.ts
@@ -6,7 +6,7 @@
  */
 import fs from "node:fs/promises";
 import path from "node:path";
-import { jsonResult } from "openclaw/plugin-sdk";
+import { jsonResult } from "../../json-result.js";
 import type { ToolContext } from "../../types.js";
 import type { PluginContext } from "../../context.js";
 import { requireWorkspaceDir } from "../helpers.js";

--- a/lib/tools/admin/config-reset.ts
+++ b/lib/tools/admin/config-reset.ts
@@ -6,10 +6,9 @@
  */
 import fs from "node:fs/promises";
 import path from "node:path";
-import { jsonResult } from "openclaw/plugin-sdk";
 import type { ToolContext } from "../../types.js";
 import type { PluginContext } from "../../context.js";
-import { requireWorkspaceDir } from "../helpers.js";
+import { jsonResult, requireWorkspaceDir } from "../helpers.js";
 import { backupAndWrite } from "../../setup/workspace.js";
 import { WORKFLOW_YAML_TEMPLATE, DEFAULT_ROLE_INSTRUCTIONS } from "../../setup/templates.js";
 import { getAllRoleIds } from "../../roles/index.js";

--- a/lib/tools/admin/config-reset.ts
+++ b/lib/tools/admin/config-reset.ts
@@ -11,8 +11,7 @@ import type { ToolContext } from "../../types.js";
 import type { PluginContext } from "../../context.js";
 import { requireWorkspaceDir } from "../helpers.js";
 import { backupAndWrite } from "../../setup/workspace.js";
-import { WORKFLOW_YAML_TEMPLATE, DEFAULT_ROLE_INSTRUCTIONS } from "../../setup/templates.js";
-import { getAllRoleIds } from "../../roles/index.js";
+import { WORKFLOW_YAML_TEMPLATE, DEFAULT_PROMPT_INSTRUCTIONS } from "../../setup/templates.js";
 import { DATA_DIR } from "../../setup/migrate-layout.js";
 import { log as auditLog } from "../../audit.js";
 
@@ -34,7 +33,7 @@ export function createConfigResetTool(_ctx: PluginContext) {
           type: "string",
           enum: ["workflow", "prompts", "all"],
           description:
-            "What to reset. 'workflow' = workflow.yaml, 'prompts' = devclaw/prompts/*.md, 'all' = both. Default: 'all'.",
+            "What to reset. 'workflow' = workflow.yaml, 'prompts' = devclaw/prompts/*.md (including orchestrator.md), 'all' = both. Default: 'all'.",
         },
       },
       required: ["channelId"],
@@ -54,12 +53,11 @@ export function createConfigResetTool(_ctx: PluginContext) {
       if (target === "prompts" || target === "all") {
         const promptsDir = path.join(dataDir, "prompts");
         await fs.mkdir(promptsDir, { recursive: true });
-        for (const role of getAllRoleIds()) {
-          const content = DEFAULT_ROLE_INSTRUCTIONS[role];
+        for (const [promptName, content] of Object.entries(DEFAULT_PROMPT_INSTRUCTIONS)) {
           if (!content) continue;
-          const rolePath = path.join(promptsDir, `${role}.md`);
-          await backupAndWrite(rolePath, content);
-          resetFiles.push(`devclaw/prompts/${role}.md`);
+          const promptPath = path.join(promptsDir, `${promptName}.md`);
+          await backupAndWrite(promptPath, content);
+          resetFiles.push(`devclaw/prompts/${promptName}.md`);
         }
       }
 

--- a/lib/tools/admin/config.ts
+++ b/lib/tools/admin/config.ts
@@ -8,7 +8,7 @@
  */
 import fs from "node:fs/promises";
 import path from "node:path";
-import { jsonResult } from "openclaw/plugin-sdk";
+import { jsonResult } from "../../json-result.js";
 import type { ToolContext } from "../../types.js";
 import type { PluginContext } from "../../context.js";
 import { writeAllDefaults, backupAndWrite, fileExists } from "../../setup/workspace.js";

--- a/lib/tools/admin/config.ts
+++ b/lib/tools/admin/config.ts
@@ -13,7 +13,7 @@ import { jsonResult } from "../../json-result.js";
 import type { ToolContext } from "../../types.js";
 import type { PluginContext } from "../../context.js";
 import { writeAllDefaults, backupAndWrite, fileExists } from "../../setup/workspace.js";
-import { WORKFLOW_YAML_TEMPLATE, DEFAULT_ROLE_INSTRUCTIONS } from "../../setup/templates.js";
+import { WORKFLOW_YAML_TEMPLATE, DEFAULT_PROMPT_INSTRUCTIONS } from "../../setup/templates.js";
 import { DATA_DIR } from "../../setup/migrate-layout.js";
 import { getCurrentVersion, readVersionFile } from "../../setup/version.js";
 import { getBuildProvenance, formatBuildProvenanceSummary } from "../../build-provenance.js";
@@ -92,11 +92,11 @@ async function handleReset(workspacePath: string, scope: string) {
     written.push("devclaw/workflow.yaml");
   } else if (scope === "prompts") {
     const promptsDir = path.join(dataDir, "prompts");
-    for (const [role, content] of Object.entries(DEFAULT_ROLE_INSTRUCTIONS)) {
+    for (const [promptName, content] of Object.entries(DEFAULT_PROMPT_INSTRUCTIONS)) {
       if (!content) continue;
-      const rolePath = path.join(promptsDir, `${role}.md`);
+      const rolePath = path.join(promptsDir, `${promptName}.md`);
       await backupAndWrite(rolePath, content);
-      written.push(`devclaw/prompts/${role}.md`);
+      written.push(`devclaw/prompts/${promptName}.md`);
     }
   } else {
     throw new Error(`Unknown scope: ${scope}. Use: prompts, workflow, or all.`);

--- a/lib/tools/admin/config.ts
+++ b/lib/tools/admin/config.ts
@@ -8,7 +8,7 @@
  */
 import fs from "node:fs/promises";
 import path from "node:path";
-import { jsonResult } from "openclaw/plugin-sdk";
+import { jsonResult } from "../helpers.js";
 import type { ToolContext } from "../../types.js";
 import type { PluginContext } from "../../context.js";
 import { writeAllDefaults, backupAndWrite, fileExists } from "../../setup/workspace.js";

--- a/lib/tools/admin/config.ts
+++ b/lib/tools/admin/config.ts
@@ -5,6 +5,7 @@
  * - reset: Reset config files to package defaults (with .bak backups)
  * - diff: Show differences between current workflow.yaml and package default
  * - version: Show current and workspace DevClaw versions
+ * - provenance: Show embedded live runtime build provenance
  */
 import fs from "node:fs/promises";
 import path from "node:path";
@@ -15,6 +16,7 @@ import { writeAllDefaults, backupAndWrite, fileExists } from "../../setup/worksp
 import { WORKFLOW_YAML_TEMPLATE, DEFAULT_ROLE_INSTRUCTIONS } from "../../setup/templates.js";
 import { DATA_DIR } from "../../setup/migrate-layout.js";
 import { getCurrentVersion, readVersionFile } from "../../setup/version.js";
+import { getBuildProvenance, formatBuildProvenanceSummary } from "../../build-provenance.js";
 
 export function createConfigTool(ctx: PluginContext) {
   return (toolCtx: ToolContext) => ({
@@ -27,19 +29,21 @@ Actions:
   Scope: --prompts (prompts only), --workflow (workflow.yaml only), --all (everything).
 - **diff**: Show differences between current workflow.yaml and the package default template.
 - **version**: Show DevClaw package version and workspace tracked version.
+- **provenance**: Show embedded live runtime build provenance.
 
 Examples:
   config({ action: "reset", scope: "workflow" })
   config({ action: "reset", scope: "all" })
   config({ action: "diff" })
-  config({ action: "version" })`,
+  config({ action: "version" })
+  config({ action: "provenance" })`,
     parameters: {
       type: "object",
       required: ["action"],
       properties: {
         action: {
           type: "string",
-          enum: ["reset", "diff", "version"],
+          enum: ["reset", "diff", "version", "provenance"],
           description: "Config action to perform.",
         },
         scope: {
@@ -62,6 +66,8 @@ Examples:
           return await handleDiff(workspacePath);
         case "version":
           return await handleVersion(workspacePath);
+        case "provenance":
+          return handleProvenance();
         default:
           throw new Error(`Unknown config action: ${action}`);
       }
@@ -174,5 +180,24 @@ async function handleVersion(workspacePath: string) {
       : workspaceVersion
         ? `DevClaw v${packageVersion} (workspace tracked: v${workspaceVersion}) — version mismatch.`
         : `DevClaw v${packageVersion} — workspace version not yet tracked.`,
+  });
+}
+
+function handleProvenance() {
+  const provenance = getBuildProvenance();
+
+  return jsonResult({
+    success: true,
+    action: "provenance",
+    packageVersion: provenance.packageVersion,
+    provenance,
+    summary:
+      `Live runtime provenance: ${formatBuildProvenanceSummary(provenance)}\n` +
+      `commit=${provenance.commitSha ?? "unknown"}\n` +
+      `short=${provenance.shortCommitSha ?? "unknown"}\n` +
+      `branch=${provenance.branch ?? "unknown"}\n` +
+      `dirty=${provenance.dirty === null ? "unknown" : provenance.dirty ? "true" : "false"}\n` +
+      `built=${provenance.buildTimestamp ?? "unknown"}\n` +
+      `source=${provenance.source}`,
   });
 }

--- a/lib/tools/admin/health.ts
+++ b/lib/tools/admin/health.ts
@@ -12,7 +12,7 @@
  *
  * Read-only by default (surfaces issues). Pass fix=true to apply fixes.
  */
-import { jsonResult } from "openclaw/plugin-sdk/channel-runtime";
+import { jsonResult } from "../../json-result.js";
 import type { PluginContext } from "../../context.js";
 import type { ToolContext } from "../../types.js";
 import { readProjects, getProject } from "../../projects/index.js";
@@ -24,11 +24,19 @@ export function createHealthTool(ctx: PluginContext) {
   return (toolCtx: ToolContext) => ({
     name: "health",
     label: "Health",
-    description: `Scan worker health across projects. Detects zombies, stale workers, orphaned state. Pass fix=true to auto-fix. Context-aware: auto-filters in group chats.`,
+    description: `Scan worker health across projects. Detects zombies, stale workers, orphaned state. Pass fix=true to auto-fix. When channelId is set, pass messageThreadId in Telegram forum topics so the correct project is selected.`,
     parameters: {
       type: "object",
       properties: {
-        channelId: { type: "string", description: "Channel ID identifying the project. Omit for all." },
+        channelId: {
+          type: "string",
+          description: "Project slug or channel ID. Omit to scan all registered projects.",
+        },
+        messageThreadId: {
+          type: "number",
+          description:
+            "Optional Telegram forum topic ID (message_thread_id). When provided with a channel ID, resolves the topic-bound project within the chat.",
+        },
         fix: { type: "boolean", description: "Apply fixes for detected issues. Default: false (read-only)." },
       },
     },
@@ -38,19 +46,24 @@ export function createHealthTool(ctx: PluginContext) {
       const fix = (params.fix as boolean) ?? false;
 
       const slugOrChannelId = params.channelId as string | undefined;
+      const messageThreadId = params.messageThreadId as number | undefined;
+      const channelType = (toolCtx.messageChannel as string | undefined) ?? "telegram";
+      const accountId = toolCtx.agentAccountId as string | undefined;
 
       const data = await readProjects(workspaceDir);
 
-      // Resolve slug from slugOrChannelId
       let slugs = Object.keys(data.projects);
       if (slugOrChannelId) {
-        // Use legacy resolution by channelId or slug (health is not topic-scoped;
-        // it scans the full project), so we intentionally pass the bare string.
-        const project = getProject(data, slugOrChannelId);
-        const slug = project ?
-          (data.projects[slugOrChannelId] ? slugOrChannelId :
-            Object.keys(data.projects).find(s => data.projects[s].channels.some(ch => ch.channelId === slugOrChannelId)))
-          : undefined;
+        const project =
+          data.projects[slugOrChannelId] !== undefined
+            ? data.projects[slugOrChannelId]
+            : getProject(data, {
+                channelId: slugOrChannelId,
+                channel: channelType,
+                accountId,
+                messageThreadId,
+              });
+        const slug = project?.slug;
         slugs = slug ? [slug] : [];
       }
 

--- a/lib/tools/admin/health.ts
+++ b/lib/tools/admin/health.ts
@@ -12,13 +12,12 @@
  *
  * Read-only by default (surfaces issues). Pass fix=true to apply fixes.
  */
-import { jsonResult } from "openclaw/plugin-sdk";
 import type { PluginContext } from "../../context.js";
 import type { ToolContext } from "../../types.js";
 import { readProjects, getProject } from "../../projects/index.js";
 import { log as auditLog } from "../../audit.js";
 import { checkWorkerHealth, scanOrphanedLabels, fetchGatewaySessions, type HealthFix } from "../../services/heartbeat/health.js";
-import { requireWorkspaceDir, resolveProvider } from "../helpers.js";
+import { jsonResult, requireWorkspaceDir, resolveProvider } from "../helpers.js";
 
 export function createHealthTool(ctx: PluginContext) {
   return (toolCtx: ToolContext) => ({

--- a/lib/tools/admin/health.ts
+++ b/lib/tools/admin/health.ts
@@ -12,7 +12,7 @@
  *
  * Read-only by default (surfaces issues). Pass fix=true to apply fixes.
  */
-import { jsonResult } from "openclaw/plugin-sdk";
+import { jsonResult } from "openclaw/plugin-sdk/channel-runtime";
 import type { PluginContext } from "../../context.js";
 import type { ToolContext } from "../../types.js";
 import { readProjects, getProject } from "../../projects/index.js";
@@ -44,6 +44,8 @@ export function createHealthTool(ctx: PluginContext) {
       // Resolve slug from slugOrChannelId
       let slugs = Object.keys(data.projects);
       if (slugOrChannelId) {
+        // Use legacy resolution by channelId or slug (health is not topic-scoped;
+        // it scans the full project), so we intentionally pass the bare string.
         const project = getProject(data, slugOrChannelId);
         const slug = project ?
           (data.projects[slugOrChannelId] ? slugOrChannelId :

--- a/lib/tools/admin/onboard.ts
+++ b/lib/tools/admin/onboard.ts
@@ -3,7 +3,7 @@
  *
  * Returns step-by-step guidance. Call this before setup.
  */
-import { jsonResult } from "openclaw/plugin-sdk";
+import { jsonResult } from "../../json-result.js";
 import type { ToolContext } from "../../types.js";
 import type { PluginContext } from "../../context.js";
 import { isPluginConfigured, hasWorkspaceFiles, buildOnboardToolContext, buildReconfigContext } from "../../setup/onboarding.js";

--- a/lib/tools/admin/onboard.ts
+++ b/lib/tools/admin/onboard.ts
@@ -3,7 +3,7 @@
  *
  * Returns step-by-step guidance. Call this before setup.
  */
-import { jsonResult } from "openclaw/plugin-sdk";
+import { jsonResult } from "../helpers.js";
 import type { ToolContext } from "../../types.js";
 import type { PluginContext } from "../../context.js";
 import { isPluginConfigured, hasWorkspaceFiles, buildOnboardToolContext, buildReconfigContext } from "../../setup/onboarding.js";

--- a/lib/tools/admin/project-register.ts
+++ b/lib/tools/admin/project-register.ts
@@ -6,7 +6,7 @@
  *
  * Replaces the manual steps of running glab/gh label create + editing projects.json.
  */
-import { jsonResult } from "openclaw/plugin-sdk";
+import { jsonResult } from "../helpers.js";
 import type { ToolContext } from "../../types.js";
 import type { PluginContext } from "../../context.js";
 import fs from "node:fs/promises";

--- a/lib/tools/admin/project-register.ts
+++ b/lib/tools/admin/project-register.ts
@@ -43,10 +43,13 @@ This directory holds project-specific configuration that overrides the workspace
 
 To override default worker instructions, create \`prompts/<role>.md\`:
 
-Available roles: ${roles}
+Available worker roles: ${roles}
 
 Example: \`prompts/developer.md\` overrides the default developer instructions for this project only.
 Files here take priority over the workspace defaults in \`devclaw/prompts/\`.
+
+The orchestrator also supports a live project-specific override at \`prompts/orchestrator.md\`.
+That file is layered into the main orchestrator session after \`AGENTS.md\` and after the workspace-wide \`devclaw/prompts/orchestrator.md\`.
 
 ## Workflow Overrides
 

--- a/lib/tools/admin/project-register.ts
+++ b/lib/tools/admin/project-register.ts
@@ -6,8 +6,7 @@
  *
  * Replaces the manual steps of running glab/gh label create + editing projects.json.
  */
-import { jsonResult } from "openclaw/plugin-sdk";
-import * as pluginSdk from "openclaw/plugin-sdk";
+import { jsonResult } from "../../json-result.js";
 import type { ToolContext } from "../../types.js";
 import type { PluginContext } from "../../context.js";
 import fs from "node:fs/promises";
@@ -131,29 +130,6 @@ export function createProjectRegisterTool(ctx: PluginContext) {
     },
 
     async execute(_id: string, params: Record<string, unknown>) {
-      // #region debug log agent log
-      void fetch("http://127.0.0.1:7466/ingest/5d97a7af-7976-4064-b520-dc7c79f3b068", {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          "X-Debug-Session-Id": "052428",
-        },
-        body: JSON.stringify({
-          sessionId: "052428",
-          runId: "attach-topic-precheck",
-          hypothesisId: "H1-jsonResult-export-mismatch",
-          location: "devclaw/lib/tools/admin/project-register.ts:execute",
-          message: "Verify openclaw/plugin-sdk.jsonResult at runtime",
-          data: {
-            jsonResultType: typeof jsonResult,
-            pluginSdkJsonResultType: typeof (pluginSdk as unknown as { jsonResult?: unknown }).jsonResult,
-            pluginSdkKeys: Object.keys(pluginSdk as Record<string, unknown>).slice(0, 30),
-          },
-          timestamp: Date.now(),
-        }),
-      }).catch(() => {});
-      // #endregion
-
       const channelId = params.channelId as string;
       const name = params.name as string;
       const repo = params.repo as string;

--- a/lib/tools/admin/project-register.ts
+++ b/lib/tools/admin/project-register.ts
@@ -7,6 +7,7 @@
  * Replaces the manual steps of running glab/gh label create + editing projects.json.
  */
 import { jsonResult } from "openclaw/plugin-sdk";
+import * as pluginSdk from "openclaw/plugin-sdk";
 import type { ToolContext } from "../../types.js";
 import type { PluginContext } from "../../context.js";
 import fs from "node:fs/promises";
@@ -93,6 +94,11 @@ export function createProjectRegisterTool(ctx: PluginContext) {
           type: "string",
           description: "Channel ID — the chat/group ID where this project is managed (e.g. Telegram group ID)",
         },
+        messageThreadId: {
+          type: "number",
+          description:
+            "Optional Telegram forum topic ID (message_thread_id). When provided with channel='telegram', binds the project to this topic instead of the whole chat.",
+        },
         name: {
           type: "string",
           description: "Short project name (e.g. 'my-webapp')",
@@ -125,6 +131,29 @@ export function createProjectRegisterTool(ctx: PluginContext) {
     },
 
     async execute(_id: string, params: Record<string, unknown>) {
+      // #region debug log agent log
+      void fetch("http://127.0.0.1:7466/ingest/5d97a7af-7976-4064-b520-dc7c79f3b068", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "X-Debug-Session-Id": "052428",
+        },
+        body: JSON.stringify({
+          sessionId: "052428",
+          runId: "attach-topic-precheck",
+          hypothesisId: "H1-jsonResult-export-mismatch",
+          location: "devclaw/lib/tools/admin/project-register.ts:execute",
+          message: "Verify openclaw/plugin-sdk.jsonResult at runtime",
+          data: {
+            jsonResultType: typeof jsonResult,
+            pluginSdkJsonResultType: typeof (pluginSdk as unknown as { jsonResult?: unknown }).jsonResult,
+            pluginSdkKeys: Object.keys(pluginSdk as Record<string, unknown>).slice(0, 30),
+          },
+          timestamp: Date.now(),
+        }),
+      }).catch(() => {});
+      // #endregion
+
       const channelId = params.channelId as string;
       const name = params.name as string;
       const repo = params.repo as string;
@@ -133,6 +162,7 @@ export function createProjectRegisterTool(ctx: PluginContext) {
       const baseBranch = params.baseBranch as string;
       const deployBranch = (params.deployBranch as string) ?? baseBranch;
       const deployUrl = (params.deployUrl as string) ?? "";
+      const messageThreadId = params.messageThreadId as number | undefined;
       const workspaceDir = toolCtx.workspaceDir;
 
       if (!workspaceDir) {
@@ -208,6 +238,9 @@ export function createProjectRegisterTool(ctx: PluginContext) {
           channel: channel as "telegram" | "whatsapp" | "discord" | "slack",
           name: `channel-${existing.channels.length + 1}`,
           events: ["*"],
+          ...(messageThreadId != null && channel === "telegram"
+            ? { messageThreadId }
+            : {}),
         };
         existing.channels.push(newChannel);
         if (repoRemote && !existing.repoRemote) {
@@ -226,6 +259,9 @@ export function createProjectRegisterTool(ctx: PluginContext) {
           channel: channel as "telegram" | "whatsapp" | "discord" | "slack",
           name: "primary",
           events: ["*"],
+          ...(messageThreadId != null && channel === "telegram"
+            ? { messageThreadId }
+            : {}),
         };
 
         data.projects[slug] = {

--- a/lib/tools/admin/project-status.ts
+++ b/lib/tools/admin/project-status.ts
@@ -5,7 +5,7 @@
  * workflow config, and execution settings. No issue-tracker API calls.
  * Use `tasks_status` for live issue counts.
  */
-import { jsonResult } from "openclaw/plugin-sdk";
+import { jsonResult } from "../../json-result.js";
 import type { ToolContext } from "../../types.js";
 import type { PluginContext } from "../../context.js";
 import { requireWorkspaceDir, resolveChannelId, resolveProject } from "../helpers.js";

--- a/lib/tools/admin/project-status.ts
+++ b/lib/tools/admin/project-status.ts
@@ -28,14 +28,25 @@ export function createProjectStatusTool(ctx: PluginContext) {
           type: "string",
           description: "YOUR chat/group ID — the numeric ID of the chat you are in right now (e.g. '-1003844794417'). Do NOT guess; use the ID of the conversation this message came from.",
         },
+        messageThreadId: {
+          type: "number",
+          description: "Optional Telegram forum topic ID for this project (message_thread_id). When provided, resolves the project bound to this topic within the chat.",
+        },
       },
     },
 
     async execute(_id: string, params: Record<string, unknown>) {
       const workspaceDir = requireWorkspaceDir(toolCtx);
       const channelId = resolveChannelId(toolCtx, params.channelId as string | undefined);
+      const messageThreadId = params.messageThreadId as number | undefined;
+      const channelType = (toolCtx.messageChannel as string | undefined) ?? "telegram";
+      const accountId = toolCtx.agentAccountId as string | undefined;
 
-      const { project } = await resolveProject(workspaceDir, channelId);
+      const { project } = await resolveProject(workspaceDir, channelId, {
+        channel: channelType,
+        accountId,
+        messageThreadId,
+      });
 
       const pluginConfig = ctx.pluginConfig;
       const projectExecution = (pluginConfig?.projectExecution as string) ?? ExecutionMode.PARALLEL;

--- a/lib/tools/admin/project-status.ts
+++ b/lib/tools/admin/project-status.ts
@@ -5,10 +5,9 @@
  * workflow config, and execution settings. No issue-tracker API calls.
  * Use `tasks_status` for live issue counts.
  */
-import { jsonResult } from "openclaw/plugin-sdk";
 import type { ToolContext } from "../../types.js";
 import type { PluginContext } from "../../context.js";
-import { requireWorkspaceDir, resolveChannelId, resolveProject } from "../helpers.js";
+import { jsonResult, requireWorkspaceDir, resolveChannelId, resolveProject } from "../helpers.js";
 import { ExecutionMode, StateType } from "../../workflow/index.js";
 import { loadConfig } from "../../config/index.js";
 import { loadInstanceName } from "../../instance.js";

--- a/lib/tools/admin/setup.ts
+++ b/lib/tools/admin/setup.ts
@@ -4,7 +4,7 @@
  * Creates agent, configures model levels, writes workspace files.
  * Thin wrapper around lib/setup/.
  */
-import { jsonResult } from "openclaw/plugin-sdk";
+import { jsonResult } from "../../json-result.js";
 import type { ToolContext } from "../../types.js";
 import type { PluginContext } from "../../context.js";
 import { runSetup, type SetupOpts } from "../../setup/index.js";

--- a/lib/tools/admin/setup.ts
+++ b/lib/tools/admin/setup.ts
@@ -4,7 +4,7 @@
  * Creates agent, configures model levels, writes workspace files.
  * Thin wrapper around lib/setup/.
  */
-import { jsonResult } from "openclaw/plugin-sdk";
+import { jsonResult } from "../helpers.js";
 import type { ToolContext } from "../../types.js";
 import type { PluginContext } from "../../context.js";
 import { runSetup, type SetupOpts } from "../../setup/index.js";

--- a/lib/tools/admin/sync-labels.ts
+++ b/lib/tools/admin/sync-labels.ts
@@ -8,7 +8,7 @@
  * Calls provider.ensureLabel() directly instead of provider.ensureAllStateLabels()
  * so that custom workflow states from workspace/project overrides are included.
  */
-import { jsonResult } from "openclaw/plugin-sdk";
+import { jsonResult } from "../../json-result.js";
 import type { ToolContext } from "../../types.js";
 import type { PluginContext } from "../../context.js";
 import { requireWorkspaceDir } from "../helpers.js";
@@ -36,7 +36,12 @@ export function createSyncLabelsTool(ctx: PluginContext) {
         channelId: {
           type: "string",
           description:
-            "Channel ID identifying the project. Omit to sync all registered projects.",
+            "Project slug or channel ID. Omit to sync all registered projects.",
+        },
+        messageThreadId: {
+          type: "number",
+          description:
+            "Optional Telegram forum topic ID (message_thread_id). When provided with a channel ID, resolves the topic-bound project within the chat.",
         },
       },
     },
@@ -44,12 +49,23 @@ export function createSyncLabelsTool(ctx: PluginContext) {
     async execute(_id: string, params: Record<string, unknown>) {
       const workspaceDir = requireWorkspaceDir(toolCtx);
       const targetChannelId = params.channelId as string | undefined;
+      const messageThreadId = params.messageThreadId as number | undefined;
+      const channelType = (toolCtx.messageChannel as string | undefined) ?? "telegram";
+      const accountId = toolCtx.agentAccountId as string | undefined;
 
       const data = await readProjects(workspaceDir);
       let slugs: string[];
 
       if (targetChannelId) {
-        const project = getProject(data, targetChannelId);
+        let project =
+          data.projects[targetChannelId] !== undefined
+            ? data.projects[targetChannelId]
+            : getProject(data, {
+                channelId: targetChannelId,
+                channel: channelType,
+                accountId,
+                messageThreadId,
+              });
         if (!project) {
           throw new Error(
             `No project found for "${targetChannelId}". Register a new project with project_register first.`,

--- a/lib/tools/admin/sync-labels.ts
+++ b/lib/tools/admin/sync-labels.ts
@@ -13,6 +13,7 @@ import type { PluginContext } from "../../context.js";
 import { jsonResult, requireWorkspaceDir } from "../helpers.js";
 import { readProjects, getProject } from "../../projects/index.js";
 import { createProvider } from "../../providers/index.js";
+import { normalizeRepoTarget } from "../helpers.js";
 import { loadConfig } from "../../config/index.js";
 import {
   getStateLabels,
@@ -80,6 +81,7 @@ export function createSyncLabelsTool(ctx: PluginContext) {
           const { provider } = await createProvider({
             repo: project.repo,
             provider: project.provider,
+            target: project.repoRemote ? { repo: normalizeRepoTarget(project.repoRemote) } : undefined,
             runCommand: ctx.runCommand,
           });
 

--- a/lib/tools/admin/sync-labels.ts
+++ b/lib/tools/admin/sync-labels.ts
@@ -8,10 +8,9 @@
  * Calls provider.ensureLabel() directly instead of provider.ensureAllStateLabels()
  * so that custom workflow states from workspace/project overrides are included.
  */
-import { jsonResult } from "openclaw/plugin-sdk";
 import type { ToolContext } from "../../types.js";
 import type { PluginContext } from "../../context.js";
-import { requireWorkspaceDir } from "../helpers.js";
+import { jsonResult, requireWorkspaceDir } from "../helpers.js";
 import { readProjects, getProject } from "../../projects/index.js";
 import { createProvider } from "../../providers/index.js";
 import { loadConfig } from "../../config/index.js";

--- a/lib/tools/admin/workflow-guide.ts
+++ b/lib/tools/admin/workflow-guide.ts
@@ -8,7 +8,7 @@
  *
  * No parameters, no side effects — pure documentation.
  */
-import { jsonResult } from "openclaw/plugin-sdk";
+import { jsonResult } from "../../json-result.js";
 import type { PluginContext } from "../../context.js";
 import type { ToolContext } from "../../types.js";
 import { requireWorkspaceDir } from "../helpers.js";

--- a/lib/tools/admin/workflow-guide.ts
+++ b/lib/tools/admin/workflow-guide.ts
@@ -8,10 +8,9 @@
  *
  * No parameters, no side effects — pure documentation.
  */
-import { jsonResult } from "openclaw/plugin-sdk";
 import type { PluginContext } from "../../context.js";
 import type { ToolContext } from "../../types.js";
-import { requireWorkspaceDir } from "../helpers.js";
+import { jsonResult, requireWorkspaceDir } from "../helpers.js";
 import { DATA_DIR } from "../../setup/migrate-layout.js";
 
 export function createWorkflowGuideTool(_ctx: PluginContext) {

--- a/lib/tools/helpers.test.ts
+++ b/lib/tools/helpers.test.ts
@@ -1,0 +1,18 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { normalizeRepoTarget } from "./helpers.js";
+
+describe("normalizeRepoTarget", () => {
+  it("normalizes github https and ssh remotes", () => {
+    assert.equal(normalizeRepoTarget("https://github.com/yaqub0r/devclaw.git"), "yaqub0r/devclaw");
+    assert.equal(normalizeRepoTarget("git@github.com:yaqub0r/devclaw.git"), "yaqub0r/devclaw");
+  });
+
+  it("normalizes gitlab remotes and trims whitespace", () => {
+    assert.equal(normalizeRepoTarget("  https://gitlab.com/group/project.git  "), "group/project");
+  });
+
+  it("preserves already-normalized owner repo targets", () => {
+    assert.equal(normalizeRepoTarget("yaqub0r/devclaw"), "yaqub0r/devclaw");
+  });
+});

--- a/lib/tools/helpers.test.ts
+++ b/lib/tools/helpers.test.ts
@@ -4,8 +4,8 @@ import { normalizeRepoTarget } from "./helpers.js";
 
 describe("normalizeRepoTarget", () => {
   it("normalizes github https and ssh remotes", () => {
-    assert.equal(normalizeRepoTarget("https://github.com/yaqub0r/devclaw.git"), "yaqub0r/devclaw");
-    assert.equal(normalizeRepoTarget("git@github.com:yaqub0r/devclaw.git"), "yaqub0r/devclaw");
+    assert.equal(normalizeRepoTarget("https://github.com/example-owner/example-repo.git"), "example-owner/example-repo");
+    assert.equal(normalizeRepoTarget("git@github.com:example-owner/example-repo.git"), "example-owner/example-repo");
   });
 
   it("normalizes gitlab remotes and trims whitespace", () => {
@@ -13,6 +13,6 @@ describe("normalizeRepoTarget", () => {
   });
 
   it("preserves already-normalized owner repo targets", () => {
-    assert.equal(normalizeRepoTarget("yaqub0r/devclaw"), "yaqub0r/devclaw");
+    assert.equal(normalizeRepoTarget("example-owner/example-repo"), "example-owner/example-repo");
   });
 });

--- a/lib/tools/helpers.ts
+++ b/lib/tools/helpers.ts
@@ -41,9 +41,17 @@ export function resolveChannelId(_ctx: ToolContext, explicitChannelId?: string):
 export async function resolveProject(
   workspaceDir: string,
   channelId: string,
+  opts?: { channel?: string; accountId?: string; messageThreadId?: number | string | null },
 ): Promise<{ data: ProjectsData; project: Project }> {
   const data = await readProjects(workspaceDir);
-  const project = getProject(data, channelId);
+  const project = opts
+    ? getProject(data, {
+        channelId,
+        channel: opts.channel,
+        accountId: opts.accountId,
+        messageThreadId: opts.messageThreadId,
+      })
+    : getProject(data, channelId);
   if (!project) {
     throw new Error(
       `No project found for "${channelId}". ` +

--- a/lib/tools/helpers.ts
+++ b/lib/tools/helpers.ts
@@ -66,7 +66,25 @@ export async function resolveProject(
  * Uses stored provider type from project config if available, otherwise auto-detects.
  */
 export async function resolveProvider(project: Project, runCommand: RunCommand): Promise<ProviderWithType> {
-  return createProvider({ repo: project.repo, provider: project.provider, runCommand });
+  const target = project.repoRemote ? { repo: normalizeRepoTarget(project.repoRemote) } : undefined;
+  return createProvider({ repo: project.repo, provider: project.provider, target, runCommand });
+}
+
+function normalizeRepoTarget(repoRemote: string): string | undefined {
+  const trimmed = repoRemote.trim();
+  if (!trimmed) return undefined;
+
+  const sshMatch = trimmed.match(/github\.com[:/]([^/]+\/[^/.]+)(?:\.git)?$/i)
+    ?? trimmed.match(/gitlab\.com[:/]([^/]+\/[^/.]+)(?:\.git)?$/i);
+  if (sshMatch) return sshMatch[1];
+
+  try {
+    const url = new URL(trimmed);
+    const path = url.pathname.replace(/^\/+/, "").replace(/\.git$/i, "");
+    return path || undefined;
+  } catch {
+    return trimmed.replace(/\.git$/i, "");
+  }
 }
 
 /**

--- a/lib/tools/helpers.ts
+++ b/lib/tools/helpers.ts
@@ -70,7 +70,7 @@ export async function resolveProvider(project: Project, runCommand: RunCommand):
   return createProvider({ repo: project.repo, provider: project.provider, target, runCommand });
 }
 
-function normalizeRepoTarget(repoRemote: string): string | undefined {
+export function normalizeRepoTarget(repoRemote: string): string | undefined {
   const trimmed = repoRemote.trim();
   if (!trimmed) return undefined;
 

--- a/lib/tools/helpers.ts
+++ b/lib/tools/helpers.ts
@@ -5,6 +5,14 @@
  * project resolution, provider creation.
  */
 import type { ToolContext } from "../types.js";
+
+/**
+ * Wrap a payload as a tool result with pretty-printed JSON text.
+ * Replaces the removed `jsonResult` export from openclaw/plugin-sdk.
+ */
+export function jsonResult(payload: unknown): { content: { type: "text"; text: string }[]; details: unknown } {
+  return { content: [{ type: "text", text: JSON.stringify(payload, null, 2) }], details: payload };
+}
 import type { RunCommand } from "../context.js";
 import { readProjects, getProject, type Project, type ProjectsData } from "../projects/index.js";
 import { createProvider, type ProviderWithType } from "../providers/index.js";

--- a/lib/tools/tasks/research-task.ts
+++ b/lib/tools/tasks/research-task.ts
@@ -12,7 +12,7 @@
  *   → architect calls work_finish(result="done") → "Researching" → "Done" (issue closed)
  *   → operator reviews created tasks in Planning, moves to "To Do" when ready
  */
-import { jsonResult } from "openclaw/plugin-sdk";
+import { jsonResult } from "../../json-result.js";
 import type { ToolContext } from "../../types.js";
 import type { PluginContext } from "../../context.js";
 import type { StateLabel } from "../../providers/provider.js";
@@ -60,6 +60,11 @@ Example:
           type: "string",
           description: "YOUR chat/group ID — the numeric ID of the chat you are in right now (e.g. '-1003844794417'). Do NOT guess; use the ID of the conversation this message came from.",
         },
+        messageThreadId: {
+          type: "number",
+          description:
+            "Optional Telegram forum topic ID for this project (message_thread_id). When provided, resolves the topic-bound project within the chat.",
+        },
         title: {
           type: "string",
           description: "Research title (e.g., 'Research: Session persistence strategy')",
@@ -92,12 +97,19 @@ Example:
       const focusAreas = (params.focusAreas as string[]) ?? [];
       const complexity = (params.complexity as "simple" | "medium" | "complex") ?? "medium";
       const dryRun = (params.dryRun as boolean) ?? false;
+      const messageThreadId = params.messageThreadId as number | undefined;
       const workspaceDir = requireWorkspaceDir(toolCtx);
 
       if (!title) throw new Error("title is required");
       if (!description) throw new Error("description is required — provide detailed background context for the architect");
 
-      const { project } = await resolveProject(workspaceDir, channelId);
+      const channelType = (toolCtx.messageChannel as string | undefined) ?? "telegram";
+      const accountId = toolCtx.agentAccountId as string | undefined;
+      const { project } = await resolveProject(workspaceDir, channelId, {
+        channel: channelType,
+        accountId,
+        messageThreadId,
+      });
       const { provider } = await resolveProvider(project, ctx.runCommand);
       const pluginConfig = ctx.pluginConfig;
       const role = "architect";

--- a/lib/tools/tasks/research-task.ts
+++ b/lib/tools/tasks/research-task.ts
@@ -12,14 +12,13 @@
  *   → architect calls work_finish(result="done") → "Researching" → "Done" (issue closed)
  *   → operator reviews created tasks in Planning, moves to "To Do" when ready
  */
-import { jsonResult } from "openclaw/plugin-sdk";
 import type { ToolContext } from "../../types.js";
 import type { PluginContext } from "../../context.js";
 import type { StateLabel } from "../../providers/provider.js";
 import { getRoleWorker, countActiveSlots } from "../../projects/index.js";
 import { dispatchTask } from "../../dispatch/index.js";
 import { log as auditLog } from "../../audit.js";
-import { requireWorkspaceDir, resolveChannelId, resolveProject, resolveProvider, autoAssignOwnerLabel, applyNotifyLabel } from "../helpers.js";
+import { jsonResult, requireWorkspaceDir, resolveChannelId, resolveProject, resolveProvider, autoAssignOwnerLabel, applyNotifyLabel } from "../helpers.js";
 import { loadConfig } from "../../config/index.js";
 import { getActiveLabel } from "../../workflow/index.js";
 import { selectLevel } from "../../roles/model-selector.js";

--- a/lib/tools/tasks/task-attach.ts
+++ b/lib/tools/tasks/task-attach.ts
@@ -38,6 +38,10 @@ Use cases:
           type: "string",
           description: "YOUR chat/group ID — the numeric ID of the chat you are in right now (e.g. '-1003844794417'). Do NOT guess; use the ID of the conversation this message came from.",
         },
+        messageThreadId: {
+          type: "number",
+          description: "Optional Telegram forum topic ID for this project (message_thread_id). When provided, resolves the topic-bound project within the chat.",
+        },
         issueId: {
           type: "number",
           description: "Issue ID",
@@ -60,11 +64,18 @@ Use cases:
 
     async execute(_id: string, params: Record<string, unknown>) {
       const channelId = resolveChannelId(toolCtx, params.channelId as string | undefined);
+      const messageThreadId = params.messageThreadId as number | undefined;
       const issueId = params.issueId as number;
       const action = (params.action as string) ?? "list";
       const workspaceDir = requireWorkspaceDir(toolCtx);
 
-      const { project } = await resolveProject(workspaceDir, channelId);
+      const channelType = (toolCtx.messageChannel as string | undefined) ?? "telegram";
+      const accountId = toolCtx.agentAccountId as string | undefined;
+      const { project } = await resolveProject(workspaceDir, channelId, {
+        channel: channelType,
+        accountId,
+        messageThreadId,
+      });
 
       if (action === "list") {
         const attachments = await listAttachments(workspaceDir, project.slug, issueId);
@@ -114,7 +125,8 @@ Use cases:
         const filename = path.basename(resolvedPath);
 
         // Detect mime type
-        const { detectMime } = await import("openclaw/plugin-sdk");
+        // OpenClaw only exports detectMime from some channel submodules in this version.
+        const { detectMime } = await import("openclaw/plugin-sdk/msteams");
         const mimeType = await detectMime({ filePath: resolvedPath, buffer }) ?? "application/octet-stream";
 
         const { provider } = await resolveProvider(project, ctx.runCommand);

--- a/lib/tools/tasks/task-attach.ts
+++ b/lib/tools/tasks/task-attach.ts
@@ -6,7 +6,7 @@
  * - Manually attach a local file to an issue
  * - View attachment metadata and local paths
  */
-import { jsonResult } from "openclaw/plugin-sdk";
+import { jsonResult } from "../../json-result.js";
 import type { PluginContext } from "../../context.js";
 import type { ToolContext } from "../../types.js";
 import { log as auditLog } from "../../audit.js";

--- a/lib/tools/tasks/task-attach.ts
+++ b/lib/tools/tasks/task-attach.ts
@@ -6,11 +6,10 @@
  * - Manually attach a local file to an issue
  * - View attachment metadata and local paths
  */
-import { jsonResult } from "openclaw/plugin-sdk";
 import type { PluginContext } from "../../context.js";
 import type { ToolContext } from "../../types.js";
 import { log as auditLog } from "../../audit.js";
-import { requireWorkspaceDir, resolveChannelId, resolveProject, resolveProvider, autoAssignOwnerLabel, applyNotifyLabel } from "../helpers.js";
+import { jsonResult, requireWorkspaceDir, resolveChannelId, resolveProject, resolveProvider, autoAssignOwnerLabel, applyNotifyLabel } from "../helpers.js";
 import {
   listAttachments,
   saveAttachment,

--- a/lib/tools/tasks/task-comment.ts
+++ b/lib/tools/tasks/task-comment.ts
@@ -41,6 +41,10 @@ Examples:
           type: "string",
           description: "YOUR chat/group ID — the numeric ID of the chat you are in right now (e.g. '-1003844794417'). Do NOT guess; use the ID of the conversation this message came from.",
         },
+        messageThreadId: {
+          type: "number",
+          description: "Optional Telegram forum topic ID for this project (message_thread_id). When provided, resolves the topic-bound project within the chat.",
+        },
         issueId: {
           type: "number",
           description: "Issue ID to comment on",
@@ -59,6 +63,7 @@ Examples:
 
     async execute(_id: string, params: Record<string, unknown>) {
       const channelId = resolveChannelId(toolCtx, params.channelId as string | undefined);
+      const messageThreadId = params.messageThreadId as number | undefined;
       const issueId = params.issueId as number;
       const body = params.body as string;
       const authorRole = (params.authorRole as AuthorRole) ?? undefined;
@@ -68,7 +73,13 @@ Examples:
         throw new Error("Comment body cannot be empty.");
       }
 
-      const { project } = await resolveProject(workspaceDir, channelId);
+      const channelType = (toolCtx.messageChannel as string | undefined) ?? "telegram";
+      const accountId = toolCtx.agentAccountId as string | undefined;
+      const { project } = await resolveProject(workspaceDir, channelId, {
+        channel: channelType,
+        accountId,
+        messageThreadId,
+      });
       const { provider, type: providerType } = await resolveProvider(project, ctx.runCommand);
 
       const issue = await provider.getIssue(issueId);

--- a/lib/tools/tasks/task-comment.ts
+++ b/lib/tools/tasks/task-comment.ts
@@ -6,11 +6,10 @@
  * - Developer worker posts implementation notes
  * - Orchestrator adds summary comments
  */
-import { jsonResult } from "openclaw/plugin-sdk";
 import type { PluginContext } from "../../context.js";
 import type { ToolContext } from "../../types.js";
 import { log as auditLog } from "../../audit.js";
-import { requireWorkspaceDir, resolveChannelId, resolveProject, resolveProvider, autoAssignOwnerLabel, applyNotifyLabel } from "../helpers.js";
+import { jsonResult, requireWorkspaceDir, resolveChannelId, resolveProject, resolveProvider, autoAssignOwnerLabel, applyNotifyLabel } from "../helpers.js";
 import { getAllRoleIds, getFallbackEmoji } from "../../roles/index.js";
 
 /** Valid author roles for attribution — all registry roles + orchestrator */

--- a/lib/tools/tasks/task-comment.ts
+++ b/lib/tools/tasks/task-comment.ts
@@ -6,7 +6,7 @@
  * - Developer worker posts implementation notes
  * - Orchestrator adds summary comments
  */
-import { jsonResult } from "openclaw/plugin-sdk";
+import { jsonResult } from "../../json-result.js";
 import type { PluginContext } from "../../context.js";
 import type { ToolContext } from "../../types.js";
 import { log as auditLog } from "../../audit.js";

--- a/lib/tools/tasks/task-create.ts
+++ b/lib/tools/tasks/task-create.ts
@@ -9,7 +9,7 @@
  * - A sub-agent finds a bug and needs to file a follow-up issue
  * - Breaking down an epic into smaller tasks
  */
-import { jsonResult } from "openclaw/plugin-sdk";
+import { jsonResult } from "../../json-result.js";
 import type { PluginContext } from "../../context.js";
 import type { ToolContext } from "../../types.js";
 import { log as auditLog } from "../../audit.js";

--- a/lib/tools/tasks/task-create.ts
+++ b/lib/tools/tasks/task-create.ts
@@ -32,6 +32,10 @@ export function createTaskCreateTool(ctx: PluginContext) {
           type: "string",
           description: "YOUR chat/group ID — the numeric ID of the chat you are in right now (e.g. '-1003844794417'). Do NOT guess; use the ID of the conversation this message came from.",
         },
+        messageThreadId: {
+          type: "number",
+          description: "Optional Telegram forum topic ID for this project (message_thread_id). When provided, resolves the topic-bound project within the chat.",
+        },
         title: {
           type: "string",
           description: "Short, descriptive issue title (e.g., 'Fix login timeout bug')",
@@ -54,6 +58,7 @@ export function createTaskCreateTool(ctx: PluginContext) {
 
     async execute(_id: string, params: Record<string, unknown>) {
       const channelId = resolveChannelId(toolCtx, params.channelId as string | undefined);
+      const messageThreadId = params.messageThreadId as number | undefined;
       const title = params.title as string;
       const description = (params.description as string) ?? "";
       const label = INITIAL_LABEL;
@@ -61,7 +66,13 @@ export function createTaskCreateTool(ctx: PluginContext) {
       const pickup = (params.pickup as boolean) ?? false;
       const workspaceDir = requireWorkspaceDir(toolCtx);
 
-      const { project } = await resolveProject(workspaceDir, channelId);
+      const channelType = (toolCtx.messageChannel as string | undefined) ?? "telegram";
+      const accountId = toolCtx.agentAccountId as string | undefined;
+      const { project } = await resolveProject(workspaceDir, channelId, {
+        channel: channelType,
+        accountId,
+        messageThreadId,
+      });
       const { provider, type: providerType } = await resolveProvider(project, ctx.runCommand);
 
       const issue = await provider.createIssue(title, description, label, assignees);

--- a/lib/tools/tasks/task-create.ts
+++ b/lib/tools/tasks/task-create.ts
@@ -9,12 +9,11 @@
  * - A sub-agent finds a bug and needs to file a follow-up issue
  * - Breaking down an epic into smaller tasks
  */
-import { jsonResult } from "openclaw/plugin-sdk";
 import type { PluginContext } from "../../context.js";
 import type { ToolContext } from "../../types.js";
 import { log as auditLog } from "../../audit.js";
 import { DEFAULT_WORKFLOW } from "../../workflow/index.js";
-import { requireWorkspaceDir, resolveChannelId, resolveProject, resolveProvider, autoAssignOwnerLabel, applyNotifyLabel } from "../helpers.js";
+import { jsonResult, requireWorkspaceDir, resolveChannelId, resolveProject, resolveProvider, autoAssignOwnerLabel, applyNotifyLabel } from "../helpers.js";
 
 /** Derive the initial state label from the workflow config. */
 const INITIAL_LABEL = DEFAULT_WORKFLOW.states[DEFAULT_WORKFLOW.initial].label;

--- a/lib/tools/tasks/task-edit-body.ts
+++ b/lib/tools/tasks/task-edit-body.ts
@@ -8,7 +8,7 @@
  * DevClaw adds an explicit audit entry with who, when, and what changed.
  * Optionally posts an auto-comment on the issue for traceability.
  */
-import { jsonResult } from "openclaw/plugin-sdk";
+import { jsonResult } from "../../json-result.js";
 import type { PluginContext } from "../../context.js";
 import type { ToolContext } from "../../types.js";
 import { log as auditLog } from "../../audit.js";

--- a/lib/tools/tasks/task-edit-body.ts
+++ b/lib/tools/tasks/task-edit-body.ts
@@ -37,6 +37,10 @@ Examples:
           type: "string",
           description: "YOUR chat/group ID — the numeric ID of the chat you are in right now (e.g. '-1003844794417'). Do NOT guess; use the ID of the conversation this message came from.",
         },
+        messageThreadId: {
+          type: "number",
+          description: "Optional Telegram forum topic ID for this project (message_thread_id). When provided, resolves the topic-bound project within the chat.",
+        },
         issueId: {
           type: "number",
           description: "Issue ID to edit",
@@ -62,6 +66,7 @@ Examples:
 
     async execute(_id: string, params: Record<string, unknown>) {
       const channelId = resolveChannelId(toolCtx, params.channelId as string | undefined);
+      const messageThreadId = params.messageThreadId as number | undefined;
       const issueId = params.issueId as number;
       const newTitle = (params.title as string | undefined);
       const newBody = (params.body as string | undefined);
@@ -73,7 +78,13 @@ Examples:
         throw new Error("At least one of 'title' or 'body' must be provided.");
       }
 
-      const { project } = await resolveProject(workspaceDir, channelId);
+      const channelType = (toolCtx.messageChannel as string | undefined) ?? "telegram";
+      const accountId = toolCtx.agentAccountId as string | undefined;
+      const { project } = await resolveProject(workspaceDir, channelId, {
+        channel: channelType,
+        accountId,
+        messageThreadId,
+      });
       const { provider, type: providerType } = await resolveProvider(project, ctx.runCommand);
 
       // Determine editable states from per-project workflow config.

--- a/lib/tools/tasks/task-edit-body.ts
+++ b/lib/tools/tasks/task-edit-body.ts
@@ -8,13 +8,12 @@
  * DevClaw adds an explicit audit entry with who, when, and what changed.
  * Optionally posts an auto-comment on the issue for traceability.
  */
-import { jsonResult } from "openclaw/plugin-sdk";
 import type { PluginContext } from "../../context.js";
 import type { ToolContext } from "../../types.js";
 import { log as auditLog } from "../../audit.js";
 import { loadConfig } from "../../config/index.js";
 import { getInitialStateLabel, getCurrentStateLabel } from "../../workflow/index.js";
-import { requireWorkspaceDir, resolveChannelId, resolveProject, resolveProvider, autoAssignOwnerLabel, applyNotifyLabel } from "../helpers.js";
+import { jsonResult, requireWorkspaceDir, resolveChannelId, resolveProject, resolveProvider, autoAssignOwnerLabel, applyNotifyLabel } from "../helpers.js";
 
 export function createTaskEditBodyTool(ctx: PluginContext) {
   return (toolCtx: ToolContext) => ({

--- a/lib/tools/tasks/task-list.ts
+++ b/lib/tools/tasks/task-list.ts
@@ -4,11 +4,10 @@
  * Lists issues grouped by state label with optional filtering by state type,
  * specific label, or text search. Supports terminal (closed) issues.
  */
-import { jsonResult } from "openclaw/plugin-sdk";
 import type { PluginContext } from "../../context.js";
 import type { ToolContext } from "../../types.js";
 import { log as auditLog } from "../../audit.js";
-import { requireWorkspaceDir, resolveChannelId, resolveProject, resolveProvider } from "../helpers.js";
+import { jsonResult, requireWorkspaceDir, resolveChannelId, resolveProject, resolveProvider } from "../helpers.js";
 import { loadWorkflow, StateType, findStateByLabel } from "../../workflow/index.js";
 
 export function createTaskListTool(ctx: PluginContext) {

--- a/lib/tools/tasks/task-list.ts
+++ b/lib/tools/tasks/task-list.ts
@@ -4,7 +4,7 @@
  * Lists issues grouped by state label with optional filtering by state type,
  * specific label, or text search. Supports terminal (closed) issues.
  */
-import { jsonResult } from "openclaw/plugin-sdk";
+import { jsonResult } from "../../json-result.js";
 import type { PluginContext } from "../../context.js";
 import type { ToolContext } from "../../types.js";
 import { log as auditLog } from "../../audit.js";

--- a/lib/tools/tasks/task-list.ts
+++ b/lib/tools/tasks/task-list.ts
@@ -24,6 +24,10 @@ export function createTaskListTool(ctx: PluginContext) {
           type: "string",
           description: "YOUR chat/group ID — the numeric ID of the chat you are in right now (e.g. '-1003844794417'). Do NOT guess; use the ID of the conversation this message came from.",
         },
+        messageThreadId: {
+          type: "number",
+          description: "Optional Telegram forum topic ID for this project (message_thread_id). When provided, resolves the topic-bound project within the chat.",
+        },
         stateType: {
           type: "string",
           enum: ["queue", "active", "hold", "terminal", "all"],
@@ -47,12 +51,19 @@ export function createTaskListTool(ctx: PluginContext) {
     async execute(_id: string, params: Record<string, unknown>) {
       const workspaceDir = requireWorkspaceDir(toolCtx);
       const channelId = resolveChannelId(toolCtx, params.channelId as string | undefined);
+      const messageThreadId = params.messageThreadId as number | undefined;
       const stateType = params.stateType as string | undefined;
       const label = params.label as string | undefined;
       const search = params.search as string | undefined;
       const limit = (params.limit as number) ?? 20;
 
-      const { project } = await resolveProject(workspaceDir, channelId);
+      const channelType = (toolCtx.messageChannel as string | undefined) ?? "telegram";
+      const accountId = toolCtx.agentAccountId as string | undefined;
+      const { project } = await resolveProject(workspaceDir, channelId, {
+        channel: channelType,
+        accountId,
+        messageThreadId,
+      });
       const { provider } = await resolveProvider(project, ctx.runCommand);
       const workflow = await loadWorkflow(workspaceDir, project.name);
 

--- a/lib/tools/tasks/task-owner.ts
+++ b/lib/tools/tasks/task-owner.ts
@@ -5,10 +5,9 @@
  * owns them for queue scanning and dispatch. Supports claiming a
  * single issue or all unclaimed queued issues for a project.
  */
-import { jsonResult } from "openclaw/plugin-sdk";
 import type { PluginContext } from "../../context.js";
 import type { ToolContext } from "../../types.js";
-import { requireWorkspaceDir, resolveChannelId, resolveProject, resolveProvider } from "../helpers.js";
+import { jsonResult, requireWorkspaceDir, resolveChannelId, resolveProject, resolveProvider } from "../helpers.js";
 import { loadConfig } from "../../config/index.js";
 import { loadInstanceName } from "../../instance.js";
 import {

--- a/lib/tools/tasks/task-owner.ts
+++ b/lib/tools/tasks/task-owner.ts
@@ -5,7 +5,7 @@
  * owns them for queue scanning and dispatch. Supports claiming a
  * single issue or all unclaimed queued issues for a project.
  */
-import { jsonResult } from "openclaw/plugin-sdk";
+import { jsonResult } from "../../json-result.js";
 import type { PluginContext } from "../../context.js";
 import type { ToolContext } from "../../types.js";
 import { requireWorkspaceDir, resolveChannelId, resolveProject, resolveProvider } from "../helpers.js";

--- a/lib/tools/tasks/task-owner.ts
+++ b/lib/tools/tasks/task-owner.ts
@@ -35,6 +35,10 @@ export function createTaskOwnerTool(ctx: PluginContext) {
           type: "string",
           description: "YOUR chat/group ID — the numeric ID of the chat you are in right now (e.g. '-1003844794417'). Do NOT guess; use the ID of the conversation this message came from.",
         },
+        messageThreadId: {
+          type: "number",
+          description: "Optional Telegram forum topic ID for this project (message_thread_id). When provided, resolves the topic-bound project within the chat.",
+        },
         issueId: {
           type: "number",
           description:
@@ -54,7 +58,14 @@ export function createTaskOwnerTool(ctx: PluginContext) {
       const force = (params.force as boolean) ?? false;
       const workspaceDir = requireWorkspaceDir(toolCtx);
 
-      const { project } = await resolveProject(workspaceDir, channelId);
+      const messageThreadId = params.messageThreadId as number | undefined;
+      const channelType = (toolCtx.messageChannel as string | undefined) ?? "telegram";
+      const accountId = toolCtx.agentAccountId as string | undefined;
+      const { project } = await resolveProject(workspaceDir, channelId, {
+        channel: channelType,
+        accountId,
+        messageThreadId,
+      });
       const { provider } = await resolveProvider(project, ctx.runCommand);
       const resolvedConfig = await loadConfig(workspaceDir, project.name);
       const instanceName = await loadInstanceName(

--- a/lib/tools/tasks/task-set-level.ts
+++ b/lib/tools/tasks/task-set-level.ts
@@ -30,6 +30,10 @@ Examples:
           type: "string",
           description: "YOUR chat/group ID — the numeric ID of the chat you are in right now (e.g. '-1003844794417'). Do NOT guess; use the ID of the conversation this message came from.",
         },
+        messageThreadId: {
+          type: "number",
+          description: "Optional Telegram forum topic ID for this project (message_thread_id). When provided, resolves the topic-bound project within the chat.",
+        },
         issueId: {
           type: "number",
           description: "Issue ID to update",
@@ -56,7 +60,14 @@ Examples:
         throw new Error("'level' is required.");
       }
 
-      const { project } = await resolveProject(workspaceDir, channelId);
+      const messageThreadId = params.messageThreadId as number | undefined;
+      const channelType = (toolCtx.messageChannel as string | undefined) ?? "telegram";
+      const accountId = toolCtx.agentAccountId as string | undefined;
+      const { project } = await resolveProject(workspaceDir, channelId, {
+        channel: channelType,
+        accountId,
+        messageThreadId,
+      });
       const { provider, type: providerType } = await resolveProvider(project, ctx.runCommand);
       const resolvedConfig = await loadConfig(workspaceDir, project.name);
 

--- a/lib/tools/tasks/task-set-level.ts
+++ b/lib/tools/tasks/task-set-level.ts
@@ -5,13 +5,12 @@
  * applied as a role:level label and respected by the heartbeat when the
  * issue is later advanced via task_start.
  */
-import { jsonResult } from "openclaw/plugin-sdk";
 import type { PluginContext } from "../../context.js";
 import type { ToolContext } from "../../types.js";
 import { log as auditLog } from "../../audit.js";
 import { StateType, findStateByLabel, getCurrentStateLabel, getRoleLabelColor } from "../../workflow/index.js";
 import { loadConfig } from "../../config/index.js";
-import { requireWorkspaceDir, resolveChannelId, resolveProject, resolveProvider, autoAssignOwnerLabel, applyNotifyLabel } from "../helpers.js";
+import { jsonResult, requireWorkspaceDir, resolveChannelId, resolveProject, resolveProvider, autoAssignOwnerLabel, applyNotifyLabel } from "../helpers.js";
 
 export function createTaskSetLevelTool(ctx: PluginContext) {
   return (toolCtx: ToolContext) => ({

--- a/lib/tools/tasks/task-set-level.ts
+++ b/lib/tools/tasks/task-set-level.ts
@@ -5,7 +5,7 @@
  * applied as a role:level label and respected by the heartbeat when the
  * issue is later advanced via task_start.
  */
-import { jsonResult } from "openclaw/plugin-sdk";
+import { jsonResult } from "../../json-result.js";
 import type { PluginContext } from "../../context.js";
 import type { ToolContext } from "../../types.js";
 import { log as auditLog } from "../../audit.js";

--- a/lib/tools/tasks/task-start.ts
+++ b/lib/tools/tasks/task-start.ts
@@ -47,6 +47,10 @@ Examples:
           type: "string",
           description: "YOUR chat/group ID — the numeric ID of the chat you are in right now (e.g. '-1003844794417'). Do NOT guess; use the ID of the conversation this message came from.",
         },
+        messageThreadId: {
+          type: "number",
+          description: "Optional Telegram forum topic ID for this project (message_thread_id). When provided, resolves the topic-bound project within the chat.",
+        },
         issueId: {
           type: "number",
           description: "Issue ID to advance.",
@@ -64,7 +68,14 @@ Examples:
       const levelHint = params.level as string | undefined;
       const workspaceDir = requireWorkspaceDir(toolCtx);
 
-      const { project } = await resolveProject(workspaceDir, channelId);
+      const messageThreadId = params.messageThreadId as number | undefined;
+      const channelType = (toolCtx.messageChannel as string | undefined) ?? "telegram";
+      const accountId = toolCtx.agentAccountId as string | undefined;
+      const { project } = await resolveProject(workspaceDir, channelId, {
+        channel: channelType,
+        accountId,
+        messageThreadId,
+      });
       const { provider } = await resolveProvider(project, ctx.runCommand);
       const resolvedConfig = await loadConfig(workspaceDir, project.name);
       const workflow = resolvedConfig.workflow;

--- a/lib/tools/tasks/task-start.ts
+++ b/lib/tools/tasks/task-start.ts
@@ -8,7 +8,6 @@
  * The heartbeat is the sole dispatcher — this tool only places issues in
  * queues, never dispatches workers directly.
  */
-import { jsonResult } from "openclaw/plugin-sdk";
 import type { PluginContext } from "../../context.js";
 import type { ToolContext } from "../../types.js";
 import { log as auditLog } from "../../audit.js";
@@ -26,7 +25,7 @@ import {
 } from "../../workflow/index.js";
 import { getLevelsForRole } from "../../roles/index.js";
 import { loadConfig } from "../../config/index.js";
-import { requireWorkspaceDir, resolveChannelId, resolveProject, resolveProvider, autoAssignOwnerLabel, applyNotifyLabel } from "../helpers.js";
+import { jsonResult, requireWorkspaceDir, resolveChannelId, resolveProject, resolveProvider, autoAssignOwnerLabel, applyNotifyLabel } from "../helpers.js";
 
 export function createTaskStartTool(ctx: PluginContext) {
   return (toolCtx: ToolContext) => ({

--- a/lib/tools/tasks/task-start.ts
+++ b/lib/tools/tasks/task-start.ts
@@ -8,7 +8,7 @@
  * The heartbeat is the sole dispatcher — this tool only places issues in
  * queues, never dispatches workers directly.
  */
-import { jsonResult } from "openclaw/plugin-sdk";
+import { jsonResult } from "../../json-result.js";
 import type { PluginContext } from "../../context.js";
 import type { ToolContext } from "../../types.js";
 import { log as auditLog } from "../../audit.js";

--- a/lib/tools/tasks/tasks-status.ts
+++ b/lib/tools/tasks/tasks-status.ts
@@ -4,7 +4,7 @@
  * Fetches all non-terminal issues grouped by state type (hold, active, queue).
  * Use `project_status` for instant local info, this tool for live issue data.
  */
-import { jsonResult } from "openclaw/plugin-sdk";
+import { jsonResult } from "../../json-result.js";
 import type { ToolContext } from "../../types.js";
 import type { PluginContext } from "../../context.js";
 import { log as auditLog } from "../../audit.js";

--- a/lib/tools/tasks/tasks-status.ts
+++ b/lib/tools/tasks/tasks-status.ts
@@ -4,12 +4,11 @@
  * Fetches all non-terminal issues grouped by state type (hold, active, queue).
  * Use `project_status` for instant local info, this tool for live issue data.
  */
-import { jsonResult } from "openclaw/plugin-sdk";
 import type { ToolContext } from "../../types.js";
 import type { PluginContext } from "../../context.js";
 import { log as auditLog } from "../../audit.js";
 import { getStateLabelsByType } from "../../services/queue.js";
-import { requireWorkspaceDir, resolveChannelId, resolveProject, resolveProvider } from "../helpers.js";
+import { jsonResult, requireWorkspaceDir, resolveChannelId, resolveProject, resolveProvider } from "../helpers.js";
 import { loadConfig } from "../../config/index.js";
 
 type IssueSummary = { id: number; title: string; url: string };

--- a/lib/tools/tasks/tasks-status.ts
+++ b/lib/tools/tasks/tasks-status.ts
@@ -30,14 +30,25 @@ export function createTasksStatusTool(ctx: PluginContext) {
           type: "string",
           description: "YOUR chat/group ID — the numeric ID of the chat you are in right now (e.g. '-1003844794417'). Do NOT guess; use the ID of the conversation this message came from.",
         },
+        messageThreadId: {
+          type: "number",
+          description: "Optional Telegram forum topic ID for this project (message_thread_id). When provided, resolves the project bound to this topic within the chat.",
+        },
       },
     },
 
     async execute(_id: string, params: Record<string, unknown>) {
       const workspaceDir = requireWorkspaceDir(toolCtx);
       const channelId = resolveChannelId(toolCtx, params.channelId as string | undefined);
+      const messageThreadId = params.messageThreadId as number | undefined;
+      const channelType = (toolCtx.messageChannel as string | undefined) ?? "telegram";
+      const accountId = toolCtx.agentAccountId as string | undefined;
 
-      const { project } = await resolveProject(workspaceDir, channelId);
+      const { project } = await resolveProject(workspaceDir, channelId, {
+        channel: channelType,
+        accountId,
+        messageThreadId,
+      });
       const { provider } = await resolveProvider(project, ctx.runCommand);
 
       const projectConfig = await loadConfig(workspaceDir, project.name);

--- a/lib/tools/worker/work-finish.ts
+++ b/lib/tools/worker/work-finish.ts
@@ -224,16 +224,20 @@ export function createWorkFinishTool(ctx: PluginContext) {
       const { project } = await resolveProject(workspaceDir, channelId);
       const roleWorker = getRoleWorker(project, role);
 
-      // Find the first active slot across all levels
+      // Find the first active slot across all levels that matches this session.
+      // Session keys can differ slightly in casing between the tool context and
+      // stored slot state, so comparisons are case-insensitive.
       let slotIndex: number | null = null;
       let slotLevel: string | null = null;
       let issueId: number | null = null;
 
       for (const [level, slots] of Object.entries(roleWorker.levels)) {
         for (let i = 0; i < slots.length; i++) {
-          if (slots[i]!.active && slots[i]!.issueId &&
-              (!toolCtx.sessionKey || !slots[i]!.sessionKey ||
-               slots[i]!.sessionKey === toolCtx.sessionKey)) {
+          const slot = slots[i]!;
+          if (slot.active && slot.issueId &&
+              (!toolCtx.sessionKey || !slot.sessionKey ||
+               (slot.sessionKey && toolCtx.sessionKey &&
+                slot.sessionKey.toLowerCase() === toolCtx.sessionKey.toLowerCase()))) {
             slotLevel = level;
             slotIndex = i;
             issueId = Number(slots[i]!.issueId);

--- a/lib/tools/worker/work-finish.ts
+++ b/lib/tools/worker/work-finish.ts
@@ -185,6 +185,7 @@ export function createWorkFinishTool(ctx: PluginContext) {
       required: ["channelId", "role", "result"],
       properties: {
         channelId: { type: "string", description: "YOUR chat/group ID — the numeric ID of the chat you are in right now (e.g. '-1003844794417'). Do NOT guess; use the ID of the conversation this message came from." },
+        messageThreadId: { type: "number", description: "Optional Telegram forum topic ID for this project (message_thread_id). When provided, resolves the project bound to this topic within the chat." },
         role: { type: "string", enum: getAllRoleIds(), description: "Worker role" },
         result: { type: "string", enum: ["done", "pass", "fail", "refine", "blocked", "approve", "reject"], description: "Completion result" },
         summary: { type: "string", description: "Brief summary" },
@@ -209,6 +210,7 @@ export function createWorkFinishTool(ctx: PluginContext) {
       const role = params.role as string;
       const result = params.result as string;
       const channelId = resolveChannelId(toolCtx, params.channelId as string | undefined);
+      const messageThreadId = params.messageThreadId as number | undefined;
       const summary = params.summary as string | undefined;
       const prUrl = params.prUrl as string | undefined;
       const createdTasks = params.createdTasks as Array<{ id: number; title: string; url: string }> | undefined;
@@ -221,7 +223,13 @@ export function createWorkFinishTool(ctx: PluginContext) {
       }
 
       // Resolve project + worker
-      const { project } = await resolveProject(workspaceDir, channelId);
+      const channelType = (toolCtx.messageChannel as string | undefined) ?? "telegram";
+      const accountId = toolCtx.agentAccountId as string | undefined;
+      const { project } = await resolveProject(workspaceDir, channelId, {
+        channel: channelType,
+        accountId,
+        messageThreadId,
+      });
       const roleWorker = getRoleWorker(project, role);
 
       // Find the first active slot across all levels that matches this session.

--- a/lib/tools/worker/work-finish.ts
+++ b/lib/tools/worker/work-finish.ts
@@ -7,7 +7,7 @@
  * All roles (including architect) use the standard pipeline via executeCompletion.
  * Architect workflow: Researching → Done (done, closes issue), Researching → Refining (blocked).
  */
-import { jsonResult } from "openclaw/plugin-sdk";
+import { jsonResult } from "../../json-result.js";
 import { readFile } from "node:fs/promises";
 import { join } from "node:path";
 import type { ToolContext } from "../../types.js";

--- a/lib/tools/worker/work-finish.ts
+++ b/lib/tools/worker/work-finish.ts
@@ -7,7 +7,6 @@
  * All roles (including architect) use the standard pipeline via executeCompletion.
  * Architect workflow: Researching → Done (done, closes issue), Researching → Refining (blocked).
  */
-import { jsonResult } from "openclaw/plugin-sdk";
 import { readFile } from "node:fs/promises";
 import { join } from "node:path";
 import type { ToolContext } from "../../types.js";
@@ -16,7 +15,7 @@ import { getRoleWorker, resolveRepoPath, findSlotByIssue } from "../../projects/
 import { executeCompletion, getRule } from "../../services/pipeline.js";
 import { log as auditLog } from "../../audit.js";
 import { DATA_DIR } from "../../setup/migrate-layout.js";
-import { requireWorkspaceDir, resolveChannelId, resolveProject, resolveProvider } from "../helpers.js";
+import { jsonResult, requireWorkspaceDir, resolveChannelId, resolveProject, resolveProvider } from "../helpers.js";
 import { getAllRoleIds, isValidResult, getCompletionResults } from "../../roles/index.js";
 import { loadWorkflow } from "../../workflow/index.js";
 

--- a/lib/workflow/labels.ts
+++ b/lib/workflow/labels.ts
@@ -44,8 +44,8 @@ export function getNotifyLabel(channel: string, nameOrIndex: string): string {
  */
 export function resolveNotifyChannel(
   issueLabels: string[],
-  channels: Array<{ channelId: string; channel: string; name?: string; accountId?: string }>,
-): { channelId: string; channel: string; accountId?: string } | undefined {
+  channels: Array<{ channelId: string; channel: string; name?: string; accountId?: string; messageThreadId?: number }>,
+): { channelId: string; channel: string; accountId?: string; messageThreadId?: number } | undefined {
   const notifyLabel = issueLabels.find((l) => l.startsWith(NOTIFY_LABEL_PREFIX));
   if (notifyLabel) {
     const value = notifyLabel.slice(NOTIFY_LABEL_PREFIX.length);

--- a/package-lock.json
+++ b/package-lock.json
@@ -949,6 +949,160 @@
         "sisteransi": "^1.0.5"
       }
     },
+    "node_modules/@cloudflare/workers-types": {
+      "version": "4.20260120.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20260120.0.tgz",
+      "integrity": "sha512-B8pueG+a5S+mdK3z8oKu1ShcxloZ7qWb68IEyLLaepvdryIbNC7JVPcY0bWsjS56UQVKc5fnyRge3yZIwc9bxw==",
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "peer": true
+    },
+    "node_modules/@discordjs/node-pre-gyp": {
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/@discordjs/node-pre-gyp/-/node-pre-gyp-0.4.5.tgz",
+      "integrity": "sha512-YJOVVZ545x24mHzANfYoy0BJX5PDyeZlpiJjDkUBM/V/Ao7TFX9lcUvCN4nr0tbr5ubeaXxtEBILUrHtTphVeQ==",
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "detect-libc": "^2.0.0",
+        "https-proxy-agent": "^5.0.0",
+        "make-dir": "^3.1.0",
+        "node-fetch": "^2.6.7",
+        "nopt": "^5.0.0",
+        "npmlog": "^5.0.1",
+        "rimraf": "^3.0.2",
+        "semver": "^7.3.5",
+        "tar": "^6.1.11"
+      },
+      "bin": {
+        "node-pre-gyp": "bin/node-pre-gyp"
+      }
+    },
+    "node_modules/@discordjs/node-pre-gyp/node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/@discordjs/node-pre-gyp/node_modules/chownr": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
+      "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
+      "license": "ISC",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@discordjs/node-pre-gyp/node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/@discordjs/node-pre-gyp/node_modules/minipass": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz",
+      "integrity": "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==",
+      "license": "ISC",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@discordjs/node-pre-gyp/node_modules/minizlib": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
+      "integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "minipass": "^3.0.0",
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@discordjs/node-pre-gyp/node_modules/minizlib/node_modules/minipass": {
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+      "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+      "license": "ISC",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@discordjs/node-pre-gyp/node_modules/tar": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-6.2.1.tgz",
+      "integrity": "sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==",
+      "deprecated": "Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "license": "ISC",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "chownr": "^2.0.0",
+        "fs-minipass": "^2.0.0",
+        "minipass": "^5.0.0",
+        "minizlib": "^2.1.1",
+        "mkdirp": "^1.0.3",
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@discordjs/node-pre-gyp/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "license": "ISC",
+      "optional": true,
+      "peer": true
+    },
+    "node_modules/@discordjs/opus": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@discordjs/opus/-/opus-0.10.0.tgz",
+      "integrity": "sha512-HHEnSNrSPmFEyndRdQBJN2YE6egyXS9JUnJWyP6jficK0Y+qKMEZXyYTgmzpjrxXP1exM/hKaNP7BRBUEWkU5w==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@discordjs/node-pre-gyp": "^0.4.5",
+        "node-addon-api": "^8.1.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/@discordjs/voice": {
       "version": "0.19.0",
       "resolved": "https://registry.npmjs.org/@discordjs/voice/-/voice-0.19.0.tgz",
@@ -994,6 +1148,40 @@
         "opusscript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.8.1.tgz",
+      "integrity": "sha512-AvT9QFpxK0Zd8J0jopedNm+w/2fIzvtPKPjqyw9jwvBaReTTqPBk9Hixaz7KbjimP+QNz605/XnjFcDAL2pqBg==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.1.0",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.8.1.tgz",
+      "integrity": "sha512-mehfKSMWjjNol8659Z8KxEMrdSJDDot5SXMq00dM8BN4o+CLNXQ0xH2V7EchNHV4RmbZLmmPdEaXZc5H2FXmDg==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.1.0.tgz",
+      "integrity": "sha512-WI0DdZ8xFSbgMjR1sFsKABJ/C5OnRrjT06JXbZKexJGrDuPTzZdDYfFlsgcCXCyf+suG5QU2e/y1Wo2V/OapLQ==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -1534,6 +1722,20 @@
         "ciao-bcs": "lib/bonjour-conformance-testing.js"
       }
     },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.9",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.9.tgz",
+      "integrity": "sha512-vHL6w3ecZsky+8P5MD+eFfaGTyCeOHUIFYMGpQGbrBTSmNNoxv0if69rEZ5giu36weC5saFuznL411gRX7bJDw==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
     "node_modules/@huggingface/jinja": {
       "version": "0.5.5",
       "resolved": "https://registry.npmjs.org/@huggingface/jinja/-/jinja-0.5.5.tgz",
@@ -1552,6 +1754,534 @@
       "peer": true,
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@img/sharp-darwin-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.5.tgz",
+      "integrity": "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-darwin-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.5.tgz",
+      "integrity": "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.2.4.tgz",
+      "integrity": "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true,
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.4.tgz",
+      "integrity": "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true,
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.4.tgz",
+      "integrity": "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==",
+      "cpu": [
+        "arm"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.4.tgz",
+      "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-ppc64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.2.4.tgz",
+      "integrity": "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-riscv64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.2.4.tgz",
+      "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-s390x": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.2.4.tgz",
+      "integrity": "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.4.tgz",
+      "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.2.4.tgz",
+      "integrity": "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.4.tgz",
+      "integrity": "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.5.tgz",
+      "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
+      "cpu": [
+        "arm"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.5.tgz",
+      "integrity": "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-ppc64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.34.5.tgz",
+      "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-ppc64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-riscv64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.34.5.tgz",
+      "integrity": "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-riscv64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-s390x": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.34.5.tgz",
+      "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
+      "cpu": [
+        "s390x"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-s390x": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.5.tgz",
+      "integrity": "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.5.tgz",
+      "integrity": "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.5.tgz",
+      "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-wasm32": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.34.5.tgz",
+      "integrity": "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==",
+      "cpu": [
+        "wasm32"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@emnapi/runtime": "^1.7.0"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.5.tgz",
+      "integrity": "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-ia32": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.34.5.tgz",
+      "integrity": "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.5.tgz",
+      "integrity": "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
       }
     },
     "node_modules/@isaacs/cliui": {
@@ -1733,6 +2463,295 @@
         "@lydell/node-pty-win32-x64": "1.2.0-beta.3"
       }
     },
+    "node_modules/@lydell/node-pty-darwin-arm64": {
+      "version": "1.2.0-beta.3",
+      "resolved": "https://registry.npmjs.org/@lydell/node-pty-darwin-arm64/-/node-pty-darwin-arm64-1.2.0-beta.3.tgz",
+      "integrity": "sha512-owcv+e1/OSu3bf9ZBdUQqJsQF888KyuSIiPYFNn0fLhgkhm9F3Pvha76Kj5mCPnodf7hh3suDe7upw7GPRXftQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true
+    },
+    "node_modules/@lydell/node-pty-darwin-x64": {
+      "version": "1.2.0-beta.3",
+      "resolved": "https://registry.npmjs.org/@lydell/node-pty-darwin-x64/-/node-pty-darwin-x64-1.2.0-beta.3.tgz",
+      "integrity": "sha512-k38O+UviWrWdxtqZBBc/D8NJU11Rey8Y2YMwSWNxLv3eXZZdF5IVpbBkI/2RmLsV5nCcciqLPbukxeZnEfPlwA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true
+    },
+    "node_modules/@lydell/node-pty-linux-arm64": {
+      "version": "1.2.0-beta.3",
+      "resolved": "https://registry.npmjs.org/@lydell/node-pty-linux-arm64/-/node-pty-linux-arm64-1.2.0-beta.3.tgz",
+      "integrity": "sha512-HUwRpGu3O+4sv9DAQFKnyW5LYhyYu2SDUa/bdFO/t4dIFCM4uDJEq47wfRM7+aYtJTi1b3lakN8SlWeuFQqJQQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true
+    },
+    "node_modules/@lydell/node-pty-linux-x64": {
+      "version": "1.2.0-beta.3",
+      "resolved": "https://registry.npmjs.org/@lydell/node-pty-linux-x64/-/node-pty-linux-x64-1.2.0-beta.3.tgz",
+      "integrity": "sha512-+RRY0PoCUeQaCvPR7/UnkGbxulwbFtoTWJfe+o4T1RcNtngrgaI55I9nl8CD8uqhGrB3smKuyvPM5UtwGhASUw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true
+    },
+    "node_modules/@lydell/node-pty-win32-arm64": {
+      "version": "1.2.0-beta.3",
+      "resolved": "https://registry.npmjs.org/@lydell/node-pty-win32-arm64/-/node-pty-win32-arm64-1.2.0-beta.3.tgz",
+      "integrity": "sha512-UEDd9ASp2M3iIYpIzfmfBlpyn4+K1G4CAjYcHWStptCkefoSVXWTiUBIa1KjBjZi3/xmsHIDpBEYTkGWuvLt2Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true
+    },
+    "node_modules/@lydell/node-pty-win32-x64": {
+      "version": "1.2.0-beta.3",
+      "resolved": "https://registry.npmjs.org/@lydell/node-pty-win32-x64/-/node-pty-win32-x64-1.2.0-beta.3.tgz",
+      "integrity": "sha512-TpdqSFYx7/Rj+68tuP6F/lkRYrHCYAIJgaS1bx3SctTkb5QAQCFwOKHd4xlsivmEOMT2LdhkJggPxwX9PAO5pQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true
+    },
+    "node_modules/@mariozechner/clipboard": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard/-/clipboard-0.3.2.tgz",
+      "integrity": "sha512-IHQpksNjo7EAtGuHFU+tbWDp5LarH3HU/8WiB9O70ZEoBPHOg0/6afwSLK0QyNMMmx4Bpi/zl6+DcBXe95nWYA==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">= 10"
+      },
+      "optionalDependencies": {
+        "@mariozechner/clipboard-darwin-arm64": "0.3.2",
+        "@mariozechner/clipboard-darwin-universal": "0.3.2",
+        "@mariozechner/clipboard-darwin-x64": "0.3.2",
+        "@mariozechner/clipboard-linux-arm64-gnu": "0.3.2",
+        "@mariozechner/clipboard-linux-arm64-musl": "0.3.2",
+        "@mariozechner/clipboard-linux-riscv64-gnu": "0.3.2",
+        "@mariozechner/clipboard-linux-x64-gnu": "0.3.2",
+        "@mariozechner/clipboard-linux-x64-musl": "0.3.2",
+        "@mariozechner/clipboard-win32-arm64-msvc": "0.3.2",
+        "@mariozechner/clipboard-win32-x64-msvc": "0.3.2"
+      }
+    },
+    "node_modules/@mariozechner/clipboard-darwin-arm64": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-darwin-arm64/-/clipboard-darwin-arm64-0.3.2.tgz",
+      "integrity": "sha512-uBf6K7Je1ihsgvmWxA8UCGCeI+nbRVRXoarZdLjl6slz94Zs1tNKFZqx7aCI5O1i3e0B6ja82zZ06BWrl0MCVw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@mariozechner/clipboard-darwin-universal": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-darwin-universal/-/clipboard-darwin-universal-0.3.2.tgz",
+      "integrity": "sha512-mxSheKTW2U9LsBdXy0SdmdCAE5HqNS9QUmpNHLnfJ+SsbFKALjEZc5oRrVMXxGQSirDvYf5bjmRyT0QYYonnlg==",
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@mariozechner/clipboard-darwin-x64": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-darwin-x64/-/clipboard-darwin-x64-0.3.2.tgz",
+      "integrity": "sha512-U1BcVEoidvwIp95+HJswSW+xr28EQiHR7rZjH6pn8Sja5yO4Yoe3yCN0Zm8Lo72BbSOK/fTSq0je7CJpaPCspg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@mariozechner/clipboard-linux-arm64-gnu": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-arm64-gnu/-/clipboard-linux-arm64-gnu-0.3.2.tgz",
+      "integrity": "sha512-BsinwG3yWTIjdgNCxsFlip7LkfwPk+ruw/aFCXHUg/fb5XC/Ksp+YMQ7u0LUtiKzIv/7LMXgZInJQH6gxbAaqQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@mariozechner/clipboard-linux-arm64-musl": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-arm64-musl/-/clipboard-linux-arm64-musl-0.3.2.tgz",
+      "integrity": "sha512-0/Gi5Xq2V6goXBop19ePoHvXsmJD9SzFlO3S+d6+T2b+BlPcpOu3Oa0wTjl+cZrLAAEzA86aPNBI+VVAFDFPKw==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@mariozechner/clipboard-linux-riscv64-gnu": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-riscv64-gnu/-/clipboard-linux-riscv64-gnu-0.3.2.tgz",
+      "integrity": "sha512-2AFFiXB24qf0zOZsxI1GJGb9wQGlOJyN6UwoXqmKS3dpQi/l6ix30IzDDA4c4ZcCcx4D+9HLYXhC1w7Sov8pXA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@mariozechner/clipboard-linux-x64-gnu": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-x64-gnu/-/clipboard-linux-x64-gnu-0.3.2.tgz",
+      "integrity": "sha512-v6fVnsn7WMGg73Dab8QMwyFce7tzGfgEixKgzLP8f1GJqkJZi5zO4k4FOHzSgUufgLil63gnxvMpjWkgfeQN7A==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@mariozechner/clipboard-linux-x64-musl": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-x64-musl/-/clipboard-linux-x64-musl-0.3.2.tgz",
+      "integrity": "sha512-xVUtnoMQ8v2JVyfJLKKXACA6avdnchdbBkTsZs8BgJQo29qwCp5NIHAUO8gbJ40iaEGToW5RlmVk2M9V0HsHEw==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@mariozechner/clipboard-win32-arm64-msvc": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-win32-arm64-msvc/-/clipboard-win32-arm64-msvc-0.3.2.tgz",
+      "integrity": "sha512-AEgg95TNi8TGgak2wSXZkXKCvAUTjWoU1Pqb0ON7JHrX78p616XUFNTJohtIon3e0w6k0pYPZeCuqRCza/Tqeg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@mariozechner/clipboard-win32-x64-msvc": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-win32-x64-msvc/-/clipboard-win32-x64-msvc-0.3.2.tgz",
+      "integrity": "sha512-tGRuYpZwDOD7HBrCpyRuhGnHHSCknELvqwKKUG4JSfSB7JIU7LKRh6zx6fMUOQd8uISK35TjFg5UcNih+vJhFA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/@mariozechner/jiti": {
       "version": "2.6.5",
       "resolved": "https://registry.npmjs.org/@mariozechner/jiti/-/jiti-2.6.5.tgz",
@@ -1899,6 +2918,512 @@
         "@napi-rs/canvas-linux-x64-musl": "0.1.95",
         "@napi-rs/canvas-win32-arm64-msvc": "0.1.95",
         "@napi-rs/canvas-win32-x64-msvc": "0.1.95"
+      }
+    },
+    "node_modules/@napi-rs/canvas-android-arm64": {
+      "version": "0.1.95",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-android-arm64/-/canvas-android-arm64-0.1.95.tgz",
+      "integrity": "sha512-SqTh0wsYbetckMXEvHqmR7HKRJujVf1sYv1xdlhkifg6TlCSysz1opa49LlS3+xWuazcQcfRfmhA07HxxxGsAA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-darwin-arm64": {
+      "version": "0.1.95",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-arm64/-/canvas-darwin-arm64-0.1.95.tgz",
+      "integrity": "sha512-F7jT0Syu+B9DGBUBcMk3qCRIxAWiDXmvEjamwbYfbZl7asI1pmXZUnCOoIu49Wt0RNooToYfRDxU9omD6t5Xuw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-darwin-x64": {
+      "version": "0.1.95",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-x64/-/canvas-darwin-x64-0.1.95.tgz",
+      "integrity": "sha512-54eb2Ho15RDjYGXO/harjRznBrAvu+j5nQ85Z4Qd6Qg3slR8/Ja+Yvvy9G4yo7rdX6NR9GPkZeSTf2UcKXwaXw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-arm-gnueabihf": {
+      "version": "0.1.95",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm-gnueabihf/-/canvas-linux-arm-gnueabihf-0.1.95.tgz",
+      "integrity": "sha512-hYaLCSLx5bmbnclzQc3ado3PgZ66blJWzjXp0wJmdwpr/kH+Mwhj6vuytJIomgksyJoCdIqIa4N6aiqBGJtJ5Q==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-arm64-gnu": {
+      "version": "0.1.95",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-gnu/-/canvas-linux-arm64-gnu-0.1.95.tgz",
+      "integrity": "sha512-J7VipONahKsmScPZsipHVQBqpbZx4favaD8/enWzzlGcjiwycOoymL7f4tNeqdjK0su19bDOUt6mjp9gsPWYlw==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-arm64-musl": {
+      "version": "0.1.95",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-musl/-/canvas-linux-arm64-musl-0.1.95.tgz",
+      "integrity": "sha512-PXy0UT1J/8MPG8UAkWp6Fd51ZtIZINFzIjGH909JjQrtCuJf3X6nanHYdz1A+Wq9o4aoPAw1YEUpFS1lelsVlg==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-riscv64-gnu": {
+      "version": "0.1.95",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-riscv64-gnu/-/canvas-linux-riscv64-gnu-0.1.95.tgz",
+      "integrity": "sha512-2IzCkW2RHRdcgF9W5/plHvYFpc6uikyjMb5SxjqmNxfyDFz9/HB89yhi8YQo0SNqrGRI7yBVDec7Pt+uMyRWsg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-x64-gnu": {
+      "version": "0.1.95",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-gnu/-/canvas-linux-x64-gnu-0.1.95.tgz",
+      "integrity": "sha512-OV/ol/OtcUr4qDhQg8G7SdViZX8XyQeKpPsVv/j3+7U178FGoU4M+yIocdVo1ih/A8GQ63+LjF4jDoEjaVU8Pw==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-x64-musl": {
+      "version": "0.1.95",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-musl/-/canvas-linux-x64-musl-0.1.95.tgz",
+      "integrity": "sha512-Z5KzqBK/XzPz5+SFHKz7yKqClEQ8pOiEDdgk5SlphBLVNb8JFIJkxhtJKSvnJyHh2rjVgiFmvtJzMF0gNwwKyQ==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-win32-arm64-msvc": {
+      "version": "0.1.95",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-win32-arm64-msvc/-/canvas-win32-arm64-msvc-0.1.95.tgz",
+      "integrity": "sha512-aj0YbRpe8qVJ4OzMsK7NfNQePgcf9zkGFzNZ9mSuaxXzhpLHmlF2GivNdCdNOg8WzA/NxV6IU4c5XkXadUMLeA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-win32-x64-msvc": {
+      "version": "0.1.95",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-win32-x64-msvc/-/canvas-win32-x64-msvc-0.1.95.tgz",
+      "integrity": "sha512-GA8leTTCfdjuHi8reICTIxU0081PhXvl3lzIniLUjeLACx9GubUiyzkwFb+oyeKLS5IAGZFLKnzAf4wm2epRlA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.1.tgz",
+      "integrity": "sha512-p64ah1M1ld8xjWv3qbvFwHiFVWrq1yFvV4f7w+mzaqiR4IlSgkqhcRdHwsGgomwzBH51sRY4NEowLxnaBjcW/A==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1",
+        "@tybys/wasm-util": "^0.10.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@node-llama-cpp/linux-arm64": {
+      "version": "3.16.2",
+      "resolved": "https://registry.npmjs.org/@node-llama-cpp/linux-arm64/-/linux-arm64-3.16.2.tgz",
+      "integrity": "sha512-CxzgPsS84wL3W5sZRgxP3c9iJKEW+USrak1SmX6EAJxW/v9QGzehvT6W/aR1FyfidiIyQtOp3ga0Gg/9xfJPGw==",
+      "cpu": [
+        "arm64",
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@node-llama-cpp/linux-armv7l": {
+      "version": "3.16.2",
+      "resolved": "https://registry.npmjs.org/@node-llama-cpp/linux-armv7l/-/linux-armv7l-3.16.2.tgz",
+      "integrity": "sha512-9G6W/MkQ/DLwGmpcj143NQ50QJg5gQZfzVf5RYx77VczBqhgwkgYHILekYrOs4xanOeqeJ8jnOnQQSp1YaJZUg==",
+      "cpu": [
+        "arm",
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@node-llama-cpp/linux-x64": {
+      "version": "3.16.2",
+      "resolved": "https://registry.npmjs.org/@node-llama-cpp/linux-x64/-/linux-x64-3.16.2.tgz",
+      "integrity": "sha512-OXYf8rVfoDyvN+YrfKk8F9An9a5GOxVIM8OcR1U911tc0oRNf8yfJrQ8KrM75R26gwq0Y6YZwVTP0vRCInwWOw==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@node-llama-cpp/linux-x64-cuda": {
+      "version": "3.16.2",
+      "resolved": "https://registry.npmjs.org/@node-llama-cpp/linux-x64-cuda/-/linux-x64-cuda-3.16.2.tgz",
+      "integrity": "sha512-LTBQFqjin7tyrLNJz0XWTB5QAHDsZV71/qiiRRjXdBKSZHVVaPLfdgxypGu7ggPeBNsv+MckRXdlH5C7yMtE4A==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@node-llama-cpp/linux-x64-cuda-ext": {
+      "version": "3.16.2",
+      "resolved": "https://registry.npmjs.org/@node-llama-cpp/linux-x64-cuda-ext/-/linux-x64-cuda-ext-3.16.2.tgz",
+      "integrity": "sha512-47d9myCJauZyzAlN7IK1eIt/4CcBMslF+yHy4q+yJotD/RV/S6qRpK2kGn+ybtdVjkPGNCoPkHKcyla9iIVjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@node-llama-cpp/linux-x64-vulkan": {
+      "version": "3.16.2",
+      "resolved": "https://registry.npmjs.org/@node-llama-cpp/linux-x64-vulkan/-/linux-x64-vulkan-3.16.2.tgz",
+      "integrity": "sha512-HDLAw4ZhwJuhKuF6n4x520yZXAQZahUOXtCGvPubjfpmIOElKrfDvCVlRsthAP0JwcwINzIQlVys3boMIXfBgw==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@node-llama-cpp/mac-arm64-metal": {
+      "version": "3.16.2",
+      "resolved": "https://registry.npmjs.org/@node-llama-cpp/mac-arm64-metal/-/mac-arm64-metal-3.16.2.tgz",
+      "integrity": "sha512-nEZ74qB0lUohF88yR741YUrUqz/qD+FJFzUTHj0FwxAynSZCjvwtzEDtavRlh3qd3yLD/0ChNn00/RQ54ISImw==",
+      "cpu": [
+        "arm64",
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@node-llama-cpp/mac-x64": {
+      "version": "3.16.2",
+      "resolved": "https://registry.npmjs.org/@node-llama-cpp/mac-x64/-/mac-x64-3.16.2.tgz",
+      "integrity": "sha512-BjA+DgeDt+kRxVMV6kChb9XVXm7U5b90jUif7Z/s6ZXtOOnV6exrTM2W09kbSqAiNhZmctcVY83h2dwNTZ/yIw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@node-llama-cpp/win-arm64": {
+      "version": "3.16.2",
+      "resolved": "https://registry.npmjs.org/@node-llama-cpp/win-arm64/-/win-arm64-3.16.2.tgz",
+      "integrity": "sha512-XHNFQzUjYODtkZjIn4NbQVrBtGB9RI9TpisiALryqfrIqagQmjBh6dmxZWlt5uduKAfT7M2/2vrABGR490FACA==",
+      "cpu": [
+        "arm64",
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@node-llama-cpp/win-x64": {
+      "version": "3.16.2",
+      "resolved": "https://registry.npmjs.org/@node-llama-cpp/win-x64/-/win-x64-3.16.2.tgz",
+      "integrity": "sha512-etrivzbyLNVhZlUosFW8JSL0OSiuKQf9qcI3dNdehD907sHquQbBJrG7lXcdL6IecvXySp3oAwCkM87VJ0b3Fg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@node-llama-cpp/win-x64-cuda": {
+      "version": "3.16.2",
+      "resolved": "https://registry.npmjs.org/@node-llama-cpp/win-x64-cuda/-/win-x64-cuda-3.16.2.tgz",
+      "integrity": "sha512-jStDELHrU3rKQMOk5Hs5bWEazyjE2hzHwpNf6SblOpaGkajM/HJtxEZoL0mLHJx5qeXs4oOVkr7AzuLy0WPpNA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@node-llama-cpp/win-x64-cuda-ext": {
+      "version": "3.16.2",
+      "resolved": "https://registry.npmjs.org/@node-llama-cpp/win-x64-cuda-ext/-/win-x64-cuda-ext-3.16.2.tgz",
+      "integrity": "sha512-sdv4Kzn9bOQWNBRvw6B/zcn8dQRfZhjIHv5AfDBIOfRlSCgjebFpBeYUoU4wZPpjr3ISwcqO5MEWsw+AbUdV3Q==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@node-llama-cpp/win-x64-vulkan": {
+      "version": "3.16.2",
+      "resolved": "https://registry.npmjs.org/@node-llama-cpp/win-x64-vulkan/-/win-x64-vulkan-3.16.2.tgz",
+      "integrity": "sha512-9xuHFCOhCQjZgQSFrk79EuSKn9nGWt/SAq/3wujQSQLtgp8jGdtZgwcmuDUoemInf10en2dcOmEt7t8dQdC3XA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@octokit/app": {
@@ -2275,6 +3800,17 @@
       "license": "MIT",
       "peer": true
     },
+    "node_modules/@pkgjs/parseargs": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/@protobufjs/aspromise": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
@@ -2348,6 +3884,175 @@
       "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==",
       "license": "BSD-3-Clause",
       "peer": true
+    },
+    "node_modules/@reflink/reflink": {
+      "version": "0.1.19",
+      "resolved": "https://registry.npmjs.org/@reflink/reflink/-/reflink-0.1.19.tgz",
+      "integrity": "sha512-DmCG8GzysnCZ15bres3N5AHCmwBwYgp0As6xjhQ47rAUTUXxJiK+lLUxaGsX3hd/30qUpVElh05PbGuxRPgJwA==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">= 10"
+      },
+      "optionalDependencies": {
+        "@reflink/reflink-darwin-arm64": "0.1.19",
+        "@reflink/reflink-darwin-x64": "0.1.19",
+        "@reflink/reflink-linux-arm64-gnu": "0.1.19",
+        "@reflink/reflink-linux-arm64-musl": "0.1.19",
+        "@reflink/reflink-linux-x64-gnu": "0.1.19",
+        "@reflink/reflink-linux-x64-musl": "0.1.19",
+        "@reflink/reflink-win32-arm64-msvc": "0.1.19",
+        "@reflink/reflink-win32-x64-msvc": "0.1.19"
+      }
+    },
+    "node_modules/@reflink/reflink-darwin-arm64": {
+      "version": "0.1.19",
+      "resolved": "https://registry.npmjs.org/@reflink/reflink-darwin-arm64/-/reflink-darwin-arm64-0.1.19.tgz",
+      "integrity": "sha512-ruy44Lpepdk1FqDz38vExBY/PVUsjxZA+chd9wozjUH9JjuDT/HEaQYA6wYN9mf041l0yLVar6BCZuWABJvHSA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@reflink/reflink-darwin-x64": {
+      "version": "0.1.19",
+      "resolved": "https://registry.npmjs.org/@reflink/reflink-darwin-x64/-/reflink-darwin-x64-0.1.19.tgz",
+      "integrity": "sha512-By85MSWrMZa+c26TcnAy8SDk0sTUkYlNnwknSchkhHpGXOtjNDUOxJE9oByBnGbeuIE1PiQsxDG3Ud+IVV9yuA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@reflink/reflink-linux-arm64-gnu": {
+      "version": "0.1.19",
+      "resolved": "https://registry.npmjs.org/@reflink/reflink-linux-arm64-gnu/-/reflink-linux-arm64-gnu-0.1.19.tgz",
+      "integrity": "sha512-7P+er8+rP9iNeN+bfmccM4hTAaLP6PQJPKWSA4iSk2bNvo6KU6RyPgYeHxXmzNKzPVRcypZQTpFgstHam6maVg==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@reflink/reflink-linux-arm64-musl": {
+      "version": "0.1.19",
+      "resolved": "https://registry.npmjs.org/@reflink/reflink-linux-arm64-musl/-/reflink-linux-arm64-musl-0.1.19.tgz",
+      "integrity": "sha512-37iO/Dp6m5DDaC2sf3zPtx/hl9FV3Xze4xoYidrxxS9bgP3S8ALroxRK6xBG/1TtfXKTvolvp+IjrUU6ujIGmA==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@reflink/reflink-linux-x64-gnu": {
+      "version": "0.1.19",
+      "resolved": "https://registry.npmjs.org/@reflink/reflink-linux-x64-gnu/-/reflink-linux-x64-gnu-0.1.19.tgz",
+      "integrity": "sha512-jbI8jvuYCaA3MVUdu8vLoLAFqC+iNMpiSuLbxlAgg7x3K5bsS8nOpTRnkLF7vISJ+rVR8W+7ThXlXlUQ93ulkw==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@reflink/reflink-linux-x64-musl": {
+      "version": "0.1.19",
+      "resolved": "https://registry.npmjs.org/@reflink/reflink-linux-x64-musl/-/reflink-linux-x64-musl-0.1.19.tgz",
+      "integrity": "sha512-e9FBWDe+lv7QKAwtKOt6A2W/fyy/aEEfr0g6j/hWzvQcrzHCsz07BNQYlNOjTfeytrtLU7k449H1PI95jA4OjQ==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@reflink/reflink-win32-arm64-msvc": {
+      "version": "0.1.19",
+      "resolved": "https://registry.npmjs.org/@reflink/reflink-win32-arm64-msvc/-/reflink-win32-arm64-msvc-0.1.19.tgz",
+      "integrity": "sha512-09PxnVIQcd+UOn4WAW73WU6PXL7DwGS6wPlkMhMg2zlHHG65F3vHepOw06HFCq+N42qkaNAc8AKIabWvtk6cIQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@reflink/reflink-win32-x64-msvc": {
+      "version": "0.1.19",
+      "resolved": "https://registry.npmjs.org/@reflink/reflink-win32-x64-msvc/-/reflink-win32-x64-msvc-0.1.19.tgz",
+      "integrity": "sha512-E//yT4ni2SyhwP8JRjVGWr3cbnhWDiPLgnQ66qqaanjjnMiu3O/2tjCPQXlcGc/DEYofpDc9fvhv6tALQsMV9w==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 10"
+      }
     },
     "node_modules/@silvia-odwyer/photon-node": {
       "version": "0.3.4",
@@ -3200,6 +4905,256 @@
         "@snazzah/davey-win32-x64-msvc": "0.1.10"
       }
     },
+    "node_modules/@snazzah/davey-android-arm-eabi": {
+      "version": "0.1.10",
+      "resolved": "https://registry.npmjs.org/@snazzah/davey-android-arm-eabi/-/davey-android-arm-eabi-0.1.10.tgz",
+      "integrity": "sha512-7bwHxSNEI2wVXOT6xnmpnO9SHb2xwAnf9oEdL45dlfVHTgU1Okg5rwGwRvZ2aLVFFbTyecfC8EVZyhpyTkjLSw==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@snazzah/davey-android-arm64": {
+      "version": "0.1.10",
+      "resolved": "https://registry.npmjs.org/@snazzah/davey-android-arm64/-/davey-android-arm64-0.1.10.tgz",
+      "integrity": "sha512-68WUf2LQwQTP9MgPcCqTWwJztJSIk0keGfF2Y/b+MihSDh29fYJl7C0rbz69aUrVCvCC2lYkB/46P8X1kBz7yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@snazzah/davey-darwin-arm64": {
+      "version": "0.1.10",
+      "resolved": "https://registry.npmjs.org/@snazzah/davey-darwin-arm64/-/davey-darwin-arm64-0.1.10.tgz",
+      "integrity": "sha512-nYC+DWCGUC1jUGEenCNQE/jJpL/02m0ebY/NvTCQbul5ktI/ShVzgA3kzssEhZvhf6jbH048Rs39wDhp/b24Jg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@snazzah/davey-darwin-x64": {
+      "version": "0.1.10",
+      "resolved": "https://registry.npmjs.org/@snazzah/davey-darwin-x64/-/davey-darwin-x64-0.1.10.tgz",
+      "integrity": "sha512-0q5Rrcs+O9sSSnPX+A3R3djEQs2nTAtMe5N3lApO6lZas/QNMl6wkEWCvTbDc2cfAYBMSk2jgc1awlRXi4LX3Q==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@snazzah/davey-freebsd-x64": {
+      "version": "0.1.10",
+      "resolved": "https://registry.npmjs.org/@snazzah/davey-freebsd-x64/-/davey-freebsd-x64-0.1.10.tgz",
+      "integrity": "sha512-/Gq5YDD6Oz8iBqVJLswUnetCv9JCRo1quYX5ujzpAG8zPCNItZo4g4h5p9C+h4Yoay2quWBYhoaVqQKT96bm8g==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@snazzah/davey-linux-arm-gnueabihf": {
+      "version": "0.1.10",
+      "resolved": "https://registry.npmjs.org/@snazzah/davey-linux-arm-gnueabihf/-/davey-linux-arm-gnueabihf-0.1.10.tgz",
+      "integrity": "sha512-0Z7Vrt0WIbgxws9CeHB9qlueYJlvltI44rUuZmysdi70UcHGxlr7nE3MnzYCr9nRWRegohn8EQPWHMKMDJH2GA==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@snazzah/davey-linux-arm64-gnu": {
+      "version": "0.1.10",
+      "resolved": "https://registry.npmjs.org/@snazzah/davey-linux-arm64-gnu/-/davey-linux-arm64-gnu-0.1.10.tgz",
+      "integrity": "sha512-xhZQycn4QB+qXhqm/QmZ+kb9MHMXcbjjoPfvcIL4WMQXFG/zUWHW8EiBk7ZTEGMOpeab3F9D1+MlgumglYByUQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@snazzah/davey-linux-arm64-musl": {
+      "version": "0.1.10",
+      "resolved": "https://registry.npmjs.org/@snazzah/davey-linux-arm64-musl/-/davey-linux-arm64-musl-0.1.10.tgz",
+      "integrity": "sha512-pudzQCP9rZItwW4qHHvciMwtNd9kWH4l73g6Id1LRpe6sc8jiFBV7W+YXITj2PZbI0by6XPfkRP6Dk5IkGOuAw==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@snazzah/davey-linux-x64-gnu": {
+      "version": "0.1.10",
+      "resolved": "https://registry.npmjs.org/@snazzah/davey-linux-x64-gnu/-/davey-linux-x64-gnu-0.1.10.tgz",
+      "integrity": "sha512-DC8qRmk+xJEFNqjxKB46cETKeDQqgUqE5p39KXS2k6Vl/XTi8pw8pXOxrPfYte5neoqlWAVQzbxuLnwpyRJVEQ==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@snazzah/davey-linux-x64-musl": {
+      "version": "0.1.10",
+      "resolved": "https://registry.npmjs.org/@snazzah/davey-linux-x64-musl/-/davey-linux-x64-musl-0.1.10.tgz",
+      "integrity": "sha512-wPR5/2QmsF7sR0WUaCwbk4XI3TLcxK9PVK8mhgcAYyuRpbhcVgNGWXs8ulcyMSXve5pFRJAFAuMTGCEb014peg==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@snazzah/davey-wasm32-wasi": {
+      "version": "0.1.10",
+      "resolved": "https://registry.npmjs.org/@snazzah/davey-wasm32-wasi/-/davey-wasm32-wasi-0.1.10.tgz",
+      "integrity": "sha512-SfQavU+eKTDbRmPeLRodrVSfsWq25PYTmH1nIZW3B27L6IkijzjXZZuxiU1ZG1gdI5fB7mwXrOTtx34t+vAG7Q==",
+      "cpu": [
+        "wasm32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@napi-rs/wasm-runtime": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@snazzah/davey-win32-arm64-msvc": {
+      "version": "0.1.10",
+      "resolved": "https://registry.npmjs.org/@snazzah/davey-win32-arm64-msvc/-/davey-win32-arm64-msvc-0.1.10.tgz",
+      "integrity": "sha512-Raafk53smYs67wZCY9bQXHXzbaiRMS5QCdjTdin3D9fF5A06T/0Zv1z7/YnaN+O3GSL/Ou3RvynF7SziToYiFQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@snazzah/davey-win32-ia32-msvc": {
+      "version": "0.1.10",
+      "resolved": "https://registry.npmjs.org/@snazzah/davey-win32-ia32-msvc/-/davey-win32-ia32-msvc-0.1.10.tgz",
+      "integrity": "sha512-pAs43l/DiZ+icqBwxIwNePzuYxFM1ZblVuf7t6vwwSLxvova7vnREnU7qDVjbc5/YTUHOsqYy3S6TpZMzDo2lw==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@snazzah/davey-win32-x64-msvc": {
+      "version": "0.1.10",
+      "resolved": "https://registry.npmjs.org/@snazzah/davey-win32-x64-msvc/-/davey-win32-x64-msvc-0.1.10.tgz",
+      "integrity": "sha512-kr6148VVBoUT4CtD+5hYshTFRny7R/xQZxXFhFc0fYjtmdMVM8Px9M91olg1JFNxuNzdfMfTufR58Q3wfBocug==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/@tinyhttp/content-disposition": {
       "version": "2.2.4",
       "resolved": "https://registry.npmjs.org/@tinyhttp/content-disposition/-/content-disposition-2.2.4.tgz",
@@ -3246,6 +5201,17 @@
       "license": "MIT",
       "peer": true
     },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
+      "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@types/aws-lambda": {
       "version": "8.10.161",
       "resolved": "https://registry.npmjs.org/@types/aws-lambda/-/aws-lambda-8.10.161.tgz",
@@ -3262,6 +5228,17 @@
       "dependencies": {
         "@types/connect": "*",
         "@types/node": "*"
+      }
+    },
+    "node_modules/@types/bun": {
+      "version": "1.3.9",
+      "resolved": "https://registry.npmjs.org/@types/bun/-/bun-1.3.9.tgz",
+      "integrity": "sha512-KQ571yULOdWJiMH+RIWIOZ7B2RXQGpL1YQrBtLIV3FqDcCu6FsbFUBwhdKUlCKUpS3PJDsHlJ1QKlpxoVR+xtw==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "bun-types": "1.3.9"
       }
     },
     "node_modules/@types/connect": {
@@ -3399,6 +5376,17 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/yauzl": {
+      "version": "2.10.3",
+      "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.3.tgz",
+      "integrity": "sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@whiskeysockets/baileys": {
       "version": "7.0.0-rc.9",
       "resolved": "https://registry.npmjs.org/@whiskeysockets/baileys/-/baileys-7.0.0-rc.9.tgz",
@@ -3468,6 +5456,14 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/abbrev": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
+      "license": "ISC",
+      "optional": true,
+      "peer": true
     },
     "node_modules/abort-controller": {
       "version": "3.0.0",
@@ -3586,6 +5582,46 @@
       "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/aproba": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/aproba/-/aproba-2.1.0.tgz",
+      "integrity": "sha512-tLIEcj5GuR2RSTnxNKdkK0dJ/GrC7P38sUkiDmDuHfsHmbagTFAxDVIBltoklXEVIQ/f14IL8IMJ5pn9Hez1Ew==",
+      "license": "ISC",
+      "optional": true,
+      "peer": true
+    },
+    "node_modules/are-we-there-yet": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-2.0.0.tgz",
+      "integrity": "sha512-Ci/qENmwHnsYo9xKIcUJN5LeDKdJ6R1Z1j9V/J5wyq8nh/mYPEpIKJbBZXtZjG04HiK7zV/p6Vs9952MrMeUIw==",
+      "deprecated": "This package is no longer supported.",
+      "license": "ISC",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "delegates": "^1.0.0",
+        "readable-stream": "^3.6.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/are-we-there-yet/node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
     },
     "node_modules/argparse": {
       "version": "2.0.1",
@@ -3796,6 +5832,17 @@
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/bun-types": {
+      "version": "1.3.9",
+      "resolved": "https://registry.npmjs.org/bun-types/-/bun-types-1.3.9.tgz",
+      "integrity": "sha512-+UBWWOakIP4Tswh0Bt0QD0alpTY8cb5hvgiYeWCMet9YukHbzuruIEeXC2D7nMJPB12kbh8C7XJykSexEqGKJg==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/bytes": {
       "version": "3.1.2",
@@ -4154,6 +6201,17 @@
       "license": "MIT",
       "peer": true
     },
+    "node_modules/color-support": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
+      "integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==",
+      "license": "ISC",
+      "optional": true,
+      "peer": true,
+      "bin": {
+        "color-support": "bin.js"
+      }
+    },
     "node_modules/combined-stream": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
@@ -4176,6 +6234,22 @@
       "engines": {
         "node": ">=14"
       }
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true
+    },
+    "node_modules/console-control-strings": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+      "integrity": "sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ==",
+      "license": "ISC",
+      "optional": true,
+      "peer": true
     },
     "node_modules/content-disposition": {
       "version": "1.0.1",
@@ -4392,6 +6466,14 @@
       "engines": {
         "node": ">=0.4.0"
       }
+    },
+    "node_modules/delegates": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+      "integrity": "sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/depd": {
       "version": "2.0.0",
@@ -5174,6 +7256,50 @@
         "node": ">=14.14"
       }
     },
+    "node_modules/fs-minipass": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
+      "integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
+      "license": "ISC",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "minipass": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/fs-minipass/node_modules/minipass": {
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+      "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+      "license": "ISC",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/fs-minipass/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "license": "ISC",
+      "optional": true,
+      "peer": true
+    },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+      "license": "ISC",
+      "optional": true,
+      "peer": true
+    },
     "node_modules/function-bind": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
@@ -5182,6 +7308,54 @@
       "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/gauge": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/gauge/-/gauge-3.0.2.tgz",
+      "integrity": "sha512-+5J6MS/5XksCuXq++uFRsnUd7Ovu1XenbeuIuNRJxYWjgQbPuFhT14lAvsWfqfAmnwluf1OwMjz39HjfLPci0Q==",
+      "deprecated": "This package is no longer supported.",
+      "license": "ISC",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "aproba": "^1.0.3 || ^2.0.0",
+        "color-support": "^1.1.2",
+        "console-control-strings": "^1.0.0",
+        "has-unicode": "^2.0.1",
+        "object-assign": "^4.1.1",
+        "signal-exit": "^3.0.0",
+        "string-width": "^4.2.3",
+        "strip-ansi": "^6.0.1",
+        "wide-align": "^1.1.2"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/gauge/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/gauge/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/gaxios": {
@@ -5553,6 +7727,14 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/has-unicode": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+      "integrity": "sha512-8Rf9Y83NBReMnx0gFzA8JImQACstCYWUplepDa9xprwwtmgEZUF0h/i5xSA625zB/I37EtrswSST6OXxwaaIJQ==",
+      "license": "ISC",
+      "optional": true,
+      "peer": true
+    },
     "node_modules/hashery": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/hashery/-/hashery-1.5.0.tgz",
@@ -5587,6 +7769,17 @@
       "peer": true,
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/hono": {
+      "version": "4.12.5",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.5.tgz",
+      "integrity": "sha512-3qq+FUBtlTHhtYxbxheZgY8NIFnkkC/MR8u5TTsr7YZ3wixryQ3cCwn3iZbg8p8B88iDBBAYSfZDS75t8MN7Vg==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=16.9.0"
       }
     },
     "node_modules/hookified": {
@@ -5752,6 +7945,19 @@
       "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
+      "license": "ISC",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
     },
     "node_modules/inherits": {
       "version": "2.0.4",
@@ -6368,6 +8574,34 @@
         "node": "20 || >=22"
       }
     },
+    "node_modules/make-dir": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
+      "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "semver": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/make-dir/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "license": "ISC",
+      "optional": true,
+      "peer": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
     "node_modules/markdown-it": {
       "version": "14.1.1",
       "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.1.tgz",
@@ -6526,6 +8760,20 @@
       },
       "engines": {
         "node": ">= 18"
+      }
+    },
+    "node_modules/mkdirp": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/ms": {
@@ -6753,6 +9001,46 @@
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/node-readable-to-web-readable-stream": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/node-readable-to-web-readable-stream/-/node-readable-to-web-readable-stream-0.4.2.tgz",
+      "integrity": "sha512-/cMZNI34v//jUTrI+UIo4ieHAB5EZRY/+7OmXZgBxaWBMcW2tGdceIw06RFxWxrKZ5Jp3sI2i5TsRo+CBhtVLQ==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true
+    },
+    "node_modules/nopt": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-5.0.0.tgz",
+      "integrity": "sha512-Tbj67rffqceeLpcRXrT7vKAN8CwfPeIBgM7E6iBkmKLV7bEMwpGgYLGv0jACUsECaa/vuxP0IjEont6umdMgtQ==",
+      "license": "ISC",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "abbrev": "1"
+      },
+      "bin": {
+        "nopt": "bin/nopt.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/npmlog": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-5.0.1.tgz",
+      "integrity": "sha512-AqZtDUWOMKs1G/8lwylVjrdYgqA4d9nu8hc+0gzRxlDb1I10+FHBGMXs6aiQHFdCUUlqH99MUMuLfzWDNDtfxw==",
+      "deprecated": "This package is no longer supported.",
+      "license": "ISC",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "are-we-there-yet": "^2.0.0",
+        "console-control-strings": "^1.1.0",
+        "gauge": "^3.0.0",
+        "set-blocking": "^2.0.0"
       }
     },
     "node_modules/nth-check": {
@@ -7207,6 +9495,17 @@
       "integrity": "sha512-Njv/59hHaokb/hRUjce3Hdv12wd60MtM9Z5Olmn+nehe0QDAsRtRbJPvJ0Z91TusF0SuZRIvnM+S4l6EIP8leA==",
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/path-key": {
       "version": "3.1.1",
@@ -7696,6 +9995,81 @@
         "node": ">= 4"
       }
     },
+    "node_modules/rimraf": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+      "deprecated": "Rimraf versions prior to v4 are no longer supported",
+      "license": "ISC",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/rimraf/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true
+    },
+    "node_modules/rimraf/node_modules/brace-expansion": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/rimraf/node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "license": "ISC",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/rimraf/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "license": "ISC",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/router": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
@@ -7810,6 +10184,14 @@
         "type": "opencollective",
         "url": "https://opencollective.com/express"
       }
+    },
+    "node_modules/set-blocking": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+      "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
+      "license": "ISC",
+      "optional": true,
+      "peer": true
     },
     "node_modules/setimmediate": {
       "version": "1.0.5",
@@ -8118,6 +10500,76 @@
         "sqlite-vec-linux-x64": "0.1.7-alpha.2",
         "sqlite-vec-windows-x64": "0.1.7-alpha.2"
       }
+    },
+    "node_modules/sqlite-vec-darwin-arm64": {
+      "version": "0.1.7-alpha.2",
+      "resolved": "https://registry.npmjs.org/sqlite-vec-darwin-arm64/-/sqlite-vec-darwin-arm64-0.1.7-alpha.2.tgz",
+      "integrity": "sha512-raIATOqFYkeCHhb/t3r7W7Cf2lVYdf4J3ogJ6GFc8PQEgHCPEsi+bYnm2JT84MzLfTlSTIdxr4/NKv+zF7oLPw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT OR Apache",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true
+    },
+    "node_modules/sqlite-vec-darwin-x64": {
+      "version": "0.1.7-alpha.2",
+      "resolved": "https://registry.npmjs.org/sqlite-vec-darwin-x64/-/sqlite-vec-darwin-x64-0.1.7-alpha.2.tgz",
+      "integrity": "sha512-jeZEELsQjjRsVojsvU5iKxOvkaVuE+JYC8Y4Ma8U45aAERrDYmqZoHvgSG7cg1PXL3bMlumFTAmHynf1y4pOzA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT OR Apache",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true
+    },
+    "node_modules/sqlite-vec-linux-arm64": {
+      "version": "0.1.7-alpha.2",
+      "resolved": "https://registry.npmjs.org/sqlite-vec-linux-arm64/-/sqlite-vec-linux-arm64-0.1.7-alpha.2.tgz",
+      "integrity": "sha512-6Spj4Nfi7tG13jsUG+W7jnT0bCTWbyPImu2M8nWp20fNrd1SZ4g3CSlDAK8GBdavX7wRlbBHCZ+BDa++rbDewA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT OR Apache",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true
+    },
+    "node_modules/sqlite-vec-linux-x64": {
+      "version": "0.1.7-alpha.2",
+      "resolved": "https://registry.npmjs.org/sqlite-vec-linux-x64/-/sqlite-vec-linux-x64-0.1.7-alpha.2.tgz",
+      "integrity": "sha512-IcgrbHaDccTVhXDf8Orwdc2+hgDLAFORl6OBUhcvlmwswwBP1hqBTSEhovClG4NItwTOBNgpwOoQ7Qp3VDPWLg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT OR Apache",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true
+    },
+    "node_modules/sqlite-vec-windows-x64": {
+      "version": "0.1.7-alpha.2",
+      "resolved": "https://registry.npmjs.org/sqlite-vec-windows-x64/-/sqlite-vec-windows-x64-0.1.7-alpha.2.tgz",
+      "integrity": "sha512-TRP6hTjAcwvQ6xpCZvjP00pdlda8J38ArFy1lMYhtQWXiIBmWnhMaMbq4kaeCYwvTTddfidatRS+TJrwIKB/oQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT OR Apache",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true
     },
     "node_modules/statuses": {
       "version": "2.0.2",
@@ -8735,6 +11187,17 @@
       },
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/wide-align": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.5.tgz",
+      "integrity": "sha512-eDMORYaPNZ4sQIuuYPDHdQvf4gyCF9rEEV/yPxGfwPkRodwEgiMUUXTx/dex+Me0wxx53S+NgUHaP7y3MGlDmg==",
+      "license": "ISC",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "string-width": "^1.0.2 || 2 || 3 || 4"
       }
     },
     "node_modules/win-guid": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -969,6 +969,14 @@
         "url": "https://github.com/discordjs/discord.js?sponsor"
       }
     },
+    "node_modules/@discordjs/voice/node_modules/opusscript": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/opusscript/-/opusscript-0.0.8.tgz",
+      "integrity": "sha512-VSTi1aWFuCkRCVq+tx/BQ5q9fMnQ9pVZ3JU4UHKqTkf0ED3fKEPdr+gKAAl3IA2hj9rrP6iyq3hlcJq3HELtNQ==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true
+    },
     "node_modules/@discordjs/voice/node_modules/prism-media": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/prism-media/-/prism-media-1.3.5.tgz",

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "build": "node build.mjs",
     "check": "tsc --noEmit",
     "watch": "tsc --noEmit --watch",
+    "regression:release": "bash dev/regression/tests/run-all.sh",
     "prepublishOnly": "npm run build"
   },
   "peerDependencies": {


### PR DESCRIPTION
## Summary
- layer orchestrator prompt loading for main sessions using workspace and project overrides
- scaffold/reset the new orchestrator prompt file and document the precedence
- extend bootstrap and workspace tests for orchestrator prompt coverage

## Testing
- npx tsx --test lib/dispatch/bootstrap-hook.test.ts lib/setup/workspace.test.ts
- bootstrap.e2e is present but could not be executed fully in this worktree because required dev dependencies are not installed
