### PR TITLE
fix: live orchestrator prompt loading (#183)

### DIFF
--- a/defaults/AGENTS.md
+++ b/defaults/AGENTS.md
@@ -135,7 +135,9 @@ If the test phase is enabled in workflow.yaml:
 
 ### Prompt Instructions
 
-Workers receive role-specific instructions appended to their task message. These are loaded from `devclaw/projects/<project-name>/prompts/<role>.md` in the workspace, falling back to `devclaw/prompts/<role>.md` if no project-specific file exists. `project_register` scaffolds these files automatically — edit them to customize worker behavior per project.
+Workers receive role-specific instructions appended to their task message. These are loaded from `devclaw/projects/<project-name>/prompts/<role>.md` in the workspace, falling back to `devclaw/prompts/<role>.md` if no project-specific file exists. `project_register` scaffolds the project override directory automatically.
+
+The main orchestrator session also supports live prompt layering. After the AGENTS.md baseline loads, DevClaw appends `devclaw/prompts/orchestrator.md`, then `devclaw/projects/<project-name>/prompts/orchestrator.md` when that project is known.
 
 ### Heartbeats
 

--- a/defaults/AGENTS.md
+++ b/defaults/AGENTS.md
@@ -135,9 +135,9 @@ If the test phase is enabled in workflow.yaml:
 
 ### Prompt Instructions
 
-Workers receive role-specific instructions appended to their task message. These are loaded from `devclaw/projects/<project-name>/prompts/<role>.md` in the workspace, falling back to `devclaw/prompts/<role>.md` if no project-specific file exists. `project_register` scaffolds the project override directory automatically.
+Workers receive role-specific instructions via bootstrap prompt injection. These are loaded from `devclaw/projects/<project-name>/prompts/<role>.md` in the workspace, falling back to `devclaw/prompts/<role>.md` if no project-specific file exists. `project_register` scaffolds the project override directory automatically.
 
-The main orchestrator session also supports live prompt layering. After the AGENTS.md baseline loads, DevClaw appends `devclaw/prompts/orchestrator.md`, then `devclaw/projects/<project-name>/prompts/orchestrator.md` when that project is known.
+The main orchestrator session also supports live prompt layering. After the AGENTS.md baseline loads, DevClaw injects a dedicated `DEVCLAW_ORCHESTRATOR_PROMPT.md` bootstrap file whose content comes from `devclaw/prompts/orchestrator.md`, then `devclaw/projects/<project-name>/prompts/orchestrator.md` when that project is known. Keeping the orchestrator overlay in its own bootstrap file avoids losing project policy when AGENTS.md is truncated.
 
 ### Heartbeats
 

--- a/defaults/AGENTS.md
+++ b/defaults/AGENTS.md
@@ -137,7 +137,7 @@ If the test phase is enabled in workflow.yaml:
 
 Workers receive role-specific instructions via bootstrap prompt injection. These are loaded from `devclaw/projects/<project-name>/prompts/<role>.md` in the workspace, falling back to `devclaw/prompts/<role>.md` if no project-specific file exists. `project_register` scaffolds the project override directory automatically.
 
-The main orchestrator session also supports a live prompt override. After the AGENTS.md baseline loads, DevClaw injects a dedicated `DEVCLAW_ORCHESTRATOR_PROMPT.md` bootstrap file using winner-takes-all fallback: `devclaw/projects/<project-name>/prompts/orchestrator.md`, then `devclaw/prompts/orchestrator.md`, then the package default. Keeping the orchestrator prompt in its own bootstrap file avoids losing project policy when AGENTS.md is truncated.
+The main orchestrator session also supports a live prompt override. After the AGENTS.md baseline loads, DevClaw injects a dedicated `orchestrator.md` bootstrap file using winner-takes-all fallback: `devclaw/projects/<project-name>/prompts/orchestrator.md`, then `devclaw/prompts/orchestrator.md`, then the package default. Keeping the orchestrator prompt in its own bootstrap file avoids losing project policy when AGENTS.md is truncated.
 
 ### Heartbeats
 

--- a/defaults/AGENTS.md
+++ b/defaults/AGENTS.md
@@ -137,7 +137,7 @@ If the test phase is enabled in workflow.yaml:
 
 Workers receive role-specific instructions via bootstrap prompt injection. These are loaded from `devclaw/projects/<project-name>/prompts/<role>.md` in the workspace, falling back to `devclaw/prompts/<role>.md` if no project-specific file exists. `project_register` scaffolds the project override directory automatically.
 
-The main orchestrator session also supports live prompt layering. After the AGENTS.md baseline loads, DevClaw injects a dedicated `DEVCLAW_ORCHESTRATOR_PROMPT.md` bootstrap file whose content comes from `devclaw/prompts/orchestrator.md`, then `devclaw/projects/<project-name>/prompts/orchestrator.md` when that project is known. Keeping the orchestrator overlay in its own bootstrap file avoids losing project policy when AGENTS.md is truncated.
+The main orchestrator session also supports a live prompt override. After the AGENTS.md baseline loads, DevClaw injects a dedicated `DEVCLAW_ORCHESTRATOR_PROMPT.md` bootstrap file using winner-takes-all fallback: `devclaw/projects/<project-name>/prompts/orchestrator.md`, then `devclaw/prompts/orchestrator.md`, then the package default. Keeping the orchestrator prompt in its own bootstrap file avoids losing project policy when AGENTS.md is truncated.
 
 ### Heartbeats
 

--- a/defaults/devclaw/prompts/orchestrator.md
+++ b/defaults/devclaw/prompts/orchestrator.md
@@ -5,9 +5,11 @@ This file is loaded into the main orchestrator session after the AGENTS.md basel
 Precedence inside the live orchestrator prompt stack:
 1. Runtime and system rules
 2. AGENTS.md baseline
-3. `devclaw/prompts/orchestrator.md`
-4. `devclaw/projects/<project>/prompts/orchestrator.md`
-5. Current chat, issue, and task context
+3. One resolved orchestrator prompt source, chosen by fallback order:
+   - `devclaw/projects/<project>/prompts/orchestrator.md`
+   - `devclaw/prompts/orchestrator.md`
+   - package default orchestrator prompt
+4. Current chat, issue, and task context
 
 Use this file for workspace-wide orchestration policy that should not live in AGENTS.md.
 Examples: routing preferences, issue triage rules, notification style, and project management conventions.

--- a/defaults/devclaw/prompts/orchestrator.md
+++ b/defaults/devclaw/prompts/orchestrator.md
@@ -1,0 +1,13 @@
+# Orchestrator Prompt Override
+
+This file is loaded into the main orchestrator session after the AGENTS.md baseline.
+
+Precedence inside the live orchestrator prompt stack:
+1. Runtime and system rules
+2. AGENTS.md baseline
+3. `devclaw/prompts/orchestrator.md`
+4. `devclaw/projects/<project>/prompts/orchestrator.md`
+5. Current chat, issue, and task context
+
+Use this file for workspace-wide orchestration policy that should not live in AGENTS.md.
+Examples: routing preferences, issue triage rules, notification style, and project management conventions.

--- a/defaults/devclaw/prompts/orchestrator.md
+++ b/defaults/devclaw/prompts/orchestrator.md
@@ -1,6 +1,6 @@
 # Orchestrator Prompt Override
 
-This file is loaded into the main orchestrator session after the AGENTS.md baseline.
+This file is loaded into the main orchestrator session after the AGENTS.md baseline via a dedicated `DEVCLAW_ORCHESTRATOR_PROMPT.md` bootstrap file.
 
 Precedence inside the live orchestrator prompt stack:
 1. Runtime and system rules

--- a/defaults/devclaw/prompts/orchestrator.md
+++ b/defaults/devclaw/prompts/orchestrator.md
@@ -1,6 +1,6 @@
 # Orchestrator Prompt Override
 
-This file is loaded into the main orchestrator session after the AGENTS.md baseline via a dedicated `DEVCLAW_ORCHESTRATOR_PROMPT.md` bootstrap file.
+This file is loaded into the main orchestrator session after the AGENTS.md baseline via a dedicated `orchestrator.md` bootstrap file.
 
 Precedence inside the live orchestrator prompt stack:
 1. Runtime and system rules

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -521,7 +521,7 @@ sequenceDiagram
     TK-->>HB: { pickups, skipped }
 ```
 
-## Worker instructions (bootstrap hook)
+## Prompt loading (bootstrap hook)
 
 Role-specific instructions (coding standards, deployment steps, completion rules) are injected into worker sessions via the `agent:bootstrap` hook — not appended to the task message.
 
@@ -541,8 +541,16 @@ sequenceDiagram
 ```
 
 **Resolution order:**
+Worker prompt precedence:
 1. `devclaw/projects/<project>/prompts/<role>.md` (project-specific)
 2. `devclaw/prompts/<role>.md` (workspace default)
+3. package default prompt
+
+Orchestrator prompt precedence inside the main session bootstrap content:
+1. `AGENTS.md` and runtime baseline
+2. `devclaw/prompts/orchestrator.md`
+3. `devclaw/projects/<project>/prompts/orchestrator.md`
+4. current issue/chat/task context
 
 The source path is logged for production traceability: `Bootstrap hook: injected developer instructions for project "my-app" from /path/to/prompts/developer.md`.
 
@@ -757,8 +765,10 @@ See [CONFIGURATION.md](CONFIGURATION.md) for the full reference.
 | Worker state | `<workspace>/devclaw/projects.json` | Per-project worker state |
 | Workflow config (workspace) | `<workspace>/devclaw/workflow.yaml` | Workspace-level role/workflow overrides |
 | Workflow config (project) | `<workspace>/devclaw/projects/<project>/workflow.yaml` | Project-specific overrides |
-| Default role instructions | `<workspace>/devclaw/prompts/<role>.md` | Default `developer.md`, `tester.md`, `architect.md` |
+| Default role instructions | `<workspace>/devclaw/prompts/<role>.md` | Default `developer.md`, `tester.md`, `architect.md`, `reviewer.md` |
 | Project role instructions | `<workspace>/devclaw/projects/<project>/prompts/<role>.md` | Per-project role instruction overrides |
+| Default orchestrator overlay | `<workspace>/devclaw/prompts/orchestrator.md` | Live orchestrator prompt layered after AGENTS.md |
+| Project orchestrator overlay | `<workspace>/devclaw/projects/<project>/prompts/orchestrator.md` | Project-specific orchestrator overlay layered after workspace orchestrator prompt |
 | Audit log | `<workspace>/devclaw/log/audit.log` | NDJSON event log |
 | Session transcripts | `~/.openclaw/agents/<agent>/sessions/<uuid>.jsonl` | Conversation history per session |
 | Git repos | `~/git/<project>/` | Project source code |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -548,7 +548,7 @@ Worker prompt precedence:
 
 Orchestrator prompt precedence inside the main session bootstrap content:
 1. `AGENTS.md` and runtime baseline
-2. `DEVCLAW_ORCHESTRATOR_PROMPT.md` containing one resolved prompt source
+2. `orchestrator.md` containing one resolved prompt source
    (`devclaw/projects/<project>/prompts/orchestrator.md`, else
    `devclaw/prompts/orchestrator.md`, else package default)
 3. current issue/chat/task context
@@ -768,8 +768,8 @@ See [CONFIGURATION.md](CONFIGURATION.md) for the full reference.
 | Workflow config (project) | `<workspace>/devclaw/projects/<project>/workflow.yaml` | Project-specific overrides |
 | Default role instructions | `<workspace>/devclaw/prompts/<role>.md` | Default `developer.md`, `tester.md`, `architect.md`, `reviewer.md` |
 | Project role instructions | `<workspace>/devclaw/projects/<project>/prompts/<role>.md` | Per-project role instruction overrides |
-| Default orchestrator prompt | `<workspace>/devclaw/prompts/orchestrator.md` | Used for `DEVCLAW_ORCHESTRATOR_PROMPT.md` when no project override exists |
-| Project orchestrator prompt override | `<workspace>/devclaw/projects/<project>/prompts/orchestrator.md` | Wins for `DEVCLAW_ORCHESTRATOR_PROMPT.md` when the current chat resolves to that project |
+| Default orchestrator prompt | `<workspace>/devclaw/prompts/orchestrator.md` | Used for `orchestrator.md` when no project override exists |
+| Project orchestrator prompt override | `<workspace>/devclaw/projects/<project>/prompts/orchestrator.md` | Wins for `orchestrator.md` when the current chat resolves to that project |
 | Audit log | `<workspace>/devclaw/log/audit.log` | NDJSON event log |
 | Session transcripts | `~/.openclaw/agents/<agent>/sessions/<uuid>.jsonl` | Conversation history per session |
 | Git repos | `~/git/<project>/` | Project source code |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -548,8 +548,8 @@ Worker prompt precedence:
 
 Orchestrator prompt precedence inside the main session bootstrap content:
 1. `AGENTS.md` and runtime baseline
-2. `devclaw/prompts/orchestrator.md`
-3. `devclaw/projects/<project>/prompts/orchestrator.md`
+2. `DEVCLAW_ORCHESTRATOR_PROMPT.md` containing `devclaw/prompts/orchestrator.md`
+3. `DEVCLAW_ORCHESTRATOR_PROMPT.md` extended with `devclaw/projects/<project>/prompts/orchestrator.md`
 4. current issue/chat/task context
 
 The source path is logged for production traceability: `Bootstrap hook: injected developer instructions for project "my-app" from /path/to/prompts/developer.md`.
@@ -767,8 +767,8 @@ See [CONFIGURATION.md](CONFIGURATION.md) for the full reference.
 | Workflow config (project) | `<workspace>/devclaw/projects/<project>/workflow.yaml` | Project-specific overrides |
 | Default role instructions | `<workspace>/devclaw/prompts/<role>.md` | Default `developer.md`, `tester.md`, `architect.md`, `reviewer.md` |
 | Project role instructions | `<workspace>/devclaw/projects/<project>/prompts/<role>.md` | Per-project role instruction overrides |
-| Default orchestrator overlay | `<workspace>/devclaw/prompts/orchestrator.md` | Live orchestrator prompt layered after AGENTS.md |
-| Project orchestrator overlay | `<workspace>/devclaw/projects/<project>/prompts/orchestrator.md` | Project-specific orchestrator overlay layered after workspace orchestrator prompt |
+| Default orchestrator overlay | `<workspace>/devclaw/prompts/orchestrator.md` | Loaded into `DEVCLAW_ORCHESTRATOR_PROMPT.md` after AGENTS.md |
+| Project orchestrator overlay | `<workspace>/devclaw/projects/<project>/prompts/orchestrator.md` | Appended inside `DEVCLAW_ORCHESTRATOR_PROMPT.md` after the workspace orchestrator prompt |
 | Audit log | `<workspace>/devclaw/log/audit.log` | NDJSON event log |
 | Session transcripts | `~/.openclaw/agents/<agent>/sessions/<uuid>.jsonl` | Conversation history per session |
 | Git repos | `~/git/<project>/` | Project source code |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -548,9 +548,10 @@ Worker prompt precedence:
 
 Orchestrator prompt precedence inside the main session bootstrap content:
 1. `AGENTS.md` and runtime baseline
-2. `DEVCLAW_ORCHESTRATOR_PROMPT.md` containing `devclaw/prompts/orchestrator.md`
-3. `DEVCLAW_ORCHESTRATOR_PROMPT.md` extended with `devclaw/projects/<project>/prompts/orchestrator.md`
-4. current issue/chat/task context
+2. `DEVCLAW_ORCHESTRATOR_PROMPT.md` containing one resolved prompt source
+   (`devclaw/projects/<project>/prompts/orchestrator.md`, else
+   `devclaw/prompts/orchestrator.md`, else package default)
+3. current issue/chat/task context
 
 The source path is logged for production traceability: `Bootstrap hook: injected developer instructions for project "my-app" from /path/to/prompts/developer.md`.
 
@@ -767,8 +768,8 @@ See [CONFIGURATION.md](CONFIGURATION.md) for the full reference.
 | Workflow config (project) | `<workspace>/devclaw/projects/<project>/workflow.yaml` | Project-specific overrides |
 | Default role instructions | `<workspace>/devclaw/prompts/<role>.md` | Default `developer.md`, `tester.md`, `architect.md`, `reviewer.md` |
 | Project role instructions | `<workspace>/devclaw/projects/<project>/prompts/<role>.md` | Per-project role instruction overrides |
-| Default orchestrator overlay | `<workspace>/devclaw/prompts/orchestrator.md` | Loaded into `DEVCLAW_ORCHESTRATOR_PROMPT.md` after AGENTS.md |
-| Project orchestrator overlay | `<workspace>/devclaw/projects/<project>/prompts/orchestrator.md` | Appended inside `DEVCLAW_ORCHESTRATOR_PROMPT.md` after the workspace orchestrator prompt |
+| Default orchestrator prompt | `<workspace>/devclaw/prompts/orchestrator.md` | Used for `DEVCLAW_ORCHESTRATOR_PROMPT.md` when no project override exists |
+| Project orchestrator prompt override | `<workspace>/devclaw/projects/<project>/prompts/orchestrator.md` | Wins for `DEVCLAW_ORCHESTRATOR_PROMPT.md` when the current chat resolves to that project |
 | Audit log | `<workspace>/devclaw/log/audit.log` | NDJSON event log |
 | Session transcripts | `~/.openclaw/agents/<agent>/sessions/<uuid>.jsonl` | Conversation history per session |
 | Git repos | `~/git/<project>/` | Project source code |

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -364,7 +364,7 @@ Each role in the `workers` record has a `WorkerState` object:
 │   │   ├── developer.md           ← Default developer instructions
 │   │   ├── tester.md              ← Default tester instructions
 │   │   ├── architect.md           ← Default architect instructions
-│   │   └── orchestrator.md        ← Default orchestrator overlay prompt
+│   │   └── orchestrator.md        ← Default orchestrator prompt fallback
 │   ├── projects/
 │   │   ├── my-webapp/
 │   │   │   ├── workflow.yaml      ← Project-specific config overrides
@@ -372,7 +372,7 @@ Each role in the `workers` record has a `WorkerState` object:
 │   │   │       ├── developer.md   ← Project-specific developer instructions
 │   │   │       ├── tester.md      ← Project-specific tester instructions
 │   │   │       ├── architect.md   ← Project-specific architect instructions
-│   │   │       └── orchestrator.md← Project-specific orchestrator overlay prompt
+│   │   │       └── orchestrator.md← Project-specific orchestrator prompt override
 │   │   └── another-project/
 │   │       └── prompts/
 │   │           ├── developer.md
@@ -387,7 +387,7 @@ Each role in the `workers` record has a `WorkerState` object:
 
 Worker instructions are injected via the `agent:bootstrap` hook at session startup. The hook loads `devclaw/projects/<project>/prompts/<role>.md`, falling back to `devclaw/prompts/<role>.md`.
 
-The orchestrator session keeps its AGENTS.md baseline, then injects a dedicated `DEVCLAW_ORCHESTRATOR_PROMPT.md` bootstrap file whose content comes from `devclaw/prompts/orchestrator.md`, then `devclaw/projects/<project>/prompts/orchestrator.md` when the current chat resolves to a project. This keeps the live orchestrator overlay out of AGENTS.md so bootstrap truncation of AGENTS.md does not drop project-specific orchestration policy.
+The orchestrator session keeps its AGENTS.md baseline, then injects a dedicated `DEVCLAW_ORCHESTRATOR_PROMPT.md` bootstrap file from one resolved source: `devclaw/projects/<project>/prompts/orchestrator.md` when the current chat resolves to a project, otherwise `devclaw/prompts/orchestrator.md`, otherwise the package default. This keeps the live orchestrator prompt out of AGENTS.md so bootstrap truncation of AGENTS.md does not drop project-specific orchestration policy.
 
 Edit these files to customize deployment steps, test commands, acceptance criteria, coding standards, and orchestration policy.
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -387,7 +387,7 @@ Each role in the `workers` record has a `WorkerState` object:
 
 Worker instructions are injected via the `agent:bootstrap` hook at session startup. The hook loads `devclaw/projects/<project>/prompts/<role>.md`, falling back to `devclaw/prompts/<role>.md`.
 
-The orchestrator session keeps its AGENTS.md baseline, then injects a dedicated `DEVCLAW_ORCHESTRATOR_PROMPT.md` bootstrap file from one resolved source: `devclaw/projects/<project>/prompts/orchestrator.md` when the current chat resolves to a project, otherwise `devclaw/prompts/orchestrator.md`, otherwise the package default. This keeps the live orchestrator prompt out of AGENTS.md so bootstrap truncation of AGENTS.md does not drop project-specific orchestration policy.
+The orchestrator session keeps its AGENTS.md baseline, then injects a dedicated `orchestrator.md` bootstrap file from one resolved source: `devclaw/projects/<project>/prompts/orchestrator.md` when the current chat resolves to a project, otherwise `devclaw/prompts/orchestrator.md`, otherwise the package default. This keeps the live orchestrator prompt out of AGENTS.md so bootstrap truncation of AGENTS.md does not drop project-specific orchestration policy.
 
 Edit these files to customize deployment steps, test commands, acceptance criteria, coding standards, and orchestration policy.
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -363,14 +363,16 @@ Each role in the `workers` record has a `WorkerState` object:
 │   ├── prompts/
 │   │   ├── developer.md           ← Default developer instructions
 │   │   ├── tester.md              ← Default tester instructions
-│   │   └── architect.md           ← Default architect instructions
+│   │   ├── architect.md           ← Default architect instructions
+│   │   └── orchestrator.md        ← Default orchestrator overlay prompt
 │   ├── projects/
 │   │   ├── my-webapp/
 │   │   │   ├── workflow.yaml      ← Project-specific config overrides
 │   │   │   └── prompts/
 │   │   │       ├── developer.md   ← Project-specific developer instructions
 │   │   │       ├── tester.md      ← Project-specific tester instructions
-│   │   │       └── architect.md   ← Project-specific architect instructions
+│   │   │       ├── architect.md   ← Project-specific architect instructions
+│   │   │       └── orchestrator.md← Project-specific orchestrator overlay prompt
 │   │   └── another-project/
 │   │       └── prompts/
 │   │           ├── developer.md
@@ -381,11 +383,13 @@ Each role in the `workers` record has a `WorkerState` object:
 └── HEARTBEAT.md                   ← Heartbeat operation guide
 ```
 
-### Role instruction files
+### Prompt instruction files
 
-Role instructions are injected into worker sessions via the `agent:bootstrap` hook at session startup. The hook loads instructions from `devclaw/projects/<project>/prompts/<role>.md`, falling back to `devclaw/prompts/<role>.md`.
+Worker instructions are injected via the `agent:bootstrap` hook at session startup. The hook loads `devclaw/projects/<project>/prompts/<role>.md`, falling back to `devclaw/prompts/<role>.md`.
 
-Edit to customize: deployment steps, test commands, acceptance criteria, coding standards.
+The orchestrator session keeps its AGENTS.md baseline, then appends `devclaw/prompts/orchestrator.md`, then `devclaw/projects/<project>/prompts/orchestrator.md` when the current chat resolves to a project.
+
+Edit these files to customize deployment steps, test commands, acceptance criteria, coding standards, and orchestration policy.
 
 **Source:** [`lib/dispatch/bootstrap-hook.ts`](../lib/dispatch/bootstrap-hook.ts)
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -387,7 +387,7 @@ Each role in the `workers` record has a `WorkerState` object:
 
 Worker instructions are injected via the `agent:bootstrap` hook at session startup. The hook loads `devclaw/projects/<project>/prompts/<role>.md`, falling back to `devclaw/prompts/<role>.md`.
 
-The orchestrator session keeps its AGENTS.md baseline, then appends `devclaw/prompts/orchestrator.md`, then `devclaw/projects/<project>/prompts/orchestrator.md` when the current chat resolves to a project.
+The orchestrator session keeps its AGENTS.md baseline, then injects a dedicated `DEVCLAW_ORCHESTRATOR_PROMPT.md` bootstrap file whose content comes from `devclaw/prompts/orchestrator.md`, then `devclaw/projects/<project>/prompts/orchestrator.md` when the current chat resolves to a project. This keeps the live orchestrator overlay out of AGENTS.md so bootstrap truncation of AGENTS.md does not drop project-specific orchestration policy.
 
 Edit these files to customize deployment steps, test commands, acceptance criteria, coding standards, and orchestration policy.
 

--- a/docs/ONBOARDING.md
+++ b/docs/ONBOARDING.md
@@ -61,7 +61,7 @@ The setup wizard walks you through:
    - **Tester senior** (thorough review) — default: `anthropic/claude-opus-4-6`
    - **Architect junior** (standard design) — default: `anthropic/claude-sonnet-4-5`
    - **Architect senior** (complex architecture) — default: `anthropic/claude-opus-4-6`
-3. **Workspace** — Writes AGENTS.md, HEARTBEAT.md, workflow.yaml, role templates, and initializes state
+3. **Workspace** — Writes AGENTS.md, HEARTBEAT.md, workflow.yaml, prompt templates (including orchestrator.md), and initializes state
 
 Non-interactive mode:
 ```bash
@@ -155,7 +155,7 @@ Go to the Telegram/WhatsApp group for the project and tell the orchestrator agen
 The agent calls `project_register`, which atomically:
 - Validates the repo and auto-detects GitHub/GitLab from remote
 - Creates all state labels (idempotent)
-- Scaffolds role instruction files (`devclaw/projects/<project>/prompts/developer.md`, `tester.md`, `architect.md`)
+- Creates the project override directory for prompt files, including support for `devclaw/projects/<project>/prompts/orchestrator.md`
 - Adds the project entry to `projects.json`
 - Logs the registration event
 
@@ -271,7 +271,7 @@ Change which model powers each level in `workflow.yaml` — see [Configuration](
 | Agent + workspace setup | Plugin (`setup`) | Creates agent, configures models, writes workspace files |
 | Channel binding migration | Plugin (`setup` with `migrateFrom`) | Automatically moves channel-wide bindings between agents |
 | Label setup | Plugin (`project_register`) | State labels, created idempotently via IssueProvider |
-| Prompt file scaffolding | Plugin (`project_register`) | Creates `devclaw/projects/<project>/prompts/<role>.md` for each role |
+| Prompt file scaffolding | Plugin (`project_register`) | Creates the project prompt override directory and documents `devclaw/projects/<project>/prompts/<role>.md` plus `orchestrator.md` |
 | Project registration | Plugin (`project_register`) | Entry in `projects.json` with empty worker state |
 | Telegram group setup | You (once per project) | Add bot to group |
 | Issue creation | Plugin (`task_create`) | Orchestrator or workers create issues from chat |

--- a/lib/dispatch/bootstrap-hook.test.ts
+++ b/lib/dispatch/bootstrap-hook.test.ts
@@ -4,8 +4,8 @@
  */
 import { describe, it } from "node:test";
 import assert from "node:assert";
-import { parseDevClawSessionKey, loadRoleInstructions } from "./bootstrap-hook.js";
-import { DEFAULT_ROLE_INSTRUCTIONS } from "../setup/templates.js";
+import { parseDevClawSessionKey, loadOrchestratorInstructions, loadRoleInstructions } from "./bootstrap-hook.js";
+import { DEFAULT_ORCHESTRATOR_PROMPT, DEFAULT_ROLE_INSTRUCTIONS } from "../setup/templates.js";
 import fs from "node:fs/promises";
 import path from "node:path";
 import os from "node:os";
@@ -123,6 +123,46 @@ describe("loadRoleInstructions", () => {
 
     const result = await loadRoleInstructions(tmpDir, "old-project", "developer");
     assert.strictEqual(result, "Old layout instructions");
+
+    await fs.rm(tmpDir, { recursive: true });
+  });
+});
+
+describe("loadOrchestratorInstructions", () => {
+  it("should layer workspace and project orchestrator instructions in order", async () => {
+    const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "devclaw-test-"));
+    await fs.mkdir(path.join(tmpDir, "devclaw", "prompts"), { recursive: true });
+    await fs.mkdir(path.join(tmpDir, "devclaw", "projects", "my-project", "prompts"), { recursive: true });
+    await fs.writeFile(path.join(tmpDir, "devclaw", "prompts", "orchestrator.md"), "Workspace orchestrator prompt");
+    await fs.writeFile(path.join(tmpDir, "devclaw", "projects", "my-project", "prompts", "orchestrator.md"), "Project orchestrator prompt");
+
+    const result = await loadOrchestratorInstructions(tmpDir, "my-project");
+    assert.strictEqual(result, "Workspace orchestrator prompt\n\nProject orchestrator prompt");
+
+    await fs.rm(tmpDir, { recursive: true });
+  });
+
+  it("should return layered sources when requested", async () => {
+    const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "devclaw-test-"));
+    await fs.mkdir(path.join(tmpDir, "devclaw", "prompts"), { recursive: true });
+    await fs.mkdir(path.join(tmpDir, "devclaw", "projects", "my-project", "prompts"), { recursive: true });
+    const workspacePath = path.join(tmpDir, "devclaw", "prompts", "orchestrator.md");
+    const projectPath = path.join(tmpDir, "devclaw", "projects", "my-project", "prompts", "orchestrator.md");
+    await fs.writeFile(workspacePath, "Workspace orchestrator prompt");
+    await fs.writeFile(projectPath, "Project orchestrator prompt");
+
+    const result = await loadOrchestratorInstructions(tmpDir, "my-project", { withSource: true });
+    assert.strictEqual(result.content, "Workspace orchestrator prompt\n\nProject orchestrator prompt");
+    assert.deepStrictEqual(result.sources, [workspacePath, projectPath]);
+
+    await fs.rm(tmpDir, { recursive: true });
+  });
+
+  it("should fall back to package default orchestrator prompt", async () => {
+    const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "devclaw-test-"));
+
+    const result = await loadOrchestratorInstructions(tmpDir, "missing-project");
+    assert.strictEqual(result, DEFAULT_ORCHESTRATOR_PROMPT.trim());
 
     await fs.rm(tmpDir, { recursive: true });
   });

--- a/lib/dispatch/bootstrap-hook.test.ts
+++ b/lib/dispatch/bootstrap-hook.test.ts
@@ -129,7 +129,7 @@ describe("loadRoleInstructions", () => {
 });
 
 describe("loadOrchestratorInstructions", () => {
-  it("should layer workspace and project orchestrator instructions in order", async () => {
+  it("should prefer project orchestrator instructions over workspace defaults", async () => {
     const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "devclaw-test-"));
     await fs.mkdir(path.join(tmpDir, "devclaw", "prompts"), { recursive: true });
     await fs.mkdir(path.join(tmpDir, "devclaw", "projects", "my-project", "prompts"), { recursive: true });
@@ -137,12 +137,23 @@ describe("loadOrchestratorInstructions", () => {
     await fs.writeFile(path.join(tmpDir, "devclaw", "projects", "my-project", "prompts", "orchestrator.md"), "Project orchestrator prompt");
 
     const result = await loadOrchestratorInstructions(tmpDir, "my-project");
-    assert.strictEqual(result, "Workspace orchestrator prompt\n\nProject orchestrator prompt");
+    assert.strictEqual(result, "Project orchestrator prompt");
 
     await fs.rm(tmpDir, { recursive: true });
   });
 
-  it("should return layered sources when requested", async () => {
+  it("should fall back to workspace orchestrator instructions when no project override exists", async () => {
+    const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "devclaw-test-"));
+    await fs.mkdir(path.join(tmpDir, "devclaw", "prompts"), { recursive: true });
+    await fs.writeFile(path.join(tmpDir, "devclaw", "prompts", "orchestrator.md"), "Workspace orchestrator prompt");
+
+    const result = await loadOrchestratorInstructions(tmpDir, "missing-project");
+    assert.strictEqual(result, "Workspace orchestrator prompt");
+
+    await fs.rm(tmpDir, { recursive: true });
+  });
+
+  it("should return the winning source when requested", async () => {
     const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "devclaw-test-"));
     await fs.mkdir(path.join(tmpDir, "devclaw", "prompts"), { recursive: true });
     await fs.mkdir(path.join(tmpDir, "devclaw", "projects", "my-project", "prompts"), { recursive: true });
@@ -152,8 +163,8 @@ describe("loadOrchestratorInstructions", () => {
     await fs.writeFile(projectPath, "Project orchestrator prompt");
 
     const result = await loadOrchestratorInstructions(tmpDir, "my-project", { withSource: true });
-    assert.strictEqual(result.content, "Workspace orchestrator prompt\n\nProject orchestrator prompt");
-    assert.deepStrictEqual(result.sources, [workspacePath, projectPath]);
+    assert.strictEqual(result.content, "Project orchestrator prompt");
+    assert.strictEqual(result.source, projectPath);
 
     await fs.rm(tmpDir, { recursive: true });
   });

--- a/lib/dispatch/bootstrap-hook.ts
+++ b/lib/dispatch/bootstrap-hook.ts
@@ -1,45 +1,31 @@
 /**
- * bootstrap-hook.ts — Bootstrap support for DevClaw worker sessions.
+ * bootstrap-hook.ts — Bootstrap support for DevClaw sessions.
  *
  * Provides:
- *   1. agent:bootstrap (internal hook) — replaces the orchestrator's AGENTS.md
- *      with role-specific instructions so the worker sees its own prompt on
- *      every turn. Requires hooks.internal.enabled in config.
- *   2. loadRoleInstructions() — loads role-specific prompt files from workspace.
- *      Used by both the bootstrap hook (persistent per-turn injection) and
- *      dispatch.ts (extraSystemPrompt fallback for the dispatch turn).
+ *   1. agent:bootstrap (internal hook) for worker sessions, replacing the
+ *      orchestrator's AGENTS.md with role-specific instructions so workers see
+ *      their own prompt on every turn.
+ *   2. agent:bootstrap handling for main/orchestrator sessions, appending live
+ *      workspace and project-specific orchestrator prompt layers to AGENTS.md.
+ *   3. Prompt loaders used by bootstrap and dispatch fallback paths.
  */
 import fs from "node:fs/promises";
 import path from "node:path";
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
 import type { PluginContext } from "../context.js";
 import { getSessionKeyRolePattern } from "../roles/index.js";
+import { getProject, readProjects } from "../projects/index.js";
 import { DATA_DIR } from "../setup/migrate-layout.js";
-import { DEFAULT_ROLE_INSTRUCTIONS } from "../setup/templates.js";
+import { DEFAULT_ORCHESTRATOR_PROMPT, DEFAULT_ROLE_INSTRUCTIONS } from "../setup/templates.js";
 
-/**
- * Parse a DevClaw subagent session key to extract project name and role.
- *
- * Session key format (named): `agent:{agentId}:subagent:{projectName}-{role}-{level}-{name}` (name is lowercase)
- * Session key format (numeric): `agent:{agentId}:subagent:{projectName}-{role}-{level}-{slotIndex}`
- * Session key format (legacy): `agent:{agentId}:subagent:{projectName}-{role}-{level}`
- * Examples:
- *   - `agent:devclaw:subagent:my-project-developer-medior-ada`  → { projectName: "my-project", role: "developer" }
- *   - `agent:devclaw:subagent:my-project-developer-medior-0`    → { projectName: "my-project", role: "developer" }
- *   - `agent:devclaw:subagent:webapp-tester-medior`              → { projectName: "webapp", role: "tester" } (legacy)
- *
- * Note: projectName may contain hyphens, so we match role from the end.
- */
 export function parseDevClawSessionKey(
   sessionKey: string,
 ): { projectName: string; role: string } | null {
   const rolePattern = getSessionKeyRolePattern();
-  // Named/numeric format: ...-{role}-{level}-{nameOrIndex}
   const newMatch = sessionKey.match(
     new RegExp(`:subagent:(.+)-(${rolePattern})-[^-]+-[^-]+$`),
   );
   if (newMatch) return { projectName: newMatch[1], role: newMatch[2] };
-  // Legacy format fallback: ...-{role}-{level} (for in-flight sessions during migration)
   const legacyMatch = sessionKey.match(
     new RegExp(`:subagent:(.+)-(${rolePattern})-[^-]+$`),
   );
@@ -47,26 +33,62 @@ export function parseDevClawSessionKey(
   return null;
 }
 
-/**
- * Result of loading role instructions — includes the source for traceability.
- */
-export type RoleInstructionsResult = {
+export type PromptInstructionsResult = {
   content: string;
-  /** Which file the instructions were loaded from, or null if none found. */
   source: string | null;
 };
 
+export type LayeredPromptInstructionsResult = {
+  content: string;
+  sources: string[];
+};
+
+export type RoleInstructionsResult = PromptInstructionsResult;
+
+async function loadPromptInstructions(
+  workspaceDir: string,
+  promptName: string,
+  opts?: { projectName?: string; withSource?: boolean; includePackageDefault?: string },
+): Promise<string | PromptInstructionsResult> {
+  const dataDir = path.join(workspaceDir, DATA_DIR);
+  const candidates = [
+    opts?.projectName
+      ? path.join(dataDir, "projects", opts.projectName, "prompts", `${promptName}.md`)
+      : null,
+    opts?.projectName
+      ? path.join(workspaceDir, "projects", "roles", opts.projectName, `${promptName}.md`)
+      : null,
+    path.join(dataDir, "prompts", `${promptName}.md`),
+    path.join(workspaceDir, "projects", "roles", "default", `${promptName}.md`),
+  ].filter((value): value is string => Boolean(value));
+
+  for (const filePath of candidates) {
+    try {
+      const content = await fs.readFile(filePath, "utf-8");
+      if (opts?.withSource) return { content, source: filePath };
+      return content;
+    } catch {
+      /* not found, try next */
+    }
+  }
+
+  if (opts?.includePackageDefault) {
+    if (opts.withSource) return { content: opts.includePackageDefault, source: "package-default" };
+    return opts.includePackageDefault;
+  }
+
+  if (opts?.withSource) return { content: "", source: null };
+  return "";
+}
+
 /**
  * Load role-specific instructions from workspace.
- * Tries project-specific file first, then workspace default, then package default.
- * Returns both the content and the source path for logging/traceability.
- *
  * Resolution order:
- *   1. devclaw/projects/<project>/prompts/<role>.md  (project-specific override)
- *   2. projects/roles/<project>/<role>.md             (old project-specific)
- *   3. devclaw/prompts/<role>.md                      (workspace default)
- *   4. projects/roles/default/<role>.md               (old default)
- *   5. Package default from templates.ts              (in-memory fallback)
+ *   1. devclaw/projects/<project>/prompts/<role>.md
+ *   2. projects/roles/<project>/<role>.md
+ *   3. devclaw/prompts/<role>.md
+ *   4. projects/roles/default/<role>.md
+ *   5. package default
  */
 export async function loadRoleInstructions(
   workspaceDir: string,
@@ -85,48 +107,125 @@ export async function loadRoleInstructions(
   role: string,
   opts?: { withSource: true },
 ): Promise<string | RoleInstructionsResult> {
+  return loadPromptInstructions(workspaceDir, role, {
+    projectName,
+    withSource: opts?.withSource,
+    includePackageDefault: DEFAULT_ROLE_INSTRUCTIONS[role],
+  }) as Promise<string | RoleInstructionsResult>;
+}
+
+/**
+ * Load orchestrator-specific instructions from workspace.
+ * Resolution order inside the orchestrator session:
+ *   1. AGENTS.md / runtime baseline (outside this loader)
+ *   2. devclaw/prompts/orchestrator.md
+ *   3. devclaw/projects/<project>/prompts/orchestrator.md
+ *   4. package default
+ */
+export async function loadOrchestratorInstructions(
+  workspaceDir: string,
+  projectName?: string,
+): Promise<string>;
+export async function loadOrchestratorInstructions(
+  workspaceDir: string,
+  projectName: string | undefined,
+  opts: { withSource: true },
+): Promise<LayeredPromptInstructionsResult>;
+export async function loadOrchestratorInstructions(
+  workspaceDir: string,
+  projectName?: string,
+  opts?: { withSource: true },
+): Promise<string | LayeredPromptInstructionsResult> {
   const dataDir = path.join(workspaceDir, DATA_DIR);
+  const layers: string[] = [];
+  const sources: string[] = [];
 
-  const candidates = [
-    path.join(dataDir, "projects", projectName, "prompts", `${role}.md`),
-    path.join(workspaceDir, "projects", "roles", projectName, `${role}.md`),
-    path.join(dataDir, "prompts", `${role}.md`),
-    path.join(workspaceDir, "projects", "roles", "default", `${role}.md`),
+  const workspaceCandidates = [
+    path.join(dataDir, "prompts", "orchestrator.md"),
+    path.join(workspaceDir, "projects", "roles", "default", "orchestrator.md"),
   ];
-
-  for (const filePath of candidates) {
+  for (const filePath of workspaceCandidates) {
     try {
       const content = await fs.readFile(filePath, "utf-8");
-      if (opts?.withSource) return { content, source: filePath };
-      return content;
+      layers.push(content.trim());
+      sources.push(filePath);
+      break;
     } catch {
       /* not found, try next */
     }
   }
 
-  // Final fallback: package defaults (in-memory, always available)
-  const packageDefault = DEFAULT_ROLE_INSTRUCTIONS[role];
-  if (packageDefault) {
-    if (opts?.withSource) return { content: packageDefault, source: "package-default" };
-    return packageDefault;
+  if (projectName) {
+    const projectCandidates = [
+      path.join(dataDir, "projects", projectName, "prompts", "orchestrator.md"),
+      path.join(workspaceDir, "projects", "roles", projectName, "orchestrator.md"),
+    ];
+    for (const filePath of projectCandidates) {
+      try {
+        const content = await fs.readFile(filePath, "utf-8");
+        layers.push(content.trim());
+        sources.push(filePath);
+        break;
+      } catch {
+        /* not found, try next */
+      }
+    }
   }
 
-  if (opts?.withSource) return { content: "", source: null };
-  return "";
+  if (layers.length === 0 && DEFAULT_ORCHESTRATOR_PROMPT.trim()) {
+    layers.push(DEFAULT_ORCHESTRATOR_PROMPT.trim());
+    sources.push("package-default");
+  }
+
+  const content = layers.filter(Boolean).join("\n\n");
+  if (opts?.withSource) return { content, sources };
+  return content;
+}
+
+async function resolveProjectNameForBootstrap(
+  workspaceDir: string,
+  context: {
+    projectName?: string;
+    projectSlug?: string;
+    channelId?: string;
+    conversationId?: string;
+    messageThreadId?: number | string | null;
+    accountId?: string;
+    channel?: string;
+  },
+): Promise<string | undefined> {
+  if (context.projectName) return context.projectName;
+  if (context.projectSlug) return context.projectSlug;
+
+  const channelId = context.channelId ?? context.conversationId;
+  if (!channelId) return undefined;
+
+  try {
+    const data = await readProjects(workspaceDir);
+    return getProject(data, {
+      channelId,
+      channel: context.channel ?? "telegram",
+      accountId: context.accountId,
+      messageThreadId: context.messageThreadId,
+    })?.name;
+  } catch {
+    return undefined;
+  }
 }
 
 /**
- * Register the agent:bootstrap hook for DevClaw worker sessions.
+ * Register the agent:bootstrap hook for DevClaw sessions.
  *
- * Replaces the orchestrator's AGENTS.md with role-specific instructions
- * loaded from the workspace. This ensures workers see their own prompt on
- * every turn — not just the dispatch turn (where extraSystemPrompt is used).
+ * Worker precedence:
+ *   1. devclaw/projects/<project>/prompts/<role>.md
+ *   2. devclaw/prompts/<role>.md
+ *   3. package default prompt
  *
- * If role instructions are found, AGENTS.md content is replaced entirely.
- * If none are found, AGENTS.md is still stripped to avoid orchestrator bleed.
- *
- * Requires hooks.internal.enabled in config. If the hook doesn't fire,
- * dispatch.ts still passes instructions via extraSystemPrompt (single-turn).
+ * Orchestrator precedence inside bootstrap AGENTS content:
+ *   1. existing AGENTS.md/runtime baseline
+ *   2. devclaw/prompts/orchestrator.md
+ *   3. devclaw/projects/<project>/prompts/orchestrator.md
+ *   4. issue/task/chat-specific context (outside this hook)
  */
 export function registerBootstrapHook(api: OpenClawPluginApi, ctx: PluginContext): void {
   api.registerHook(
@@ -135,11 +234,15 @@ export function registerBootstrapHook(api: OpenClawPluginApi, ctx: PluginContext
       const sessionKey = event.sessionKey;
       if (!sessionKey) return;
 
-      const parsed = parseDevClawSessionKey(sessionKey);
-      if (!parsed) return;
-
       const context = event.context as {
         workspaceDir?: string;
+        projectName?: string;
+        projectSlug?: string;
+        channelId?: string;
+        conversationId?: string;
+        messageThreadId?: number | string | null;
+        accountId?: string;
+        channel?: string;
         bootstrapFiles?: Array<{
           name: string;
           path: string;
@@ -154,13 +257,30 @@ export function registerBootstrapHook(api: OpenClawPluginApi, ctx: PluginContext
       const agentsEntry = bootstrapFiles.find((f) => f.name === "AGENTS.md");
       if (!agentsEntry) return;
 
-      // Load role instructions from workspace (project-specific → default fallback)
+      const parsed = parseDevClawSessionKey(sessionKey);
       const workspaceDir = context.workspaceDir;
+
       if (!workspaceDir) {
+        if (!parsed) return;
         agentsEntry.content = "";
         agentsEntry.missing = true;
         ctx.logger.info(
           `agent:bootstrap: stripped AGENTS.md for ${parsed.role} worker in "${parsed.projectName}" (no workspaceDir)`,
+        );
+        return;
+      }
+
+      if (!parsed) {
+        const projectName = await resolveProjectNameForBootstrap(workspaceDir, context);
+        const { content, sources } = await loadOrchestratorInstructions(workspaceDir, projectName, { withSource: true });
+        if (!content.trim()) return;
+
+        const baseline = agentsEntry.content?.trimEnd() ?? "";
+        const separator = baseline ? "\n\n" : "";
+        agentsEntry.content = `${baseline}${separator}<!-- DEVCLAW:ORCHESTRATOR-PROMPT -->\n${content.trim()}\n<!-- /DEVCLAW:ORCHESTRATOR-PROMPT -->\n`;
+        agentsEntry.missing = false;
+        ctx.logger.info(
+          `agent:bootstrap: appended orchestrator instructions${projectName ? ` for "${projectName}"` : ""} from ${sources.join(" -> ")}`,
         );
         return;
       }
@@ -189,7 +309,7 @@ export function registerBootstrapHook(api: OpenClawPluginApi, ctx: PluginContext
     {
       name: "devclaw-bootstrap-role-instructions",
       description:
-        "Replaces orchestrator AGENTS.md with role-specific instructions for DevClaw workers",
+        "Replaces worker AGENTS.md with role prompts and appends live orchestrator prompts for main sessions",
     } as any,
   );
 }

--- a/lib/dispatch/bootstrap-hook.ts
+++ b/lib/dispatch/bootstrap-hook.ts
@@ -5,9 +5,9 @@
  *   1. agent:bootstrap (internal hook) for worker sessions, replacing the
  *      orchestrator's AGENTS.md with role-specific instructions so workers see
  *      their own prompt on every turn.
- *   2. agent:bootstrap handling for main/orchestrator sessions, injecting live
- *      workspace and project-specific orchestrator prompt layers as a separate
- *      bootstrap file instead of piggybacking on AGENTS.md.
+ *   2. agent:bootstrap handling for main/orchestrator sessions, injecting one
+ *      resolved orchestrator prompt as a separate bootstrap file instead of
+ *      piggybacking on AGENTS.md.
  *   3. Prompt loaders used by bootstrap and dispatch fallback paths.
  */
 import fs from "node:fs/promises";
@@ -34,17 +34,12 @@ export function parseDevClawSessionKey(
   return null;
 }
 
-export type PromptInstructionsResult = {
+export type PromptSourceResult = {
   content: string;
   source: string | null;
 };
 
-export type LayeredPromptInstructionsResult = {
-  content: string;
-  sources: string[];
-};
-
-export type RoleInstructionsResult = PromptInstructionsResult;
+export type RoleInstructionsResult = PromptSourceResult;
 
 async function loadPromptInstructions(
   workspaceDir: string,
@@ -117,13 +112,15 @@ export async function loadRoleInstructions(
 
 /**
  * Load orchestrator-specific instructions from workspace.
- * Resolution order inside the orchestrator session:
- *   1. AGENTS.md / runtime baseline (outside this loader)
- *   2. devclaw/prompts/orchestrator.md
- *   3. devclaw/projects/<project>/prompts/orchestrator.md
- *   4. package default
+ * Resolution order for the dedicated orchestrator bootstrap file:
+ *   1. devclaw/projects/<project>/prompts/orchestrator.md
+ *   2. projects/roles/<project>/orchestrator.md
+ *   3. devclaw/prompts/orchestrator.md
+ *   4. projects/roles/default/orchestrator.md
+ *   5. package default
  *
- * The returned content is meant for a dedicated bootstrap file so it remains
+ * AGENTS.md remains the baseline bootstrap context outside this loader. The
+ * returned content is injected as a separate bootstrap file so it remains
  * independently loadable even when AGENTS.md is truncated by bootstrap limits.
  */
 export async function loadOrchestratorInstructions(
@@ -134,56 +131,17 @@ export async function loadOrchestratorInstructions(
   workspaceDir: string,
   projectName: string | undefined,
   opts: { withSource: true },
-): Promise<LayeredPromptInstructionsResult>;
+): Promise<PromptSourceResult>;
 export async function loadOrchestratorInstructions(
   workspaceDir: string,
   projectName?: string,
   opts?: { withSource: true },
-): Promise<string | LayeredPromptInstructionsResult> {
-  const dataDir = path.join(workspaceDir, DATA_DIR);
-  const layers: string[] = [];
-  const sources: string[] = [];
-
-  const workspaceCandidates = [
-    path.join(dataDir, "prompts", "orchestrator.md"),
-    path.join(workspaceDir, "projects", "roles", "default", "orchestrator.md"),
-  ];
-  for (const filePath of workspaceCandidates) {
-    try {
-      const content = await fs.readFile(filePath, "utf-8");
-      layers.push(content.trim());
-      sources.push(filePath);
-      break;
-    } catch {
-      /* not found, try next */
-    }
-  }
-
-  if (projectName) {
-    const projectCandidates = [
-      path.join(dataDir, "projects", projectName, "prompts", "orchestrator.md"),
-      path.join(workspaceDir, "projects", "roles", projectName, "orchestrator.md"),
-    ];
-    for (const filePath of projectCandidates) {
-      try {
-        const content = await fs.readFile(filePath, "utf-8");
-        layers.push(content.trim());
-        sources.push(filePath);
-        break;
-      } catch {
-        /* not found, try next */
-      }
-    }
-  }
-
-  if (layers.length === 0 && DEFAULT_ORCHESTRATOR_PROMPT.trim()) {
-    layers.push(DEFAULT_ORCHESTRATOR_PROMPT.trim());
-    sources.push("package-default");
-  }
-
-  const content = layers.filter(Boolean).join("\n\n");
-  if (opts?.withSource) return { content, sources };
-  return content;
+): Promise<string | PromptSourceResult> {
+  return loadPromptInstructions(workspaceDir, "orchestrator", {
+    projectName,
+    withSource: opts?.withSource,
+    includePackageDefault: DEFAULT_ORCHESTRATOR_PROMPT.trim(),
+  }) as Promise<string | PromptSourceResult>;
 }
 
 async function resolveProjectNameForBootstrap(
@@ -227,9 +185,8 @@ async function resolveProjectNameForBootstrap(
  *
  * Orchestrator precedence inside bootstrap context:
  *   1. existing AGENTS.md/runtime baseline
- *   2. DEVCLAW_ORCHESTRATOR_PROMPT.md (workspace orchestrator prompt layer)
- *   3. DEVCLAW_ORCHESTRATOR_PROMPT.md (project orchestrator prompt layer)
- *   4. issue/task/chat-specific context (outside this hook)
+ *   2. DEVCLAW_ORCHESTRATOR_PROMPT.md from the resolved orchestrator prompt source
+ *   3. issue/task/chat-specific context (outside this hook)
  */
 export function registerBootstrapHook(api: OpenClawPluginApi, ctx: PluginContext): void {
   api.registerHook(
@@ -276,7 +233,7 @@ export function registerBootstrapHook(api: OpenClawPluginApi, ctx: PluginContext
 
       if (!parsed) {
         const projectName = await resolveProjectNameForBootstrap(workspaceDir, context);
-        const { content, sources } = await loadOrchestratorInstructions(workspaceDir, projectName, { withSource: true });
+        const { content, source } = await loadOrchestratorInstructions(workspaceDir, projectName, { withSource: true });
         if (!content.trim()) return;
 
         const promptFileName = "DEVCLAW_ORCHESTRATOR_PROMPT.md";
@@ -293,7 +250,7 @@ export function registerBootstrapHook(api: OpenClawPluginApi, ctx: PluginContext
         if (!existingPromptEntry) bootstrapFiles.push(promptEntry);
 
         ctx.logger.info(
-          `agent:bootstrap: injected orchestrator prompt file${projectName ? ` for "${projectName}"` : ""} from ${sources.join(" -> ")}`,
+          `agent:bootstrap: injected orchestrator prompt file${projectName ? ` for "${projectName}"` : ""} from ${source}`,
         );
         return;
       }

--- a/lib/dispatch/bootstrap-hook.ts
+++ b/lib/dispatch/bootstrap-hook.ts
@@ -45,7 +45,7 @@ async function loadPromptInstructions(
   workspaceDir: string,
   promptName: string,
   opts?: { projectName?: string; withSource?: boolean; includePackageDefault?: string },
-): Promise<string | PromptInstructionsResult> {
+): Promise<string | PromptSourceResult> {
   const dataDir = path.join(workspaceDir, DATA_DIR);
   const candidates = [
     opts?.projectName
@@ -120,8 +120,8 @@ export async function loadRoleInstructions(
  *   5. package default
  *
  * AGENTS.md remains the baseline bootstrap context outside this loader. The
- * returned content is injected as a separate bootstrap file so it remains
- * independently loadable even when AGENTS.md is truncated by bootstrap limits.
+ * returned content is injected as a separate bootstrap file named
+ * orchestrator.md so operators see the real editable prompt name directly.
  */
 export async function loadOrchestratorInstructions(
   workspaceDir: string,
@@ -185,7 +185,7 @@ async function resolveProjectNameForBootstrap(
  *
  * Orchestrator precedence inside bootstrap context:
  *   1. existing AGENTS.md/runtime baseline
- *   2. DEVCLAW_ORCHESTRATOR_PROMPT.md from the resolved orchestrator prompt source
+ *   2. orchestrator.md from the resolved orchestrator prompt source
  *   3. issue/task/chat-specific context (outside this hook)
  */
 export function registerBootstrapHook(api: OpenClawPluginApi, ctx: PluginContext): void {
@@ -236,7 +236,7 @@ export function registerBootstrapHook(api: OpenClawPluginApi, ctx: PluginContext
         const { content, source } = await loadOrchestratorInstructions(workspaceDir, projectName, { withSource: true });
         if (!content.trim()) return;
 
-        const promptFileName = "DEVCLAW_ORCHESTRATOR_PROMPT.md";
+        const promptFileName = "orchestrator.md";
         const existingPromptEntry = bootstrapFiles.find((f) => f.name === promptFileName);
         const promptEntry = existingPromptEntry ?? {
           name: promptFileName,

--- a/lib/dispatch/bootstrap-hook.ts
+++ b/lib/dispatch/bootstrap-hook.ts
@@ -5,8 +5,9 @@
  *   1. agent:bootstrap (internal hook) for worker sessions, replacing the
  *      orchestrator's AGENTS.md with role-specific instructions so workers see
  *      their own prompt on every turn.
- *   2. agent:bootstrap handling for main/orchestrator sessions, appending live
- *      workspace and project-specific orchestrator prompt layers to AGENTS.md.
+ *   2. agent:bootstrap handling for main/orchestrator sessions, injecting live
+ *      workspace and project-specific orchestrator prompt layers as a separate
+ *      bootstrap file instead of piggybacking on AGENTS.md.
  *   3. Prompt loaders used by bootstrap and dispatch fallback paths.
  */
 import fs from "node:fs/promises";
@@ -121,6 +122,9 @@ export async function loadRoleInstructions(
  *   2. devclaw/prompts/orchestrator.md
  *   3. devclaw/projects/<project>/prompts/orchestrator.md
  *   4. package default
+ *
+ * The returned content is meant for a dedicated bootstrap file so it remains
+ * independently loadable even when AGENTS.md is truncated by bootstrap limits.
  */
 export async function loadOrchestratorInstructions(
   workspaceDir: string,
@@ -221,10 +225,10 @@ async function resolveProjectNameForBootstrap(
  *   2. devclaw/prompts/<role>.md
  *   3. package default prompt
  *
- * Orchestrator precedence inside bootstrap AGENTS content:
+ * Orchestrator precedence inside bootstrap context:
  *   1. existing AGENTS.md/runtime baseline
- *   2. devclaw/prompts/orchestrator.md
- *   3. devclaw/projects/<project>/prompts/orchestrator.md
+ *   2. DEVCLAW_ORCHESTRATOR_PROMPT.md (workspace orchestrator prompt layer)
+ *   3. DEVCLAW_ORCHESTRATOR_PROMPT.md (project orchestrator prompt layer)
  *   4. issue/task/chat-specific context (outside this hook)
  */
 export function registerBootstrapHook(api: OpenClawPluginApi, ctx: PluginContext): void {
@@ -275,12 +279,21 @@ export function registerBootstrapHook(api: OpenClawPluginApi, ctx: PluginContext
         const { content, sources } = await loadOrchestratorInstructions(workspaceDir, projectName, { withSource: true });
         if (!content.trim()) return;
 
-        const baseline = agentsEntry.content?.trimEnd() ?? "";
-        const separator = baseline ? "\n\n" : "";
-        agentsEntry.content = `${baseline}${separator}<!-- DEVCLAW:ORCHESTRATOR-PROMPT -->\n${content.trim()}\n<!-- /DEVCLAW:ORCHESTRATOR-PROMPT -->\n`;
-        agentsEntry.missing = false;
+        const promptFileName = "DEVCLAW_ORCHESTRATOR_PROMPT.md";
+        const existingPromptEntry = bootstrapFiles.find((f) => f.name === promptFileName);
+        const promptEntry = existingPromptEntry ?? {
+          name: promptFileName,
+          path: path.join(workspaceDir, promptFileName),
+          content: "",
+          missing: false,
+        };
+
+        promptEntry.content = content.trim();
+        promptEntry.missing = false;
+        if (!existingPromptEntry) bootstrapFiles.push(promptEntry);
+
         ctx.logger.info(
-          `agent:bootstrap: appended orchestrator instructions${projectName ? ` for "${projectName}"` : ""} from ${sources.join(" -> ")}`,
+          `agent:bootstrap: injected orchestrator prompt file${projectName ? ` for "${projectName}"` : ""} from ${sources.join(" -> ")}`,
         );
         return;
       }
@@ -309,7 +322,7 @@ export function registerBootstrapHook(api: OpenClawPluginApi, ctx: PluginContext
     {
       name: "devclaw-bootstrap-role-instructions",
       description:
-        "Replaces worker AGENTS.md with role prompts and appends live orchestrator prompts for main sessions",
+        "Replaces worker AGENTS.md with role prompts and injects live orchestrator prompts for main sessions",
     } as any,
   );
 }

--- a/lib/services/bootstrap.e2e.test.ts
+++ b/lib/services/bootstrap.e2e.test.ts
@@ -320,6 +320,48 @@ describe("E2E bootstrap — agent:bootstrap hook (AGENTS.md stripping)", () => {
     assert.ok(!result.files["orchestrator.md"]?.content.includes("DevClaw topic prompt"));
   });
 
+  it("should use the chat-level project prompt for unrelated topics in the same chat", async () => {
+    h = await createTestHarness({
+      projectName: "firstlight",
+      channelId: "-1003746138337",
+    });
+
+    const workspacePrompt = "Workspace orchestrator prompt";
+    const projectPrompt = "How many licks does it take to get to the tootsie roll center of a tootsie pop? 365";
+    await h.writePrompt("orchestrator", workspacePrompt);
+    await h.writePrompt("orchestrator", projectPrompt, "firstlight");
+
+    const result = await h.simulateBootstrap("agent:main:orchestrator", { messageThreadId: 1 });
+    assert.strictEqual(result.files["orchestrator.md"]?.content, projectPrompt);
+    assert.ok(!result.files["orchestrator.md"]?.content.includes(workspacePrompt));
+  });
+
+  it("should still use the same project prompt for an exact topic binding when both chat and topic bindings exist", async () => {
+    h = await createTestHarness({
+      projectName: "firstlight",
+      channelId: "-1003746138337",
+    });
+
+    const data = await h.readProjects();
+    data.projects.firstlight!.channels.push({
+      channelId: "-1003746138337",
+      channel: "telegram",
+      messageThreadId: 2270,
+      name: "First Light topic",
+      events: ["*"],
+    });
+    await h.writeProjects(data);
+
+    const workspacePrompt = "Workspace orchestrator prompt";
+    const projectPrompt = "How many licks does it take to get to the tootsie roll center of a tootsie pop? 365";
+    await h.writePrompt("orchestrator", workspacePrompt);
+    await h.writePrompt("orchestrator", projectPrompt, "firstlight");
+
+    const result = await h.simulateBootstrap("agent:main:orchestrator", { messageThreadId: 2270 });
+    assert.strictEqual(result.files["orchestrator.md"]?.content, projectPrompt);
+    assert.ok(!result.files["orchestrator.md"]?.content.includes(workspacePrompt));
+  });
+
   it("should NOT strip AGENTS.md for unknown roles", async () => {
     h = await createTestHarness({ projectName: "custom-app" });
 

--- a/lib/services/bootstrap.e2e.test.ts
+++ b/lib/services/bootstrap.e2e.test.ts
@@ -228,10 +228,10 @@ describe("E2E bootstrap — agent:bootstrap hook (AGENTS.md stripping)", () => {
     assert.ok(!result.agentsMdContent.includes("Workspace orchestrator prompt"));
     assert.ok(!result.agentsMdContent.includes("Project orchestrator prompt"));
     assert.strictEqual(
-      result.files["DEVCLAW_ORCHESTRATOR_PROMPT.md"]?.content,
+      result.files["orchestrator.md"]?.content,
       "Project orchestrator prompt",
     );
-    assert.strictEqual(result.files["DEVCLAW_ORCHESTRATOR_PROMPT.md"]?.missing, false);
+    assert.strictEqual(result.files["orchestrator.md"]?.missing, false);
   });
 
   it("should resolve topic-bound projects for orchestrator prompt injection", async () => {
@@ -271,10 +271,10 @@ describe("E2E bootstrap — agent:bootstrap hook (AGENTS.md stripping)", () => {
 
     const result = await h.simulateBootstrap("agent:main:orchestrator", { messageThreadId: 183 });
     assert.strictEqual(
-      result.files["DEVCLAW_ORCHESTRATOR_PROMPT.md"]?.content,
+      result.files["orchestrator.md"]?.content,
       "DevClaw topic prompt",
     );
-    assert.ok(!result.files["DEVCLAW_ORCHESTRATOR_PROMPT.md"]?.content.includes("Root project prompt"));
+    assert.ok(!result.files["orchestrator.md"]?.content.includes("Root project prompt"));
   });
 
   it("should fall back to chat-level project when no topic-specific binding matches", async () => {
@@ -314,10 +314,10 @@ describe("E2E bootstrap — agent:bootstrap hook (AGENTS.md stripping)", () => {
 
     const result = await h.simulateBootstrap("agent:main:orchestrator", { messageThreadId: 999 });
     assert.strictEqual(
-      result.files["DEVCLAW_ORCHESTRATOR_PROMPT.md"]?.content,
+      result.files["orchestrator.md"]?.content,
       "Root project prompt",
     );
-    assert.ok(!result.files["DEVCLAW_ORCHESTRATOR_PROMPT.md"]?.content.includes("DevClaw topic prompt"));
+    assert.ok(!result.files["orchestrator.md"]?.content.includes("DevClaw topic prompt"));
   });
 
   it("should NOT strip AGENTS.md for unknown roles", async () => {

--- a/lib/services/bootstrap.e2e.test.ts
+++ b/lib/services/bootstrap.e2e.test.ts
@@ -217,7 +217,7 @@ describe("E2E bootstrap — agent:bootstrap hook (AGENTS.md stripping)", () => {
     assert.match(result.agentsMdContent, /Developer/i);
   });
 
-  it("should inject orchestrator prompt layers as a dedicated bootstrap file for main sessions", async () => {
+  it("should inject the winning orchestrator prompt as a dedicated bootstrap file for main sessions", async () => {
     h = await createTestHarness();
     await h.writePrompt("orchestrator", "Workspace orchestrator prompt");
     await h.writePrompt("orchestrator", "Project orchestrator prompt", h.project.name);
@@ -229,7 +229,7 @@ describe("E2E bootstrap — agent:bootstrap hook (AGENTS.md stripping)", () => {
     assert.ok(!result.agentsMdContent.includes("Project orchestrator prompt"));
     assert.strictEqual(
       result.files["DEVCLAW_ORCHESTRATOR_PROMPT.md"]?.content,
-      "Workspace orchestrator prompt\n\nProject orchestrator prompt",
+      "Project orchestrator prompt",
     );
     assert.strictEqual(result.files["DEVCLAW_ORCHESTRATOR_PROMPT.md"]?.missing, false);
   });
@@ -272,7 +272,7 @@ describe("E2E bootstrap — agent:bootstrap hook (AGENTS.md stripping)", () => {
     const result = await h.simulateBootstrap("agent:main:orchestrator", { messageThreadId: 183 });
     assert.strictEqual(
       result.files["DEVCLAW_ORCHESTRATOR_PROMPT.md"]?.content,
-      "Workspace orchestrator prompt\n\nDevClaw topic prompt",
+      "DevClaw topic prompt",
     );
     assert.ok(!result.files["DEVCLAW_ORCHESTRATOR_PROMPT.md"]?.content.includes("Root project prompt"));
   });
@@ -315,7 +315,7 @@ describe("E2E bootstrap — agent:bootstrap hook (AGENTS.md stripping)", () => {
     const result = await h.simulateBootstrap("agent:main:orchestrator", { messageThreadId: 999 });
     assert.strictEqual(
       result.files["DEVCLAW_ORCHESTRATOR_PROMPT.md"]?.content,
-      "Workspace orchestrator prompt\n\nRoot project prompt",
+      "Root project prompt",
     );
     assert.ok(!result.files["DEVCLAW_ORCHESTRATOR_PROMPT.md"]?.content.includes("DevClaw topic prompt"));
   });

--- a/lib/services/bootstrap.e2e.test.ts
+++ b/lib/services/bootstrap.e2e.test.ts
@@ -215,11 +215,17 @@ describe("E2E bootstrap — agent:bootstrap hook (AGENTS.md stripping)", () => {
     assert.strictEqual(result.agentsMdStripped, true);
   });
 
-  it("should NOT strip AGENTS.md for non-DevClaw sessions", async () => {
+  it("should append orchestrator prompt layers for main sessions", async () => {
     h = await createTestHarness();
+    await h.writePrompt("orchestrator", "Workspace orchestrator prompt");
+    await h.writePrompt("orchestrator", "Project orchestrator prompt", h.project.name);
 
     const result = await h.simulateBootstrap("agent:main:orchestrator");
     assert.strictEqual(result.agentsMdStripped, false);
+    assert.match(result.agentsMdContent, /# Orchestrator instructions/);
+    assert.match(result.agentsMdContent, /Workspace orchestrator prompt/);
+    assert.match(result.agentsMdContent, /Project orchestrator prompt/);
+    assert.match(result.agentsMdContent, /Workspace orchestrator prompt[\s\S]*Project orchestrator prompt/);
   });
 
   it("should NOT strip AGENTS.md for unknown roles", async () => {

--- a/lib/services/bootstrap.e2e.test.ts
+++ b/lib/services/bootstrap.e2e.test.ts
@@ -206,16 +206,18 @@ describe("E2E bootstrap — agent:bootstrap hook (AGENTS.md stripping)", () => {
     if (h) await h.cleanup();
   });
 
-  it("should strip AGENTS.md for DevClaw worker sessions", async () => {
+  it("should replace AGENTS.md with worker instructions for DevClaw worker sessions", async () => {
     h = await createTestHarness({ projectName: "my-app" });
 
     const result = await h.simulateBootstrap(
       "agent:main:subagent:my-app-developer-medior-Ada",
     );
-    assert.strictEqual(result.agentsMdStripped, true);
+    assert.strictEqual(result.agentsMdStripped, false);
+    assert.ok(!result.agentsMdContent.includes("This content should be stripped."));
+    assert.match(result.agentsMdContent, /Developer/i);
   });
 
-  it("should append orchestrator prompt layers for main sessions", async () => {
+  it("should inject orchestrator prompt layers as a dedicated bootstrap file for main sessions", async () => {
     h = await createTestHarness();
     await h.writePrompt("orchestrator", "Workspace orchestrator prompt");
     await h.writePrompt("orchestrator", "Project orchestrator prompt", h.project.name);
@@ -223,9 +225,13 @@ describe("E2E bootstrap — agent:bootstrap hook (AGENTS.md stripping)", () => {
     const result = await h.simulateBootstrap("agent:main:orchestrator");
     assert.strictEqual(result.agentsMdStripped, false);
     assert.match(result.agentsMdContent, /# Orchestrator instructions/);
-    assert.match(result.agentsMdContent, /Workspace orchestrator prompt/);
-    assert.match(result.agentsMdContent, /Project orchestrator prompt/);
-    assert.match(result.agentsMdContent, /Workspace orchestrator prompt[\s\S]*Project orchestrator prompt/);
+    assert.ok(!result.agentsMdContent.includes("Workspace orchestrator prompt"));
+    assert.ok(!result.agentsMdContent.includes("Project orchestrator prompt"));
+    assert.strictEqual(
+      result.files["DEVCLAW_ORCHESTRATOR_PROMPT.md"]?.content,
+      "Workspace orchestrator prompt\n\nProject orchestrator prompt",
+    );
+    assert.strictEqual(result.files["DEVCLAW_ORCHESTRATOR_PROMPT.md"]?.missing, false);
   });
 
   it("should NOT strip AGENTS.md for unknown roles", async () => {

--- a/lib/services/bootstrap.e2e.test.ts
+++ b/lib/services/bootstrap.e2e.test.ts
@@ -234,6 +234,92 @@ describe("E2E bootstrap — agent:bootstrap hook (AGENTS.md stripping)", () => {
     assert.strictEqual(result.files["DEVCLAW_ORCHESTRATOR_PROMPT.md"]?.missing, false);
   });
 
+  it("should resolve topic-bound projects for orchestrator prompt injection", async () => {
+    h = await createTestHarness({
+      projectName: "root-project",
+      channelId: "-1003581929219",
+      extraProjects: {
+        devclaw: {
+          slug: "devclaw",
+          name: "devclaw",
+          repo: "/tmp/devclaw",
+          groupName: "DevClaw Topic",
+          deployUrl: "",
+          baseBranch: "main",
+          deployBranch: "main",
+          channels: [{
+            channelId: "-1003581929219",
+            channel: "telegram",
+            messageThreadId: 183,
+            name: "topic",
+            events: ["*"],
+          }],
+          provider: "github",
+          workers: {
+            developer: { levels: {} },
+            tester: { levels: {} },
+            architect: { levels: {} },
+            reviewer: { levels: {} },
+          },
+        },
+      },
+    });
+
+    await h.writePrompt("orchestrator", "Workspace orchestrator prompt");
+    await h.writePrompt("orchestrator", "Root project prompt", "root-project");
+    await h.writePrompt("orchestrator", "DevClaw topic prompt", "devclaw");
+
+    const result = await h.simulateBootstrap("agent:main:orchestrator", { messageThreadId: 183 });
+    assert.strictEqual(
+      result.files["DEVCLAW_ORCHESTRATOR_PROMPT.md"]?.content,
+      "Workspace orchestrator prompt\n\nDevClaw topic prompt",
+    );
+    assert.ok(!result.files["DEVCLAW_ORCHESTRATOR_PROMPT.md"]?.content.includes("Root project prompt"));
+  });
+
+  it("should fall back to chat-level project when no topic-specific binding matches", async () => {
+    h = await createTestHarness({
+      projectName: "root-project",
+      channelId: "-1003581929219",
+      extraProjects: {
+        devclaw: {
+          slug: "devclaw",
+          name: "devclaw",
+          repo: "/tmp/devclaw",
+          groupName: "DevClaw Topic",
+          deployUrl: "",
+          baseBranch: "main",
+          deployBranch: "main",
+          channels: [{
+            channelId: "-1003581929219",
+            channel: "telegram",
+            messageThreadId: 183,
+            name: "topic",
+            events: ["*"],
+          }],
+          provider: "github",
+          workers: {
+            developer: { levels: {} },
+            tester: { levels: {} },
+            architect: { levels: {} },
+            reviewer: { levels: {} },
+          },
+        },
+      },
+    });
+
+    await h.writePrompt("orchestrator", "Workspace orchestrator prompt");
+    await h.writePrompt("orchestrator", "Root project prompt", "root-project");
+    await h.writePrompt("orchestrator", "DevClaw topic prompt", "devclaw");
+
+    const result = await h.simulateBootstrap("agent:main:orchestrator", { messageThreadId: 999 });
+    assert.strictEqual(
+      result.files["DEVCLAW_ORCHESTRATOR_PROMPT.md"]?.content,
+      "Workspace orchestrator prompt\n\nRoot project prompt",
+    );
+    assert.ok(!result.files["DEVCLAW_ORCHESTRATOR_PROMPT.md"]?.content.includes("DevClaw topic prompt"));
+  });
+
   it("should NOT strip AGENTS.md for unknown roles", async () => {
     h = await createTestHarness({ projectName: "custom-app" });
 

--- a/lib/setup/templates.ts
+++ b/lib/setup/templates.ts
@@ -49,6 +49,9 @@ const DEFAULT_DEV_INSTRUCTIONS = loadDefault("devclaw/prompts/developer.md");
 const DEFAULT_QA_INSTRUCTIONS = loadDefault("devclaw/prompts/tester.md");
 const DEFAULT_ARCHITECT_INSTRUCTIONS = loadDefault("devclaw/prompts/architect.md");
 const DEFAULT_REVIEWER_INSTRUCTIONS = loadDefault("devclaw/prompts/reviewer.md");
+const DEFAULT_ORCHESTRATOR_INSTRUCTIONS = loadDefault("devclaw/prompts/orchestrator.md");
+
+export const DEFAULT_ORCHESTRATOR_PROMPT = DEFAULT_ORCHESTRATOR_INSTRUCTIONS;
 
 /** Default role instructions indexed by role ID. Used by project scaffolding. */
 export const DEFAULT_ROLE_INSTRUCTIONS: Record<string, string> = {
@@ -56,6 +59,12 @@ export const DEFAULT_ROLE_INSTRUCTIONS: Record<string, string> = {
   tester: DEFAULT_QA_INSTRUCTIONS,
   architect: DEFAULT_ARCHITECT_INSTRUCTIONS,
   reviewer: DEFAULT_REVIEWER_INSTRUCTIONS,
+};
+
+/** Prompt files scaffolded into devclaw/prompts/. Includes non-worker orchestrator prompt. */
+export const DEFAULT_PROMPT_INSTRUCTIONS: Record<string, string> = {
+  ...DEFAULT_ROLE_INSTRUCTIONS,
+  orchestrator: DEFAULT_ORCHESTRATOR_INSTRUCTIONS,
 };
 
 // ---------------------------------------------------------------------------

--- a/lib/setup/workspace.test.ts
+++ b/lib/setup/workspace.test.ts
@@ -56,7 +56,9 @@ describe("ensureDefaultFiles — managed root-block behavior", () => {
     const ws = await makeTmpDir();
     await ensureDefaultFiles(ws);
     const devPrompt = path.join(ws, DATA_DIR, "prompts", "developer.md");
+    const orchestratorPrompt = path.join(ws, DATA_DIR, "prompts", "orchestrator.md");
     assert.ok(await fileExists(devPrompt), "developer.md prompt should be created");
+    assert.ok(await fileExists(orchestratorPrompt), "orchestrator.md prompt should be created");
   });
 
   it("should NOT overwrite existing prompt files", async () => {

--- a/lib/setup/workspace.ts
+++ b/lib/setup/workspace.ts
@@ -21,9 +21,8 @@ import {
   SOUL_MD_TEMPLATE,
   TOOLS_MD_TEMPLATE,
   WORKFLOW_YAML_TEMPLATE,
-  DEFAULT_ROLE_INSTRUCTIONS,
+  DEFAULT_PROMPT_INSTRUCTIONS,
 } from "./templates.js";
-import { getAllRoleIds } from "../roles/index.js";
 import { migrateWorkspaceLayout, DATA_DIR } from "./migrate-layout.js";
 import { writeVersionFile, detectUpgrade } from "./version.js";
 import { log as auditLog } from "../audit.js";
@@ -100,11 +99,10 @@ export async function ensureWorkspaceDataFiles(workspacePath: string): Promise<v
   const projectsJsonPath = path.join(dataDir, "projects.json");
   await writeIfMissing(projectsJsonPath, JSON.stringify({ projects: {} }, null, 2) + "\n");
 
-  // devclaw/prompts/ — create-only per role (user customizations are preserved)
-  for (const role of getAllRoleIds()) {
-    const rolePath = path.join(dataDir, "prompts", `${role}.md`);
-    const content = DEFAULT_ROLE_INSTRUCTIONS[role];
-    if (content) await writeIfMissing(rolePath, content);
+  // devclaw/prompts/ — create-only per prompt target (user customizations are preserved)
+  for (const [promptName, content] of Object.entries(DEFAULT_PROMPT_INSTRUCTIONS)) {
+    const promptPath = path.join(dataDir, "prompts", `${promptName}.md`);
+    if (content) await writeIfMissing(promptPath, content);
   }
 
   // Version tracking
@@ -147,9 +145,8 @@ export async function writeAllDefaults(workspacePath: string, force = false): Pr
     [path.join(dataDir, "workflow.yaml"), WORKFLOW_YAML_TEMPLATE],
   ];
 
-  for (const role of getAllRoleIds()) {
-    const content = DEFAULT_ROLE_INSTRUCTIONS[role];
-    if (content) files.push([path.join(dataDir, "prompts", `${role}.md`), content]);
+  for (const [promptName, content] of Object.entries(DEFAULT_PROMPT_INSTRUCTIONS)) {
+    if (content) files.push([path.join(dataDir, "prompts", `${promptName}.md`), content]);
   }
 
   for (const [filePath, content] of files) {

--- a/lib/testing/harness.ts
+++ b/lib/testing/harness.ts
@@ -25,6 +25,8 @@ export type BootstrapResult = {
   agentsMdStripped: boolean;
   /** Final AGENTS.md content after bootstrap hook mutation. */
   agentsMdContent: string;
+  /** Final bootstrap files after hook mutation, indexed by file name. */
+  files: Record<string, { content: string; missing: boolean }>;
 };
 
 // ---------------------------------------------------------------------------
@@ -329,6 +331,12 @@ export async function createTestHarness(opts?: HarnessOptions): Promise<TestHarn
       return {
         agentsMdStripped: bootstrapFiles[0].missing === true && bootstrapFiles[0].content === "",
         agentsMdContent: bootstrapFiles[0].content ?? "",
+        files: Object.fromEntries(
+          bootstrapFiles.map((file) => [
+            file.name,
+            { content: file.content ?? "", missing: file.missing },
+          ]),
+        ),
       };
     },
     async cleanup() {

--- a/lib/testing/harness.ts
+++ b/lib/testing/harness.ts
@@ -23,6 +23,8 @@ import type { PluginContext } from "../context.js";
 export type BootstrapResult = {
   /** Whether AGENTS.md was stripped from bootstrap files. */
   agentsMdStripped: boolean;
+  /** Final AGENTS.md content after bootstrap hook mutation. */
+  agentsMdContent: string;
 };
 
 // ---------------------------------------------------------------------------
@@ -170,7 +172,7 @@ export type TestHarness = {
    * Simulate the agent:bootstrap hook firing for a session key.
    * Tests that AGENTS.md is stripped from bootstrap files for DevClaw workers.
    */
-  simulateBootstrap(sessionKey: string): Promise<BootstrapResult>;
+  simulateBootstrap(sessionKey: string, context?: Record<string, unknown>): Promise<BootstrapResult>;
   /** Clean up temp directory. */
   cleanup(): Promise<void>;
 };
@@ -284,7 +286,7 @@ export async function createTestHarness(opts?: HarnessOptions): Promise<TestHarn
       await fs.mkdir(dir, { recursive: true });
       await fs.writeFile(path.join(dir, `${role}.md`), content, "utf-8");
     },
-    async simulateBootstrap(sessionKey: string) {
+    async simulateBootstrap(sessionKey: string, extraContext?: Record<string, unknown>) {
       // Capture the agent:bootstrap hook callback
       let internalHookCb: ((event: any) => Promise<void>) | null = null;
       const mockApi = {
@@ -320,12 +322,13 @@ export async function createTestHarness(opts?: HarnessOptions): Promise<TestHarn
       if (hookCb) {
         await hookCb({
           sessionKey,
-          context: { bootstrapFiles },
+          context: { workspaceDir, conversationId: channelId, channelId, channel: "telegram", bootstrapFiles, ...extraContext },
         });
       }
 
       return {
         agentsMdStripped: bootstrapFiles[0].missing === true && bootstrapFiles[0].content === "",
+        agentsMdContent: bootstrapFiles[0].content ?? "",
       };
     },
     async cleanup() {

--- a/lib/tools/admin/config-reset.ts
+++ b/lib/tools/admin/config-reset.ts
@@ -11,8 +11,7 @@ import type { ToolContext } from "../../types.js";
 import type { PluginContext } from "../../context.js";
 import { requireWorkspaceDir } from "../helpers.js";
 import { backupAndWrite } from "../../setup/workspace.js";
-import { WORKFLOW_YAML_TEMPLATE, DEFAULT_ROLE_INSTRUCTIONS } from "../../setup/templates.js";
-import { getAllRoleIds } from "../../roles/index.js";
+import { WORKFLOW_YAML_TEMPLATE, DEFAULT_PROMPT_INSTRUCTIONS } from "../../setup/templates.js";
 import { DATA_DIR } from "../../setup/migrate-layout.js";
 import { log as auditLog } from "../../audit.js";
 
@@ -34,7 +33,7 @@ export function createConfigResetTool(_ctx: PluginContext) {
           type: "string",
           enum: ["workflow", "prompts", "all"],
           description:
-            "What to reset. 'workflow' = workflow.yaml, 'prompts' = devclaw/prompts/*.md, 'all' = both. Default: 'all'.",
+            "What to reset. 'workflow' = workflow.yaml, 'prompts' = devclaw/prompts/*.md (including orchestrator.md), 'all' = both. Default: 'all'.",
         },
       },
       required: ["channelId"],
@@ -54,12 +53,11 @@ export function createConfigResetTool(_ctx: PluginContext) {
       if (target === "prompts" || target === "all") {
         const promptsDir = path.join(dataDir, "prompts");
         await fs.mkdir(promptsDir, { recursive: true });
-        for (const role of getAllRoleIds()) {
-          const content = DEFAULT_ROLE_INSTRUCTIONS[role];
+        for (const [promptName, content] of Object.entries(DEFAULT_PROMPT_INSTRUCTIONS)) {
           if (!content) continue;
-          const rolePath = path.join(promptsDir, `${role}.md`);
-          await backupAndWrite(rolePath, content);
-          resetFiles.push(`devclaw/prompts/${role}.md`);
+          const promptPath = path.join(promptsDir, `${promptName}.md`);
+          await backupAndWrite(promptPath, content);
+          resetFiles.push(`devclaw/prompts/${promptName}.md`);
         }
       }
 

--- a/lib/tools/admin/config.ts
+++ b/lib/tools/admin/config.ts
@@ -13,7 +13,7 @@ import { jsonResult } from "../../json-result.js";
 import type { ToolContext } from "../../types.js";
 import type { PluginContext } from "../../context.js";
 import { writeAllDefaults, backupAndWrite, fileExists } from "../../setup/workspace.js";
-import { WORKFLOW_YAML_TEMPLATE, DEFAULT_ROLE_INSTRUCTIONS } from "../../setup/templates.js";
+import { WORKFLOW_YAML_TEMPLATE, DEFAULT_PROMPT_INSTRUCTIONS } from "../../setup/templates.js";
 import { DATA_DIR } from "../../setup/migrate-layout.js";
 import { getCurrentVersion, readVersionFile } from "../../setup/version.js";
 import { getBuildProvenance, formatBuildProvenanceSummary } from "../../build-provenance.js";
@@ -92,11 +92,11 @@ async function handleReset(workspacePath: string, scope: string) {
     written.push("devclaw/workflow.yaml");
   } else if (scope === "prompts") {
     const promptsDir = path.join(dataDir, "prompts");
-    for (const [role, content] of Object.entries(DEFAULT_ROLE_INSTRUCTIONS)) {
+    for (const [promptName, content] of Object.entries(DEFAULT_PROMPT_INSTRUCTIONS)) {
       if (!content) continue;
-      const rolePath = path.join(promptsDir, `${role}.md`);
+      const rolePath = path.join(promptsDir, `${promptName}.md`);
       await backupAndWrite(rolePath, content);
-      written.push(`devclaw/prompts/${role}.md`);
+      written.push(`devclaw/prompts/${promptName}.md`);
     }
   } else {
     throw new Error(`Unknown scope: ${scope}. Use: prompts, workflow, or all.`);

--- a/lib/tools/admin/project-register.ts
+++ b/lib/tools/admin/project-register.ts
@@ -49,7 +49,7 @@ Example: \`prompts/developer.md\` overrides the default developer instructions f
 Files here take priority over the workspace defaults in \`devclaw/prompts/\`.
 
 The orchestrator also supports a live project-specific override at \`prompts/orchestrator.md\`.
-That file is injected into the main orchestrator session through a dedicated bootstrap file, after the \`AGENTS.md\` baseline and after the workspace-wide \`devclaw/prompts/orchestrator.md\` layer.
+That file is injected into the main orchestrator session through a dedicated bootstrap file after the \`AGENTS.md\` baseline. If it exists, it wins over the workspace-wide \`devclaw/prompts/orchestrator.md\`; otherwise DevClaw falls back to the workspace file, then the package default.
 
 ## Workflow Overrides
 

--- a/lib/tools/admin/project-register.ts
+++ b/lib/tools/admin/project-register.ts
@@ -43,10 +43,13 @@ This directory holds project-specific configuration that overrides the workspace
 
 To override default worker instructions, create \`prompts/<role>.md\`:
 
-Available roles: ${roles}
+Available worker roles: ${roles}
 
 Example: \`prompts/developer.md\` overrides the default developer instructions for this project only.
 Files here take priority over the workspace defaults in \`devclaw/prompts/\`.
+
+The orchestrator also supports a live project-specific override at \`prompts/orchestrator.md\`.
+That file is layered into the main orchestrator session after \`AGENTS.md\` and after the workspace-wide \`devclaw/prompts/orchestrator.md\`.
 
 ## Workflow Overrides
 

--- a/lib/tools/admin/project-register.ts
+++ b/lib/tools/admin/project-register.ts
@@ -49,7 +49,7 @@ Example: \`prompts/developer.md\` overrides the default developer instructions f
 Files here take priority over the workspace defaults in \`devclaw/prompts/\`.
 
 The orchestrator also supports a live project-specific override at \`prompts/orchestrator.md\`.
-That file is layered into the main orchestrator session after \`AGENTS.md\` and after the workspace-wide \`devclaw/prompts/orchestrator.md\`.
+That file is injected into the main orchestrator session through a dedicated bootstrap file, after the \`AGENTS.md\` baseline and after the workspace-wide \`devclaw/prompts/orchestrator.md\` layer.
 
 ## Workflow Overrides
 


### PR DESCRIPTION
## Summary
- promote the validated live-loading orchestrator prompt slice from `issue/183-live-orchestrator-prompts`
- preserve the operator-validated commit chain ending at `e5b80a2`
- add coverage for chat-level and topic-bound orchestrator prompt fallback behavior

## Validation
- `npx tsx --test lib/dispatch/bootstrap-hook.test.ts lib/services/bootstrap.e2e.test.ts lib/setup/workspace.test.ts`
