### PR TITLE
feat: add live orchestrator intervention policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ GitHub/GitLab issues are the single source of truth — not an internal database
 
 - **[External task state](#your-issues-stay-in-your-tracker)** — labels, transitions, and status queries go through your issue tracker
 - **[Atomic operations](#what-atomic-means-here)** — label transition + state update + session dispatch + audit log in one call
-- **[Tool-based guardrails](#the-toolbox)** — 23 tools enforce the process; the agent provides intent, the plugin handles mechanics
+- **[Tool-based guardrails](#the-toolbox)** — 24 tools enforce the process; the agent provides intent, the plugin handles mechanics
 
 ### ~60-80% token savings
 
@@ -223,7 +223,7 @@ With the optional test phase enabled, an additional QA cycle runs before closing
 - **TESTER "pass"** → `Done`, issue closes
 - **TESTER "fail"** → `To Improve`, back to DEV
 
-The orchestrator doesn't need to poll, check, or coordinate. Workers are self-reporting.
+The orchestrator doesn't need to poll, check, or coordinate for the normal path. Workers are self-reporting, and optional intervention policy can wake or steer follow-up actions when configured.
 
 ### Research tasks follow a separate path
 
@@ -282,7 +282,7 @@ When a worker calls `work_finish`, the plugin transitions the label. The schedul
 - **PR approved** → auto-merge → label moves to `Done`, issue closes
 - **"blocked"** → label reverts to queue (`To Do`) for retry
 
-No orchestrator involvement. Workers self-report, the scheduler fills free slots.
+No manual orchestrator involvement for the normal path. Workers self-report, the scheduler fills free slots, and optional intervention policy can step in on matched live events.
 
 ### Execution modes
 
@@ -395,6 +395,19 @@ The orchestrator is a **planner and dispatcher** — not a coder. This separatio
 
 ### What the orchestrator does
 
+### Live intervention policy
+
+DevClaw now supports a structured live intervention layer on top of the normal pipeline:
+
+- workflow and worker activity is normalized into a per-project event timeline under `devclaw/log/orchestrator-events.<project>.ndjson`
+- the operator can manage intervention rules with `orchestrator_intervention`
+- rules can be project-wide or issue-specific, and can be changed while work is in flight
+- matched rules are either `notify` only or `auto`
+- v1 action guardrails are explicit: `comment`, `set_level`, `requeue`, `queue_issue`, `create_followup`
+- every event match and every intervention decision is audit-logged
+
+This keeps the heartbeat authoritative for the default workflow, while giving the orchestrator a bounded, inspectable way to steer exceptional flow.
+
 - **Plans**: Analyzes requirements, breaks down work, decides priorities
 - **Dispatches**: Creates issues, assigns developer levels, starts workers
 - **Coordinates**: Monitors queue, handles status checks, answers questions
@@ -498,7 +511,7 @@ You can also use the [CLI wizard or non-interactive setup](docs/ONBOARDING.md#st
 
 ## The toolbox
 
-DevClaw gives the orchestrator 23 tools. These aren't just convenience wrappers — they're **guardrails**. Each tool encodes a complex multi-step operation into a single atomic call. The agent provides intent, the plugin handles mechanics. The agent physically cannot skip a label transition, forget to update state, or dispatch to the wrong session — those decisions are made by deterministic code, not LLM reasoning.
+DevClaw gives the orchestrator 24 tools. These aren't just convenience wrappers — they're **guardrails**. Each tool encodes a complex multi-step operation into a single atomic call. The agent provides intent, the plugin handles mechanics. The agent physically cannot skip a label transition, forget to update state, or dispatch to the wrong session — those decisions are made by deterministic code, not LLM reasoning.
 
 | Tool                   | What it does                                                                            |
 | ---------------------- | --------------------------------------------------------------------------------------- |

--- a/docs/MANAGEMENT.md
+++ b/docs/MANAGEMENT.md
@@ -30,7 +30,7 @@ Classical management theory — later formalized by Bernard Bass in his work on 
 
 DevClaw's task lifecycle is built on this. The orchestrator delegates a task via `task_start`, then steps away. It only re-engages in specific scenarios:
 
-1. **DEVELOPER completes work** → The label moves to `To Review`. The heartbeat polls PR status. No orchestrator involvement needed.
+1. **DEVELOPER completes work** → The label moves to `To Review`. The heartbeat polls PR status. No manual orchestrator involvement is needed on the default path, though intervention policy may wake or steer follow-up when configured.
 2. **PR is approved** → The heartbeat auto-merges the PR, closes the issue, and transitions to Done. Pipeline complete. (Or to `To Test` if the test phase is enabled.)
 3. **PR has issues** → Comments or changes-requested reviews move the issue to `To Improve`. The scheduler dispatches DEVELOPER on the next tick.
 4. **TESTER passes** (test phase only) → The issue closes. Pipeline complete.

--- a/docs/TOOLS.md
+++ b/docs/TOOLS.md
@@ -412,6 +412,35 @@ Reference guide for workflow configuration. Call before making any workflow chan
 
 ---
 
+### `orchestrator_intervention`
+
+Manage live orchestrator intervention policy and read the normalized intervention event timeline.
+
+**Actions**
+- `set_policy` — upsert a project-wide or issue-specific rule
+- `delete_policy` — remove a rule by id
+- `list_policies` — inspect saved rules
+- `get_events` — read recent structured workflow events for a project or issue
+
+**Supported event types**
+- `worker.completed`
+- `workflow.dispatch`
+- `workflow.requeue`
+- `workflow.hold`
+- `review.feedback`
+- `review.approved`
+- `review.pr_closed`
+- `pr.merged`
+
+**Supported action types**
+- `comment`
+- `set_level`
+- `requeue`
+- `queue_issue`
+- `create_followup`
+
+Rules run in either `notify` or `auto` mode. Every match and action is audit-logged.
+
 ### `research_task`
 
 Spawn an architect for a design investigation. Creates a `To Research` issue with rich context and dispatches an architect worker through `To Research` → `Researching` states.

--- a/index.ts
+++ b/index.ts
@@ -13,6 +13,7 @@ import { createTaskAttachTool } from "./lib/tools/tasks/task-attach.js";
 import { createTaskSetLevelTool } from "./lib/tools/tasks/task-set-level.js";
 import { createTaskOwnerTool } from "./lib/tools/tasks/task-owner.js";
 import { createResearchTaskTool } from "./lib/tools/tasks/research-task.js";
+import { createOrchestratorInterventionTool } from "./lib/tools/tasks/orchestrator-intervention.js";
 
 // Task queries
 import { createTaskListTool } from "./lib/tools/tasks/task-list.js";
@@ -106,6 +107,7 @@ const plugin = {
     api.registerTool(createTaskSetLevelTool(ctx), { names: ["task_set_level"] });
     api.registerTool(createTaskOwnerTool(ctx), { names: ["task_owner"] });
     api.registerTool(createResearchTaskTool(ctx), { names: ["research_task"] });
+    api.registerTool(createOrchestratorInterventionTool(ctx), { names: ["orchestrator_intervention"] });
 
     // Task queries
     api.registerTool(createTaskListTool(ctx), { names: ["task_list"] });
@@ -136,7 +138,7 @@ const plugin = {
     registerAttachmentHook(api, ctx);
 
     api.logger.info(
-      `DevClaw plugin registered (23 tools, 1 CLI command group, 1 service, 3 hooks) | build=${formatBuildProvenanceSummary(provenance)} | provenance=${JSON.stringify(provenance)}`,
+      `DevClaw plugin registered (24 tools, 1 CLI command group, 1 service, 3 hooks) | build=${formatBuildProvenanceSummary(provenance)} | provenance=${JSON.stringify(provenance)}`,
     );
   },
 };

--- a/lib/dispatch/index.ts
+++ b/lib/dispatch/index.ts
@@ -27,6 +27,7 @@ import { slotName } from "../names.js";
 import { buildTaskMessage, buildConflictFixMessage, buildAnnouncement, formatSessionLabel } from "./message-builder.js";
 import { ensureSessionFireAndForget, sendToAgent, shouldClearSession } from "./session.js";
 import { acknowledgeComments, EYES_EMOJI } from "./acknowledge.js";
+import { recordAndApplyInterventionEvent } from "../orchestrator-intervention/engine.js";
 
 export type DispatchOpts = {
   workspaceDir: string;
@@ -96,7 +97,7 @@ export async function dispatchTask(
   // ── Setup (no side effects — safe to fail) ──────────────────────────
   const resolvedConfig = await loadConfig(workspaceDir, project.name);
   const resolvedRole = resolvedConfig.roles[role];
-  const { timeouts } = resolvedConfig;
+  const { timeouts, workflow } = resolvedConfig;
   const model = resolveModel(role, level, resolvedRole);
   const roleWorker = getRoleWorker(project, role);
   const slot = roleWorker.levels[level]?.[slotIndex] ?? emptySlot();
@@ -156,7 +157,6 @@ export async function dispatchTask(
   const comments = await provider.listComments(issueId);
 
   // Fetch PR context based on workflow role semantics (no hardcoded role/label checks)
-  const { workflow } = resolvedConfig;
   const prFeedback = isFeedbackState(workflow, fromLabel)
     ? await fetchPrFeedback(provider, issueId) : undefined;
   const prContext = hasReviewCheck(workflow, role)
@@ -328,6 +328,25 @@ export async function dispatchTask(
   }
 
   // Step 6: Audit
+  await recordAndApplyInterventionEvent({
+    workspaceDir,
+    channelId: primaryChannelId,
+    project,
+    workflow,
+    provider,
+    issue: await provider.getIssue(issueId),
+    sessionKey,
+  }, {
+    eventType: "workflow.dispatch",
+    issueId,
+    role,
+    level,
+    fromState: fromLabel,
+    toState: toLabel,
+    source: "system",
+    data: { sessionAction, botName },
+  }).catch(() => {});
+
   await auditDispatch(workspaceDir, {
     project: project.name, issueId, issueTitle,
     role, level, model, sessionAction, sessionKey,

--- a/lib/dispatch/index.ts
+++ b/lib/dispatch/index.ts
@@ -331,11 +331,13 @@ export async function dispatchTask(
   await recordAndApplyInterventionEvent({
     workspaceDir,
     channelId: primaryChannelId,
+    agentId,
     project,
     workflow,
     provider,
     issue: await provider.getIssue(issueId),
     sessionKey,
+    runCommand: rc,
   }, {
     eventType: "workflow.dispatch",
     issueId,

--- a/lib/dispatch/session.ts
+++ b/lib/dispatch/session.ts
@@ -90,6 +90,45 @@ export type NotifyRoutingTarget = {
   messageThreadId?: number;
 };
 
+export function sendToSessionFireAndForget(
+  sessionKey: string,
+  message: string,
+  opts: {
+    agentId?: string;
+    workspaceDir: string;
+    runCommand: RunCommand;
+    dispatchTimeoutMs?: number;
+    lane?: "main" | "subagent";
+    notifyTarget?: NotifyRoutingTarget;
+    idempotencyKey?: string;
+    extraSystemPrompt?: string;
+    spawnedBy?: string;
+  },
+): void {
+  const rc = opts.runCommand;
+  const gatewayParamsRecord: Record<string, unknown> = {
+    idempotencyKey: opts.idempotencyKey ?? `devclaw-session-${sessionKey}`,
+    agentId: opts.agentId ?? "devclaw",
+    sessionKey,
+    message,
+    deliver: false,
+    ...(opts.lane ? { lane: opts.lane } : {}),
+    ...(opts.spawnedBy ? { spawnedBy: opts.spawnedBy } : {}),
+    ...(opts.extraSystemPrompt ? { extraSystemPrompt: opts.extraSystemPrompt } : {}),
+  };
+  applyNotifyRoutingToGatewayParams(gatewayParamsRecord, opts.notifyTarget);
+  const gatewayParams = JSON.stringify(gatewayParamsRecord);
+  rc(
+    ["openclaw", "gateway", "call", "agent", "--params", gatewayParams, "--expect-final", "--json"],
+    { timeoutMs: opts.dispatchTimeoutMs ?? 600_000 },
+  ).catch((err) => {
+    auditLog(opts.workspaceDir, "dispatch_warning", {
+      step: "sendToSession", sessionKey,
+      error: (err as Error).message ?? String(err),
+    }).catch(() => {});
+  });
+}
+
 function applyNotifyRoutingToGatewayParams(
   params: Record<string, unknown>,
   target: NotifyRoutingTarget | undefined,
@@ -130,28 +169,15 @@ export function sendToAgent(
     notifyTarget?: NotifyRoutingTarget;
   },
 ): void {
-  const rc = opts.runCommand;
-  const gatewayParamsRecord: Record<string, unknown> = {
-    idempotencyKey: `devclaw-${opts.projectName}-${opts.issueId}-${opts.role}-${opts.level ?? "unknown"}-${opts.slotIndex ?? 0}-${opts.fromLabel ?? "unknown"}-${sessionKey}`,
-    agentId: opts.agentId ?? "devclaw",
-    sessionKey,
-    message: taskMessage,
-    deliver: false,
+  sendToSessionFireAndForget(sessionKey, taskMessage, {
+    agentId: opts.agentId,
+    workspaceDir: opts.workspaceDir,
+    runCommand: opts.runCommand,
+    dispatchTimeoutMs: opts.dispatchTimeoutMs,
     lane: "subagent",
-    ...(opts.orchestratorSessionKey ? { spawnedBy: opts.orchestratorSessionKey } : {}),
-    ...(opts.extraSystemPrompt ? { extraSystemPrompt: opts.extraSystemPrompt } : {}),
-  };
-  applyNotifyRoutingToGatewayParams(gatewayParamsRecord, opts.notifyTarget);
-  const gatewayParams = JSON.stringify(gatewayParamsRecord);
-  // Fire-and-forget: long-running agent turn, don't await
-  rc(
-    ["openclaw", "gateway", "call", "agent", "--params", gatewayParams, "--expect-final", "--json"],
-    { timeoutMs: opts.dispatchTimeoutMs ?? 600_000 },
-  ).catch((err) => {
-    auditLog(opts.workspaceDir, "dispatch_warning", {
-      step: "sendToAgent", sessionKey,
-      issue: opts.issueId, role: opts.role,
-      error: (err as Error).message ?? String(err),
-    }).catch(() => {});
+    notifyTarget: opts.notifyTarget,
+    idempotencyKey: `devclaw-${opts.projectName}-${opts.issueId}-${opts.role}-${opts.level ?? "unknown"}-${opts.slotIndex ?? 0}-${opts.fromLabel ?? "unknown"}-${sessionKey}`,
+    extraSystemPrompt: opts.extraSystemPrompt,
+    spawnedBy: opts.orchestratorSessionKey,
   });
 }

--- a/lib/orchestrator-intervention/engine.test.ts
+++ b/lib/orchestrator-intervention/engine.test.ts
@@ -1,0 +1,83 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { createTestHarness } from "../testing/harness.js";
+import { upsertInterventionPolicy } from "./store.js";
+import { recordAndApplyInterventionEvent } from "./engine.js";
+
+describe("orchestrator intervention engine", () => {
+  it("executes an auto comment policy on matching review feedback", async () => {
+    const h = await createTestHarness();
+    try {
+      const issue = h.provider.seedIssue({ iid: 42, title: "Needs follow-up", labels: ["Refining"] });
+      await upsertInterventionPolicy(h.workspaceDir, h.project.slug, {
+        id: "comment-on-feedback",
+        title: "Comment on feedback",
+        mode: "auto",
+        event: { type: "review.feedback", reason: "changes_requested" },
+        action: { type: "comment", message: "Seen on #{{issueId}}: {{reason}}" },
+      });
+
+      const executions = await recordAndApplyInterventionEvent({
+        workspaceDir: h.workspaceDir,
+        channelId: h.channelId,
+        project: h.project,
+        workflow: h.workflow,
+        provider: h.provider,
+        issue,
+      }, {
+        eventType: "review.feedback",
+        issueId: 42,
+        reason: "changes_requested",
+        source: "heartbeat",
+      });
+
+      assert.equal(executions.length, 1);
+      assert.equal(executions[0]?.executed, true);
+      const comments = await h.provider.listComments(42);
+      assert.equal(comments.length, 1);
+      assert.match(comments[0]!.body, /Seen on #42: changes_requested/);
+    } finally {
+      await h.cleanup();
+    }
+  });
+
+  it("requeues a refining issue when a hold policy matches", async () => {
+    const h = await createTestHarness();
+    try {
+      const issue = h.provider.seedIssue({ iid: 77, title: "Blocked", labels: ["Refining"] });
+      await upsertInterventionPolicy(h.workspaceDir, h.project.slug, {
+        id: "requeue-blocked",
+        title: "Requeue blocked issues",
+        mode: "auto",
+        issueId: 77,
+        event: { type: "workflow.hold", result: "blocked" },
+        action: { type: "requeue", message: "Requeued after {{result}}" },
+      });
+
+      const executions = await recordAndApplyInterventionEvent({
+        workspaceDir: h.workspaceDir,
+        channelId: h.channelId,
+        project: h.project,
+        workflow: h.workflow,
+        provider: h.provider,
+        issue,
+      }, {
+        eventType: "workflow.hold",
+        issueId: 77,
+        result: "blocked",
+        fromState: "Doing",
+        toState: "Refining",
+        source: "worker",
+      });
+
+      assert.equal(executions[0]?.executed, true);
+      const updated = await h.provider.getIssue(77);
+      assert.ok(updated.labels.includes("To Do"));
+      const comments = await h.provider.listComments(77);
+      assert.equal(comments.length, 1);
+      assert.match(comments[0]!.body, /Requeued after blocked/);
+    } finally {
+      await h.cleanup();
+    }
+  });
+});

--- a/lib/orchestrator-intervention/engine.test.ts
+++ b/lib/orchestrator-intervention/engine.test.ts
@@ -5,7 +5,7 @@ import { upsertInterventionPolicy } from "./store.js";
 import { recordAndApplyInterventionEvent } from "./engine.js";
 
 describe("orchestrator intervention engine", () => {
-  it("executes an auto comment policy on matching review feedback", async () => {
+  it("wakes the orchestrator and executes an auto comment policy on matching review feedback", async () => {
     const h = await createTestHarness();
     try {
       const issue = h.provider.seedIssue({ iid: 42, title: "Needs follow-up", labels: ["Refining"] });
@@ -20,10 +20,12 @@ describe("orchestrator intervention engine", () => {
       const executions = await recordAndApplyInterventionEvent({
         workspaceDir: h.workspaceDir,
         channelId: h.channelId,
+        agentId: "main",
         project: h.project,
         workflow: h.workflow,
         provider: h.provider,
         issue,
+        runCommand: h.runCommand,
       }, {
         eventType: "review.feedback",
         issueId: 42,
@@ -33,9 +35,14 @@ describe("orchestrator intervention engine", () => {
 
       assert.equal(executions.length, 1);
       assert.equal(executions[0]?.executed, true);
+      assert.equal((executions[0]?.details as any)?.wake?.delivered, true);
       const comments = await h.provider.listComments(42);
       assert.equal(comments.length, 1);
       assert.match(comments[0]!.body, /Seen on #42: changes_requested/);
+      const wakes = h.commands.taskMessages();
+      assert.equal(wakes.length, 1);
+      assert.match(wakes[0]!, /Live intervention wake for issue #42/);
+      assert.match(wakes[0]!, /"eventType": "review.feedback"/);
     } finally {
       await h.cleanup();
     }
@@ -57,10 +64,12 @@ describe("orchestrator intervention engine", () => {
       const executions = await recordAndApplyInterventionEvent({
         workspaceDir: h.workspaceDir,
         channelId: h.channelId,
+        agentId: "main",
         project: h.project,
         workflow: h.workflow,
         provider: h.provider,
         issue,
+        runCommand: h.runCommand,
       }, {
         eventType: "workflow.hold",
         issueId: 77,
@@ -76,6 +85,56 @@ describe("orchestrator intervention engine", () => {
       const comments = await h.provider.listComments(77);
       assert.equal(comments.length, 1);
       assert.match(comments[0]!.body, /Requeued after blocked/);
+    } finally {
+      await h.cleanup();
+    }
+  });
+
+  it("creates follow-up issues in the workflow initial hold state, not the first hold state by order", async () => {
+    const h = await createTestHarness();
+    try {
+      h.workflow = {
+        ...h.workflow,
+        initial: "planning",
+        states: {
+          refining: { label: "Refining", type: "HOLD", description: "later hold" },
+          planning: { label: "Planning", type: "HOLD", description: "initial hold" },
+          todo: h.workflow.states.todo,
+          doing: h.workflow.states.doing,
+          done: h.workflow.states.done,
+        },
+      } as any;
+      const issue = h.provider.seedIssue({ iid: 88, title: "Needs follow-up", labels: ["Doing"] });
+      await upsertInterventionPolicy(h.workspaceDir, h.project.slug, {
+        id: "create-followup",
+        title: "Create follow-up",
+        mode: "auto",
+        issueId: 88,
+        event: { type: "worker.completed", result: "done" },
+        action: { type: "create_followup", title: "Follow-up for #{{issueId}}", body: "Body" },
+      });
+
+      const executions = await recordAndApplyInterventionEvent({
+        workspaceDir: h.workspaceDir,
+        channelId: h.channelId,
+        agentId: "main",
+        project: h.project,
+        workflow: h.workflow,
+        provider: h.provider,
+        issue,
+        runCommand: h.runCommand,
+      }, {
+        eventType: "worker.completed",
+        issueId: 88,
+        result: "done",
+        source: "worker",
+      });
+
+      assert.equal(executions[0]?.executed, true);
+      const createdIssueId = Number((executions[0]?.details as any)?.createdIssueId);
+      const created = await h.provider.getIssue(createdIssueId);
+      assert.ok(created.labels.includes("Planning"));
+      assert.ok(!created.labels.includes("Refining"));
     } finally {
       await h.cleanup();
     }

--- a/lib/orchestrator-intervention/engine.test.ts
+++ b/lib/orchestrator-intervention/engine.test.ts
@@ -139,4 +139,52 @@ describe("orchestrator intervention engine", () => {
       await h.cleanup();
     }
   });
+
+  it("uses the same resolved agent id for wake session key and gateway delivery when agentId is omitted", async () => {
+    const h = await createTestHarness();
+    try {
+      const issue = h.provider.seedIssue({ iid: 93, title: "Wake target", labels: ["Doing"] });
+      await upsertInterventionPolicy(h.workspaceDir, h.project.slug, {
+        id: "notify-default-agent",
+        title: "Notify with default agent",
+        mode: "notify",
+        issueId: 93,
+        event: { type: "worker.completed", result: "done" },
+        action: { type: "comment", message: "unused" },
+      });
+
+      await recordAndApplyInterventionEvent({
+        workspaceDir: h.workspaceDir,
+        channelId: h.channelId,
+        project: h.project,
+        workflow: h.workflow,
+        provider: h.provider,
+        issue,
+        runCommand: h.runCommand,
+      }, {
+        eventType: "worker.completed",
+        issueId: 93,
+        result: "done",
+        source: "worker",
+      });
+
+      const wakeCommand = h.commands.commands.find((command) =>
+        command.argv[0] === "openclaw" &&
+        command.argv[1] === "gateway" &&
+        command.argv[2] === "call" &&
+        command.argv[3] === "agent" &&
+        command.taskMessage?.includes("Live intervention wake for issue #93"),
+      );
+      assert.ok(wakeCommand, "expected orchestrator wake gateway call");
+
+      const paramsIdx = wakeCommand!.argv.indexOf("--params");
+      assert.notEqual(paramsIdx, -1, "wake command should include --params");
+      const params = JSON.parse(wakeCommand!.argv[paramsIdx + 1]!);
+
+      assert.equal(params.agentId, "main");
+      assert.equal(params.sessionKey, `agent:main:telegram:group:${h.channelId}`);
+    } finally {
+      await h.cleanup();
+    }
+  });
 });

--- a/lib/orchestrator-intervention/engine.ts
+++ b/lib/orchestrator-intervention/engine.ts
@@ -260,9 +260,10 @@ async function wakeOrchestrator(
   const notifyTarget = resolveWakeTarget(ctx);
   if (!notifyTarget) return { delivered: false, reason: "channel_unavailable" };
 
-  const sessionKey = buildMainOrchestratorSessionKey(ctx.agentId ?? "main", notifyTarget);
+  const agentId = ctx.agentId ?? "main";
+  const sessionKey = buildMainOrchestratorSessionKey(agentId, notifyTarget);
   sendToSessionFireAndForget(sessionKey, buildWakeMessage(event, policy, mode), {
-    agentId: ctx.agentId,
+    agentId,
     workspaceDir: ctx.workspaceDir,
     runCommand: ctx.runCommand,
     lane: "main",

--- a/lib/orchestrator-intervention/engine.ts
+++ b/lib/orchestrator-intervention/engine.ts
@@ -1,0 +1,238 @@
+import { log as auditLog } from "../audit.js";
+import { loadConfig } from "../config/index.js";
+import { getRoleLabelColor, StateType, getCurrentStateLabel, findStateByLabel } from "../workflow/index.js";
+import type {
+  InterventionRuntimeContext,
+  OrchestratorInterventionAction,
+  OrchestratorInterventionEvent,
+  OrchestratorInterventionExecution,
+  OrchestratorInterventionPolicy,
+} from "./types.js";
+import { appendInterventionEvent } from "./timeline.js";
+import { loadInterventionStore } from "./store.js";
+import { resolveTarget } from "../tools/tasks/task-start.js";
+
+export async function recordAndApplyInterventionEvent(
+  ctx: InterventionRuntimeContext,
+  event: Omit<OrchestratorInterventionEvent, "ts" | "project" | "projectSlug" | "issueTitle" | "issueUrl" | "sessionKey">,
+): Promise<OrchestratorInterventionExecution[]> {
+  const normalized: OrchestratorInterventionEvent = {
+    ts: new Date().toISOString(),
+    project: ctx.project.name,
+    projectSlug: ctx.project.slug,
+    issueTitle: ctx.issue.title,
+    issueUrl: ctx.issue.web_url,
+    sessionKey: ctx.sessionKey,
+    ...event,
+  };
+
+  await appendInterventionEvent(ctx.workspaceDir, normalized);
+
+  const store = await loadInterventionStore(ctx.workspaceDir, ctx.project.slug);
+  const executions: OrchestratorInterventionExecution[] = [];
+
+  for (const policy of store.policies) {
+    if (!matchesPolicy(policy, normalized)) continue;
+
+    const mode = policy.mode ?? "auto";
+    if (mode === "notify") {
+      const details = { issueId: normalized.issueId, eventType: normalized.eventType };
+      executions.push({
+        policyId: policy.id,
+        policyTitle: policy.title,
+        matched: true,
+        executed: false,
+        mode,
+        actionType: policy.action.type,
+        details,
+      });
+      await auditLog(ctx.workspaceDir, "orchestrator_intervention_notify", {
+        project: ctx.project.name,
+        issueId: normalized.issueId,
+        policyId: policy.id,
+        policyTitle: policy.title,
+        eventType: normalized.eventType,
+        actionType: policy.action.type,
+      });
+      continue;
+    }
+
+    try {
+      const details = await executePolicyAction(ctx, normalized, policy.action);
+      const record = {
+        policyId: policy.id,
+        policyTitle: policy.title,
+        matched: true,
+        executed: true,
+        mode,
+        actionType: policy.action.type,
+        details,
+      } satisfies OrchestratorInterventionExecution;
+      executions.push(record);
+      await auditLog(ctx.workspaceDir, "orchestrator_intervention", {
+        project: ctx.project.name,
+        issueId: normalized.issueId,
+        policyId: policy.id,
+        policyTitle: policy.title,
+        eventType: normalized.eventType,
+        actionType: policy.action.type,
+        details,
+      });
+    } catch (err) {
+      const error = (err as Error).message ?? String(err);
+      executions.push({
+        policyId: policy.id,
+        policyTitle: policy.title,
+        matched: true,
+        executed: false,
+        mode,
+        actionType: policy.action.type,
+        error,
+      });
+      await auditLog(ctx.workspaceDir, "orchestrator_intervention_error", {
+        project: ctx.project.name,
+        issueId: normalized.issueId,
+        policyId: policy.id,
+        policyTitle: policy.title,
+        eventType: normalized.eventType,
+        actionType: policy.action.type,
+        error,
+      });
+    }
+  }
+
+  return executions;
+}
+
+function matchesPolicy(
+  policy: OrchestratorInterventionPolicy,
+  event: OrchestratorInterventionEvent,
+): boolean {
+  if (policy.enabled === false) return false;
+  if (policy.issueId != null && policy.issueId !== event.issueId) return false;
+  if (policy.event.type !== event.eventType) return false;
+  if (policy.event.role && policy.event.role !== event.role) return false;
+  if (policy.event.result && policy.event.result !== event.result) return false;
+  if (policy.event.reason && policy.event.reason !== event.reason) return false;
+  if (policy.event.fromState && policy.event.fromState !== event.fromState) return false;
+  if (policy.event.toState && policy.event.toState !== event.toState) return false;
+  return true;
+}
+
+async function executePolicyAction(
+  ctx: InterventionRuntimeContext,
+  event: OrchestratorInterventionEvent,
+  action: OrchestratorInterventionAction,
+): Promise<Record<string, unknown>> {
+  switch (action.type) {
+    case "comment": {
+      const body = renderTemplate(action.message, event);
+      if (!body.trim()) throw new Error("comment action requires message");
+      const commentId = await ctx.provider.addComment(ctx.issue.iid, body);
+      return { commentId, body };
+    }
+
+    case "set_level": {
+      if (!action.level) throw new Error("set_level action requires level");
+      const issue = await ctx.provider.getIssue(ctx.issue.iid);
+      const currentLabel = getCurrentStateLabel(issue.labels, ctx.workflow);
+      if (!currentLabel) throw new Error("issue has no recognized workflow label");
+      const state = findStateByLabel(ctx.workflow, currentLabel);
+      if (state?.type !== StateType.HOLD) {
+        throw new Error(`set_level is only allowed from HOLD states, got ${currentLabel}`);
+      }
+      const target = resolveTarget(ctx.workflow, currentLabel, state);
+      const targetRole = target.targetState.role;
+      if (!targetRole) throw new Error("could not determine target role for set_level");
+      const resolvedConfig = await loadConfig(ctx.workspaceDir, ctx.project.name);
+      const roleConfig = resolvedConfig.roles[targetRole];
+      if (!roleConfig.levels.includes(action.level)) {
+        throw new Error(`invalid level ${action.level} for role ${targetRole}`);
+      }
+      const oldRoleLabels = issue.labels.filter((label) => label.startsWith(`${targetRole}:`));
+      if (oldRoleLabels.length > 0) await ctx.provider.removeLabels(issue.iid, oldRoleLabels);
+      const newRoleLabel = `${targetRole}:${action.level}`;
+      await ctx.provider.ensureLabel(newRoleLabel, getRoleLabelColor(targetRole));
+      await ctx.provider.addLabel(issue.iid, newRoleLabel);
+      return { targetRole, level: action.level };
+    }
+
+    case "requeue": {
+      const issue = await ctx.provider.getIssue(ctx.issue.iid);
+      const currentLabel = getCurrentStateLabel(issue.labels, ctx.workflow);
+      if (!currentLabel) throw new Error("issue has no recognized workflow label");
+      const currentState = findStateByLabel(ctx.workflow, currentLabel);
+      if (!currentState) throw new Error(`unknown state for ${currentLabel}`);
+      const target = resolveTarget(ctx.workflow, currentLabel, currentState);
+      if (target.transitioned) {
+        await ctx.provider.transitionLabel(issue.iid, currentLabel, target.targetLabel);
+      }
+      const message = renderTemplate(action.message, event);
+      let commentId: number | undefined;
+      if (message.trim()) {
+        commentId = await ctx.provider.addComment(issue.iid, message);
+      }
+      return { from: currentLabel, to: target.targetLabel, transitioned: target.transitioned, commentId };
+    }
+
+    case "queue_issue": {
+      const targetIssueId = action.issueId;
+      if (targetIssueId == null) throw new Error("queue_issue action requires issueId");
+      const issue = await ctx.provider.getIssue(targetIssueId);
+      const currentLabel = getCurrentStateLabel(issue.labels, ctx.workflow);
+      if (!currentLabel) throw new Error(`issue #${targetIssueId} has no recognized workflow label`);
+      const currentState = findStateByLabel(ctx.workflow, currentLabel);
+      if (!currentState) throw new Error(`unknown state for ${currentLabel}`);
+      const target = resolveTarget(ctx.workflow, currentLabel, currentState);
+      if (target.transitioned) {
+        await ctx.provider.transitionLabel(targetIssueId, currentLabel, target.targetLabel);
+      }
+      return { targetIssueId, from: currentLabel, to: target.targetLabel, transitioned: target.transitioned };
+    }
+
+    case "create_followup": {
+      const planningLabel = findPlanningLabel(ctx.workflow);
+      const title = renderTemplate(action.title, event);
+      if (!title.trim()) throw new Error("create_followup action requires title");
+      const body = renderTemplate(action.body, event);
+      const created = await ctx.provider.createIssue(title, body, planningLabel);
+      if (action.queueAfterCreate) {
+        const createdState = findStateByLabel(ctx.workflow, planningLabel);
+        if (createdState) {
+          const target = resolveTarget(ctx.workflow, planningLabel, createdState);
+          if (target.transitioned) {
+            await ctx.provider.transitionLabel(created.iid, planningLabel, target.targetLabel);
+          }
+          return { createdIssueId: created.iid, createdIssueUrl: created.web_url, queuedTo: target.targetLabel };
+        }
+      }
+      return { createdIssueId: created.iid, createdIssueUrl: created.web_url, createdLabel: planningLabel };
+    }
+  }
+}
+
+function renderTemplate(template: string | undefined, event: OrchestratorInterventionEvent): string {
+  const raw = template ?? "";
+  const values: Record<string, string> = {
+    project: event.project,
+    issueId: String(event.issueId),
+    issueTitle: event.issueTitle ?? "",
+    issueUrl: event.issueUrl ?? "",
+    role: event.role ?? "",
+    level: event.level ?? "",
+    result: event.result ?? "",
+    reason: event.reason ?? "",
+    fromState: event.fromState ?? "",
+    toState: event.toState ?? "",
+    prUrl: event.prUrl ?? "",
+    eventType: event.eventType,
+    summary: String(event.data?.summary ?? ""),
+  };
+  return raw.replace(/\{\{\s*([a-zA-Z0-9_]+)\s*\}\}/g, (_m, key: string) => values[key] ?? "");
+}
+
+function findPlanningLabel(workflow: InterventionRuntimeContext["workflow"]): string {
+  const planning = Object.values(workflow.states).find((state) => state.type === StateType.HOLD);
+  if (!planning) throw new Error("workflow has no HOLD state to receive follow-up work");
+  return planning.label;
+}

--- a/lib/orchestrator-intervention/engine.ts
+++ b/lib/orchestrator-intervention/engine.ts
@@ -1,6 +1,7 @@
 import { log as auditLog } from "../audit.js";
 import { loadConfig } from "../config/index.js";
-import { getRoleLabelColor, StateType, getCurrentStateLabel, findStateByLabel } from "../workflow/index.js";
+import { sendToSessionFireAndForget, type NotifyRoutingTarget } from "../dispatch/session.js";
+import { getRoleLabelColor, StateType, getCurrentStateLabel, findStateByLabel, getInitialStateLabel } from "../workflow/index.js";
 import type {
   InterventionRuntimeContext,
   OrchestratorInterventionAction,
@@ -35,8 +36,13 @@ export async function recordAndApplyInterventionEvent(
     if (!matchesPolicy(policy, normalized)) continue;
 
     const mode = policy.mode ?? "auto";
+    const wake = await wakeOrchestrator(ctx, normalized, policy, mode).catch((err) => ({
+      delivered: false,
+      error: (err as Error).message ?? String(err),
+    }));
+
     if (mode === "notify") {
-      const details = { issueId: normalized.issueId, eventType: normalized.eventType };
+      const details = { issueId: normalized.issueId, eventType: normalized.eventType, wake };
       executions.push({
         policyId: policy.id,
         policyTitle: policy.title,
@@ -53,12 +59,14 @@ export async function recordAndApplyInterventionEvent(
         policyTitle: policy.title,
         eventType: normalized.eventType,
         actionType: policy.action.type,
+        wake,
       });
       continue;
     }
 
     try {
-      const details = await executePolicyAction(ctx, normalized, policy.action);
+      const actionDetails = await executePolicyAction(ctx, normalized, policy.action);
+      const details = { ...actionDetails, wake };
       const record = {
         policyId: policy.id,
         policyTitle: policy.title,
@@ -97,6 +105,7 @@ export async function recordAndApplyInterventionEvent(
         eventType: normalized.eventType,
         actionType: policy.action.type,
         error,
+        wake,
       });
     }
   }
@@ -232,7 +241,85 @@ function renderTemplate(template: string | undefined, event: OrchestratorInterve
 }
 
 function findPlanningLabel(workflow: InterventionRuntimeContext["workflow"]): string {
-  const planning = Object.values(workflow.states).find((state) => state.type === StateType.HOLD);
-  if (!planning) throw new Error("workflow has no HOLD state to receive follow-up work");
-  return planning.label;
+  const planningLabel = getInitialStateLabel(workflow);
+  const planning = findStateByLabel(workflow, planningLabel);
+  if (!planning || planning.type !== StateType.HOLD) {
+    throw new Error(`workflow initial state ${planningLabel} is not a HOLD state`);
+  }
+  return planningLabel;
+}
+
+async function wakeOrchestrator(
+  ctx: InterventionRuntimeContext,
+  event: OrchestratorInterventionEvent,
+  policy: OrchestratorInterventionPolicy,
+  mode: "notify" | "auto",
+): Promise<Record<string, unknown>> {
+  if (!ctx.runCommand) return { delivered: false, reason: "runCommand_unavailable" };
+
+  const notifyTarget = resolveWakeTarget(ctx);
+  if (!notifyTarget) return { delivered: false, reason: "channel_unavailable" };
+
+  const sessionKey = buildMainOrchestratorSessionKey(ctx.agentId ?? "main", notifyTarget);
+  sendToSessionFireAndForget(sessionKey, buildWakeMessage(event, policy, mode), {
+    agentId: ctx.agentId,
+    workspaceDir: ctx.workspaceDir,
+    runCommand: ctx.runCommand,
+    lane: "main",
+    notifyTarget,
+    idempotencyKey: `devclaw-orchestrator-wake-${ctx.project.slug}-${policy.id}-${event.issueId}-${event.eventType}-${event.ts}`,
+  });
+
+  await auditLog(ctx.workspaceDir, "orchestrator_intervention_wake", {
+    project: ctx.project.name,
+    issueId: event.issueId,
+    policyId: policy.id,
+    eventType: event.eventType,
+    mode,
+    sessionKey,
+  });
+
+  return { delivered: true, sessionKey, channelId: notifyTarget.channelId, messageThreadId: notifyTarget.messageThreadId ?? null };
+}
+
+function resolveWakeTarget(ctx: InterventionRuntimeContext): NotifyRoutingTarget | null {
+  const channel = ctx.project.channels.find((entry) =>
+    entry.channelId === ctx.channelId && (ctx.messageThreadId == null || entry.messageThreadId === ctx.messageThreadId),
+  ) ?? ctx.project.channels[0];
+  if (!channel) return null;
+  return {
+    channelId: channel.channelId,
+    channel: channel.channel,
+    accountId: channel.accountId,
+    messageThreadId: channel.messageThreadId,
+  };
+}
+
+function buildMainOrchestratorSessionKey(agentId: string, target: NotifyRoutingTarget): string {
+  const base = `agent:${agentId}:${target.channel}:group:${target.channelId}`;
+  return target.messageThreadId != null ? `${base}:topic:${target.messageThreadId}` : base;
+}
+
+function buildWakeMessage(
+  event: OrchestratorInterventionEvent,
+  policy: OrchestratorInterventionPolicy,
+  mode: "notify" | "auto",
+): string {
+  return [
+    `Live intervention wake for issue #${event.issueId}.`,
+    "",
+    `Matched policy: ${policy.title} (${policy.id})`,
+    `Mode: ${mode}`,
+    `Event: ${event.eventType}`,
+    `Action: ${policy.action.type}`,
+    "",
+    "Structured event:",
+    "```json",
+    JSON.stringify(event, null, 2),
+    "```",
+    "",
+    mode === "auto"
+      ? "DevClaw is executing the bounded action automatically. Review and intervene if you want to add guidance or override with further policy."
+      : "Please review this event and decide whether to intervene. The matched policy is notify-only, so no automatic workflow action was taken.",
+  ].join("\n");
 }

--- a/lib/orchestrator-intervention/store.ts
+++ b/lib/orchestrator-intervention/store.ts
@@ -1,0 +1,70 @@
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { DATA_DIR } from "../setup/migrate-layout.js";
+import type { OrchestratorInterventionPolicy, OrchestratorInterventionStore } from "./types.js";
+
+function storePath(workspaceDir: string, projectSlug: string): string {
+  return join(workspaceDir, DATA_DIR, "interventions", `${projectSlug}.json`);
+}
+
+export async function loadInterventionStore(
+  workspaceDir: string,
+  projectSlug: string,
+): Promise<OrchestratorInterventionStore> {
+  const path = storePath(workspaceDir, projectSlug);
+  try {
+    const raw = await readFile(path, "utf-8");
+    const parsed = JSON.parse(raw) as OrchestratorInterventionStore;
+    return {
+      version: 1,
+      updatedAt: parsed.updatedAt ?? new Date(0).toISOString(),
+      policies: Array.isArray(parsed.policies) ? parsed.policies : [],
+    };
+  } catch {
+    return { version: 1, updatedAt: new Date(0).toISOString(), policies: [] };
+  }
+}
+
+export async function saveInterventionStore(
+  workspaceDir: string,
+  projectSlug: string,
+  store: OrchestratorInterventionStore,
+): Promise<void> {
+  const path = storePath(workspaceDir, projectSlug);
+  await mkdir(dirname(path), { recursive: true });
+  await writeFile(path, JSON.stringify(store, null, 2) + "\n", "utf-8");
+}
+
+export async function upsertInterventionPolicy(
+  workspaceDir: string,
+  projectSlug: string,
+  policy: Omit<OrchestratorInterventionPolicy, "updatedAt">,
+): Promise<OrchestratorInterventionPolicy> {
+  const store = await loadInterventionStore(workspaceDir, projectSlug);
+  const next: OrchestratorInterventionPolicy = {
+    ...policy,
+    enabled: policy.enabled ?? true,
+    mode: policy.mode ?? "auto",
+    updatedAt: new Date().toISOString(),
+  };
+  const idx = store.policies.findIndex((p) => p.id === next.id);
+  if (idx >= 0) store.policies[idx] = next;
+  else store.policies.push(next);
+  store.updatedAt = next.updatedAt;
+  await saveInterventionStore(workspaceDir, projectSlug, store);
+  return next;
+}
+
+export async function deleteInterventionPolicy(
+  workspaceDir: string,
+  projectSlug: string,
+  policyId: string,
+): Promise<boolean> {
+  const store = await loadInterventionStore(workspaceDir, projectSlug);
+  const before = store.policies.length;
+  store.policies = store.policies.filter((p) => p.id !== policyId);
+  if (store.policies.length === before) return false;
+  store.updatedAt = new Date().toISOString();
+  await saveInterventionStore(workspaceDir, projectSlug, store);
+  return true;
+}

--- a/lib/orchestrator-intervention/timeline.ts
+++ b/lib/orchestrator-intervention/timeline.ts
@@ -1,0 +1,68 @@
+import { appendFile, mkdir, readFile, writeFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { DATA_DIR } from "../setup/migrate-layout.js";
+import { log as auditLog } from "../audit.js";
+import type { OrchestratorInterventionEvent } from "./types.js";
+
+const MAX_EVENT_LINES = 400;
+
+function eventPath(workspaceDir: string, projectSlug: string): string {
+  return join(workspaceDir, DATA_DIR, "log", `orchestrator-events.${projectSlug}.ndjson`);
+}
+
+export async function appendInterventionEvent(
+  workspaceDir: string,
+  event: OrchestratorInterventionEvent,
+): Promise<void> {
+  const path = eventPath(workspaceDir, event.projectSlug);
+  const line = JSON.stringify(event) + "\n";
+  try {
+    await mkdir(dirname(path), { recursive: true });
+    await appendFile(path, line, "utf-8");
+    await truncateIfNeeded(path);
+  } catch {
+    // Best effort only
+  }
+  await auditLog(workspaceDir, "orchestrator_event", event).catch(() => {});
+}
+
+export async function readInterventionEvents(opts: {
+  workspaceDir: string;
+  projectSlug: string;
+  issueId?: number;
+  limit?: number;
+}): Promise<OrchestratorInterventionEvent[]> {
+  const path = eventPath(opts.workspaceDir, opts.projectSlug);
+  try {
+    const raw = await readFile(path, "utf-8");
+    const entries = raw.split("\n")
+      .filter(Boolean)
+      .map((line) => {
+        try {
+          return JSON.parse(line) as OrchestratorInterventionEvent;
+        } catch {
+          return null;
+        }
+      })
+      .filter((entry): entry is OrchestratorInterventionEvent => entry !== null);
+
+    const filtered = opts.issueId == null
+      ? entries
+      : entries.filter((entry) => entry.issueId === opts.issueId);
+    return filtered.slice(-(opts.limit ?? 25));
+  } catch {
+    return [];
+  }
+}
+
+async function truncateIfNeeded(path: string): Promise<void> {
+  try {
+    const raw = await readFile(path, "utf-8");
+    const lines = raw.split("\n").filter(Boolean);
+    if (lines.length <= MAX_EVENT_LINES) return;
+    const kept = lines.slice(-MAX_EVENT_LINES).join("\n") + "\n";
+    await writeFile(path, kept, "utf-8");
+  } catch {
+    // Ignore
+  }
+}

--- a/lib/orchestrator-intervention/types.ts
+++ b/lib/orchestrator-intervention/types.ts
@@ -1,0 +1,103 @@
+import type { WorkflowConfig } from "../workflow/index.js";
+import type { IssueProvider, Issue } from "../providers/provider.js";
+import type { Project } from "../projects/index.js";
+
+export const ORCHESTRATOR_INTERVENTION_EVENT_TYPES = [
+  "worker.completed",
+  "workflow.dispatch",
+  "workflow.requeue",
+  "workflow.hold",
+  "review.feedback",
+  "review.approved",
+  "review.pr_closed",
+  "pr.merged",
+] as const;
+
+export type OrchestratorInterventionEventType = typeof ORCHESTRATOR_INTERVENTION_EVENT_TYPES[number];
+
+export type OrchestratorInterventionEvent = {
+  ts: string;
+  eventType: OrchestratorInterventionEventType;
+  project: string;
+  projectSlug: string;
+  issueId: number;
+  issueTitle?: string;
+  issueUrl?: string;
+  role?: string;
+  level?: string;
+  result?: string;
+  reason?: string;
+  fromState?: string;
+  toState?: string;
+  prUrl?: string | null;
+  source: "worker" | "heartbeat" | "system";
+  sessionKey?: string;
+  data?: Record<string, unknown>;
+};
+
+export const ORCHESTRATOR_INTERVENTION_ACTION_TYPES = [
+  "comment",
+  "set_level",
+  "requeue",
+  "queue_issue",
+  "create_followup",
+] as const;
+
+export type OrchestratorInterventionActionType = typeof ORCHESTRATOR_INTERVENTION_ACTION_TYPES[number];
+
+export type OrchestratorInterventionAction = {
+  type: OrchestratorInterventionActionType;
+  message?: string;
+  level?: string;
+  issueId?: number;
+  title?: string;
+  body?: string;
+  queueAfterCreate?: boolean;
+};
+
+export type OrchestratorInterventionPolicy = {
+  id: string;
+  title: string;
+  enabled?: boolean;
+  mode?: "notify" | "auto";
+  issueId?: number;
+  event: {
+    type: OrchestratorInterventionEventType;
+    role?: string;
+    result?: string;
+    reason?: string;
+    fromState?: string;
+    toState?: string;
+  };
+  action: OrchestratorInterventionAction;
+  updatedAt: string;
+  updatedBy?: string;
+};
+
+export type OrchestratorInterventionStore = {
+  version: 1;
+  updatedAt: string;
+  policies: OrchestratorInterventionPolicy[];
+};
+
+export type OrchestratorInterventionExecution = {
+  policyId: string;
+  policyTitle: string;
+  mode: "notify" | "auto";
+  matched: boolean;
+  executed: boolean;
+  actionType: OrchestratorInterventionActionType;
+  details?: Record<string, unknown>;
+  error?: string;
+};
+
+export type InterventionRuntimeContext = {
+  workspaceDir: string;
+  channelId: string;
+  messageThreadId?: number;
+  project: Project;
+  workflow: WorkflowConfig;
+  provider: IssueProvider;
+  issue: Issue;
+  sessionKey?: string;
+};

--- a/lib/orchestrator-intervention/types.ts
+++ b/lib/orchestrator-intervention/types.ts
@@ -1,6 +1,7 @@
 import type { WorkflowConfig } from "../workflow/index.js";
 import type { IssueProvider, Issue } from "../providers/provider.js";
 import type { Project } from "../projects/index.js";
+import type { RunCommand } from "../context.js";
 
 export const ORCHESTRATOR_INTERVENTION_EVENT_TYPES = [
   "worker.completed",
@@ -95,9 +96,11 @@ export type InterventionRuntimeContext = {
   workspaceDir: string;
   channelId: string;
   messageThreadId?: number;
+  agentId?: string;
   project: Project;
   workflow: WorkflowConfig;
   provider: IssueProvider;
   issue: Issue;
   sessionKey?: string;
+  runCommand?: RunCommand;
 };

--- a/lib/services/heartbeat/passes.ts
+++ b/lib/services/heartbeat/passes.ts
@@ -94,12 +94,15 @@ export async function performReviewPass(
   pluginConfig: Record<string, unknown> | undefined,
   runtime?: PluginRuntime,
   runCommand?: RunCommand,
+  agentId?: string,
 ): Promise<number> {
   const notifyConfig = getNotificationConfig(pluginConfig);
 
   return reviewPass({
     workspaceDir,
+    agentId,
     projectName: projectSlug,
+    project,
     workflow: resolvedConfig.workflow,
     provider,
     repoPath: project.repo,

--- a/lib/services/heartbeat/review.ts
+++ b/lib/services/heartbeat/review.ts
@@ -18,6 +18,7 @@ import { detectStepRouting } from "../queue-scan.js";
 import type { RunCommand } from "../../context.js";
 import { log as auditLog } from "../../audit.js";
 import { recordLoopDiagnostic } from "../loop-diagnostics.js";
+import { recordAndApplyInterventionEvent } from "../../orchestrator-intervention/engine.js";
 
 /**
  * Scan review-type states and transition issues whose PR check condition is met.
@@ -114,6 +115,22 @@ export async function reviewPass(opts: {
               reason: status.state === PrState.HAS_COMMENTS ? "pr_comments" : "changes_requested",
               prUrl: status.url,
             });
+            await recordAndApplyInterventionEvent({
+              workspaceDir,
+              channelId: projectName,
+              project: { slug: projectName, name: projectName, repo: repoPath, groupName: projectName, deployUrl: "", baseBranch: baseBranch ?? "main", deployBranch: baseBranch ?? "main", channels: [], workers: {} },
+              workflow,
+              provider,
+              issue: await provider.getIssue(issue.iid),
+            }, {
+              eventType: "review.feedback",
+              issueId: issue.iid,
+              reason: status.state === PrState.HAS_COMMENTS ? "pr_comments" : "changes_requested",
+              fromState: state.label,
+              toState: targetState.label,
+              prUrl: status.url,
+              source: "heartbeat",
+            }).catch(() => {});
             onFeedback?.(issue.iid, "changes_requested", status.url, issue.title, issue.web_url);
             // React to each review comment with 🤖 to acknowledge processing (best-effort)
             reactToFeedbackComments(provider, issue.iid).catch(() => {});
@@ -146,6 +163,22 @@ export async function reviewPass(opts: {
               reason: "merge_conflict",
               prUrl: status.url,
             });
+            await recordAndApplyInterventionEvent({
+              workspaceDir,
+              channelId: projectName,
+              project: { slug: projectName, name: projectName, repo: repoPath, groupName: projectName, deployUrl: "", baseBranch: baseBranch ?? "main", deployBranch: baseBranch ?? "main", channels: [], workers: {} },
+              workflow,
+              provider,
+              issue: await provider.getIssue(issue.iid),
+            }, {
+              eventType: "review.feedback",
+              issueId: issue.iid,
+              reason: "merge_conflict",
+              fromState: state.label,
+              toState: targetState.label,
+              prUrl: status.url,
+              source: "heartbeat",
+            }).catch(() => {});
             onFeedback?.(issue.iid, "merge_conflict", status.url, issue.title, issue.web_url);
             transitions++;
             continue;
@@ -182,6 +215,22 @@ export async function reviewPass(opts: {
               prUrl: status.url,
               actions: closedActions,
             });
+            await recordAndApplyInterventionEvent({
+              workspaceDir,
+              channelId: projectName,
+              project: { slug: projectName, name: projectName, repo: repoPath, groupName: projectName, deployUrl: "", baseBranch: baseBranch ?? "main", deployBranch: baseBranch ?? "main", channels: [], workers: {} },
+              workflow,
+              provider,
+              issue: await provider.getIssue(issue.iid),
+            }, {
+              eventType: "review.pr_closed",
+              issueId: issue.iid,
+              fromState: state.label,
+              toState: targetState.label,
+              prUrl: status.url,
+              reason: "pr_closed",
+              source: "heartbeat",
+            }).catch(() => {});
             onPrClosed?.(issue.iid, status.url, issue.title, issue.web_url);
             transitions++;
             continue;
@@ -281,6 +330,22 @@ export async function reviewPass(opts: {
         prState: status.state,
         prUrl: status.url,
       });
+      await recordAndApplyInterventionEvent({
+        workspaceDir,
+        channelId: projectName,
+        project: { slug: projectName, name: projectName, repo: repoPath, groupName: projectName, deployUrl: "", baseBranch: baseBranch ?? "main", deployBranch: baseBranch ?? "main", channels: [], workers: {} },
+        workflow,
+        provider,
+        issue: await provider.getIssue(issue.iid),
+      }, {
+        eventType: status.state === PrState.MERGED ? "pr.merged" : "review.approved",
+        issueId: issue.iid,
+        fromState: state.label,
+        toState: targetState.label,
+        prUrl: status.url,
+        source: "heartbeat",
+        data: { prState: status.state },
+      }).catch(() => {});
 
       transitions++;
     }

--- a/lib/services/heartbeat/review.ts
+++ b/lib/services/heartbeat/review.ts
@@ -6,6 +6,7 @@
  * Called by the heartbeat service during its periodic sweep.
  */
 import type { IssueProvider } from "../../providers/provider.js";
+import type { Project } from "../../projects/index.js";
 import { PrState } from "../../providers/provider.js";
 import {
   Action,
@@ -27,6 +28,7 @@ import { recordAndApplyInterventionEvent } from "../../orchestrator-intervention
 export async function reviewPass(opts: {
   workspaceDir: string;
   projectName: string;
+  project?: Project;
   workflow: WorkflowConfig;
   provider: IssueProvider;
   repoPath: string;
@@ -40,9 +42,11 @@ export async function reviewPass(opts: {
   /** Called when a PR is closed without merging (for notifications). */
   onPrClosed?: (issueId: number, prUrl: string | null, issueTitle: string, issueUrl: string) => void;
   runCommand: RunCommand;
+  agentId?: string;
 }): Promise<number> {
   const rc = opts.runCommand;
-  const { workspaceDir, projectName, workflow, provider, repoPath, gitPullTimeoutMs = 30_000, baseBranch, onMerge, onFeedback, onPrClosed } = opts;
+  const { workspaceDir, projectName, project, workflow, provider, repoPath, gitPullTimeoutMs = 30_000, baseBranch, onMerge, onFeedback, onPrClosed, agentId } = opts;
+  const interventionProject = project ?? { slug: projectName, name: projectName, repo: repoPath, groupName: projectName, deployUrl: "", baseBranch: baseBranch ?? "main", deployBranch: baseBranch ?? "main", channels: [], workers: {} } as Project;
   let transitions = 0;
 
   // Find all states with a review check (e.g. toReview with check: prApproved)
@@ -117,8 +121,10 @@ export async function reviewPass(opts: {
             });
             await recordAndApplyInterventionEvent({
               workspaceDir,
-              channelId: projectName,
-              project: { slug: projectName, name: projectName, repo: repoPath, groupName: projectName, deployUrl: "", baseBranch: baseBranch ?? "main", deployBranch: baseBranch ?? "main", channels: [], workers: {} },
+              channelId: project?.channels[0]?.channelId ?? projectName,
+              messageThreadId: project?.channels[0]?.messageThreadId,
+              agentId,
+              project: interventionProject,
               workflow,
               provider,
               issue: await provider.getIssue(issue.iid),
@@ -165,8 +171,10 @@ export async function reviewPass(opts: {
             });
             await recordAndApplyInterventionEvent({
               workspaceDir,
-              channelId: projectName,
-              project: { slug: projectName, name: projectName, repo: repoPath, groupName: projectName, deployUrl: "", baseBranch: baseBranch ?? "main", deployBranch: baseBranch ?? "main", channels: [], workers: {} },
+              channelId: project?.channels[0]?.channelId ?? projectName,
+              messageThreadId: project?.channels[0]?.messageThreadId,
+              agentId,
+              project: interventionProject,
               workflow,
               provider,
               issue: await provider.getIssue(issue.iid),
@@ -217,8 +225,10 @@ export async function reviewPass(opts: {
             });
             await recordAndApplyInterventionEvent({
               workspaceDir,
-              channelId: projectName,
-              project: { slug: projectName, name: projectName, repo: repoPath, groupName: projectName, deployUrl: "", baseBranch: baseBranch ?? "main", deployBranch: baseBranch ?? "main", channels: [], workers: {} },
+              channelId: project?.channels[0]?.channelId ?? projectName,
+              messageThreadId: project?.channels[0]?.messageThreadId,
+              agentId,
+              project: interventionProject,
               workflow,
               provider,
               issue: await provider.getIssue(issue.iid),
@@ -332,8 +342,10 @@ export async function reviewPass(opts: {
       });
       await recordAndApplyInterventionEvent({
         workspaceDir,
-        channelId: projectName,
-        project: { slug: projectName, name: projectName, repo: repoPath, groupName: projectName, deployUrl: "", baseBranch: baseBranch ?? "main", deployBranch: baseBranch ?? "main", channels: [], workers: {} },
+        channelId: project?.channels[0]?.channelId ?? projectName,
+        messageThreadId: project?.channels[0]?.messageThreadId,
+        agentId,
+        project: interventionProject,
         workflow,
         provider,
         issue: await provider.getIssue(issue.iid),

--- a/lib/services/heartbeat/tick-runner.ts
+++ b/lib/services/heartbeat/tick-runner.ts
@@ -113,7 +113,7 @@ export async function tick(opts: {
 
       // Review pass: transition issues whose PR check condition is met
       result.totalReviewTransitions += await performReviewPass(
-        workspaceDir, slug, project, provider, resolvedConfig, pluginConfig, runtime, runCommand,
+        workspaceDir, slug, project, provider, resolvedConfig, pluginConfig, runtime, runCommand, agentId,
       );
 
       // Review skip pass: auto-merge and transition review:skip issues through the review queue

--- a/lib/services/pipeline.ts
+++ b/lib/services/pipeline.ts
@@ -9,6 +9,7 @@ import { deactivateWorker, loadProjectBySlug, getRoleWorker } from "../projects/
 import type { RunCommand } from "../context.js";
 import { notify, getNotificationConfig } from "../dispatch/notify.js";
 import { log as auditLog } from "../audit.js";
+import { recordAndApplyInterventionEvent } from "../orchestrator-intervention/engine.js";
 import { loadConfig } from "../config/index.js";
 import { detectStepRouting } from "./queue-scan.js";
 import { recordLoopDiagnostic } from "./loop-diagnostics.js";
@@ -365,6 +366,55 @@ export async function executeCompletion(opts: {
       } catch (err) {
         auditLog(workspaceDir, "pipeline_warning", { step: "reviewNotify", issue: issueId, role, error: (err as Error).message ?? String(err) }).catch(() => {});
       }
+    }
+  }
+
+  const interventionProject = await loadProjectBySlug(workspaceDir, projectSlug);
+  if (interventionProject) {
+    const updatedIssue = await provider.getIssue(issueId);
+    const eventType = transitionedTo === "Refining"
+      ? "workflow.hold"
+      : "worker.completed";
+    await recordAndApplyInterventionEvent({
+      workspaceDir,
+      channelId: notifyTarget?.channelId ?? interventionProject.channels[0]?.channelId ?? projectSlug,
+      messageThreadId: notifyTarget?.messageThreadId,
+      project: interventionProject,
+      workflow,
+      provider,
+      issue: updatedIssue,
+    }, {
+      eventType,
+      issueId,
+      role,
+      level: opts.level,
+      result,
+      reason: transitionedTo === "Refining" ? result : undefined,
+      fromState: rule.from,
+      toState: transitionedTo,
+      prUrl: prUrl ?? null,
+      source: "worker",
+      data: { summary: summary ?? null, createdTasks: createdTasks ?? null },
+    }).catch(() => {});
+
+    if (mergedPr) {
+      await recordAndApplyInterventionEvent({
+        workspaceDir,
+        channelId: notifyTarget?.channelId ?? interventionProject.channels[0]?.channelId ?? projectSlug,
+        messageThreadId: notifyTarget?.messageThreadId,
+        project: interventionProject,
+        workflow,
+        provider,
+        issue: updatedIssue,
+      }, {
+        eventType: "pr.merged",
+        issueId,
+        role,
+        level: opts.level,
+        prUrl: prUrl ?? null,
+        source: "worker",
+        data: { mergedBy: "pipeline" },
+      }).catch(() => {});
     }
   }
 

--- a/lib/services/pipeline.ts
+++ b/lib/services/pipeline.ts
@@ -126,6 +126,8 @@ export async function executeCompletion(opts: {
   pluginConfig?: Record<string, unknown>;
   /** Plugin runtime for direct API access (avoids CLI subprocess timeouts) */
   runtime?: PluginRuntime;
+  /** Agent id used for orchestrator wake delivery */
+  agentId?: string;
   /** Workflow config (defaults to DEFAULT_WORKFLOW) */
   workflow?: WorkflowConfig;
   /** Tasks created during this work session (e.g. architect implementation tasks) */
@@ -379,10 +381,12 @@ export async function executeCompletion(opts: {
       workspaceDir,
       channelId: notifyTarget?.channelId ?? interventionProject.channels[0]?.channelId ?? projectSlug,
       messageThreadId: notifyTarget?.messageThreadId,
+      agentId: opts.agentId,
       project: interventionProject,
       workflow,
       provider,
       issue: updatedIssue,
+      runCommand: rc,
     }, {
       eventType,
       issueId,
@@ -402,10 +406,12 @@ export async function executeCompletion(opts: {
         workspaceDir,
         channelId: notifyTarget?.channelId ?? interventionProject.channels[0]?.channelId ?? projectSlug,
         messageThreadId: notifyTarget?.messageThreadId,
+        agentId: opts.agentId,
         project: interventionProject,
         workflow,
         provider,
         issue: updatedIssue,
+        runCommand: rc,
       }, {
         eventType: "pr.merged",
         issueId,

--- a/lib/tools/tasks/orchestrator-intervention.test.ts
+++ b/lib/tools/tasks/orchestrator-intervention.test.ts
@@ -1,0 +1,45 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { createTestHarness } from "../../testing/harness.js";
+import { createOrchestratorInterventionTool } from "./orchestrator-intervention.js";
+
+const pluginCtx = {
+  runCommand: (() => Promise.resolve({ stdout: "{}", stderr: "", code: 0, signal: null, killed: false })) as any,
+  runtime: {} as any,
+  pluginConfig: {},
+  config: {} as any,
+  logger: { info() {}, warn() {}, error() {}, debug() {} } as any,
+};
+
+describe("orchestrator_intervention tool", () => {
+  it("saves and lists policies", async () => {
+    const h = await createTestHarness();
+    try {
+      const tool = createOrchestratorInterventionTool(pluginCtx as any)({
+        workspaceDir: h.workspaceDir,
+        messageChannel: "telegram",
+      });
+
+      await tool.execute("1", {
+        channelId: h.channelId,
+        action: "set_policy",
+        policy: {
+          title: "Requeue blocked dev",
+          event: { type: "workflow.hold", role: "developer", result: "blocked" },
+          action: { type: "requeue", message: "Try again" },
+        },
+      });
+
+      const listed = await tool.execute("2", {
+        channelId: h.channelId,
+        action: "list_policies",
+      });
+
+      const details = listed.details as { policies: Array<{ title: string }> };
+      assert.equal(details.policies.length, 1);
+      assert.equal(details.policies[0]?.title, "Requeue blocked dev");
+    } finally {
+      await h.cleanup();
+    }
+  });
+});

--- a/lib/tools/tasks/orchestrator-intervention.ts
+++ b/lib/tools/tasks/orchestrator-intervention.ts
@@ -1,0 +1,151 @@
+import { jsonResult } from "../../json-result.js";
+import type { PluginContext } from "../../context.js";
+import type { ToolContext } from "../../types.js";
+import { log as auditLog } from "../../audit.js";
+import { requireWorkspaceDir, resolveChannelId, resolveProject } from "../helpers.js";
+import { deleteInterventionPolicy, loadInterventionStore, upsertInterventionPolicy } from "../../orchestrator-intervention/store.js";
+import { readInterventionEvents } from "../../orchestrator-intervention/timeline.js";
+import {
+  ORCHESTRATOR_INTERVENTION_ACTION_TYPES,
+  ORCHESTRATOR_INTERVENTION_EVENT_TYPES,
+  type OrchestratorInterventionPolicy,
+} from "../../orchestrator-intervention/types.js";
+
+export function createOrchestratorInterventionTool(ctx: PluginContext) {
+  return (toolCtx: ToolContext) => ({
+    name: "orchestrator_intervention",
+    label: "Orchestrator Intervention",
+    description: `Manage live orchestrator intervention policy and read the structured intervention event timeline.
+
+Actions:
+- set_policy: create or update a project-wide or issue-specific intervention rule
+- delete_policy: remove a rule by id
+- list_policies: list active rules for the project
+- get_events: read normalized live workflow events for the project or one issue
+
+Supported event types: ${ORCHESTRATOR_INTERVENTION_EVENT_TYPES.join(", ")}
+Supported action types: ${ORCHESTRATOR_INTERVENTION_ACTION_TYPES.join(", ")}`,
+    parameters: {
+      type: "object",
+      required: ["channelId", "action"],
+      properties: {
+        channelId: { type: "string", description: "YOUR chat/group ID — the numeric ID of the chat you are in right now." },
+        messageThreadId: { type: "number", description: "Optional Telegram forum topic ID for this project." },
+        action: {
+          type: "string",
+          enum: ["set_policy", "delete_policy", "list_policies", "get_events"],
+          description: "Operation to perform.",
+        },
+        policyId: { type: "string", description: "Rule id for delete_policy, or explicit id for set_policy." },
+        issueId: { type: "number", description: "Optional issue scope for set_policy or filter for get_events." },
+        limit: { type: "number", description: "Max events to return for get_events. Defaults to 20." },
+        policy: {
+          type: "object",
+          description: "Policy payload for set_policy.",
+          properties: {
+            title: { type: "string" },
+            enabled: { type: "boolean" },
+            mode: { type: "string", enum: ["notify", "auto"] },
+            event: {
+              type: "object",
+              properties: {
+                type: { type: "string", enum: [...ORCHESTRATOR_INTERVENTION_EVENT_TYPES] },
+                role: { type: "string" },
+                result: { type: "string" },
+                reason: { type: "string" },
+                fromState: { type: "string" },
+                toState: { type: "string" },
+              },
+              required: ["type"],
+            },
+            action: {
+              type: "object",
+              properties: {
+                type: { type: "string", enum: [...ORCHESTRATOR_INTERVENTION_ACTION_TYPES] },
+                message: { type: "string" },
+                level: { type: "string" },
+                issueId: { type: "number" },
+                title: { type: "string" },
+                body: { type: "string" },
+                queueAfterCreate: { type: "boolean" },
+              },
+              required: ["type"],
+            },
+          },
+          required: ["title", "event", "action"],
+        },
+      },
+    },
+
+    async execute(_id: string, params: Record<string, unknown>) {
+      const channelId = resolveChannelId(toolCtx, params.channelId as string | undefined);
+      const action = params.action as "set_policy" | "delete_policy" | "list_policies" | "get_events";
+      const workspaceDir = requireWorkspaceDir(toolCtx);
+      const messageThreadId = params.messageThreadId as number | undefined;
+      const channelType = (toolCtx.messageChannel as string | undefined) ?? "telegram";
+      const accountId = toolCtx.agentAccountId as string | undefined;
+      const { project } = await resolveProject(workspaceDir, channelId, {
+        channel: channelType,
+        accountId,
+        messageThreadId,
+      });
+
+      if (action === "list_policies") {
+        const store = await loadInterventionStore(workspaceDir, project.slug);
+        return jsonResult({ success: true, project: project.name, policies: store.policies });
+      }
+
+      if (action === "get_events") {
+        const issueId = params.issueId as number | undefined;
+        const limit = (params.limit as number | undefined) ?? 20;
+        const events = await readInterventionEvents({ workspaceDir, projectSlug: project.slug, issueId, limit });
+        return jsonResult({ success: true, project: project.name, issueId: issueId ?? null, events });
+      }
+
+      if (action === "delete_policy") {
+        const policyId = params.policyId as string | undefined;
+        if (!policyId) throw new Error("policyId is required for delete_policy");
+        const deleted = await deleteInterventionPolicy(workspaceDir, project.slug, policyId);
+        await auditLog(workspaceDir, "orchestrator_intervention_policy_delete", {
+          project: project.name,
+          policyId,
+          deleted,
+        });
+        return jsonResult({ success: true, project: project.name, policyId, deleted });
+      }
+
+      const payload = params.policy as Record<string, unknown> | undefined;
+      if (!payload) throw new Error("policy is required for set_policy");
+      if (!payload.title || !payload.event || !payload.action) {
+        throw new Error("policy.title, policy.event, and policy.action are required");
+      }
+      const policyId = (params.policyId as string | undefined) ?? slugify(String(payload.title));
+      const issueId = params.issueId as number | undefined;
+      const policy: Omit<OrchestratorInterventionPolicy, "updatedAt"> = {
+        id: policyId,
+        title: String(payload.title),
+        enabled: payload.enabled as boolean | undefined,
+        mode: (payload.mode as "notify" | "auto" | undefined) ?? "auto",
+        issueId,
+        event: payload.event as OrchestratorInterventionPolicy["event"],
+        action: payload.action as OrchestratorInterventionPolicy["action"],
+        updatedBy: toolCtx.sessionKey ?? toolCtx.agentId,
+      };
+      const saved = await upsertInterventionPolicy(workspaceDir, project.slug, policy);
+      await auditLog(workspaceDir, "orchestrator_intervention_policy_set", {
+        project: project.name,
+        policyId: saved.id,
+        title: saved.title,
+        issueId: saved.issueId ?? null,
+        mode: saved.mode,
+        eventType: saved.event.type,
+        actionType: saved.action.type,
+      });
+      return jsonResult({ success: true, project: project.name, policy: saved });
+    },
+  });
+}
+
+function slugify(value: string): string {
+  return value.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "").slice(0, 80) || "policy";
+}

--- a/lib/tools/tasks/task-start.ts
+++ b/lib/tools/tasks/task-start.ts
@@ -27,6 +27,7 @@ import {
 import { getLevelsForRole } from "../../roles/index.js";
 import { loadConfig } from "../../config/index.js";
 import { requireWorkspaceDir, resolveChannelId, resolveProject, resolveProvider, autoAssignOwnerLabel, applyNotifyLabel } from "../helpers.js";
+import { recordAndApplyInterventionEvent } from "../../orchestrator-intervention/engine.js";
 
 export function createTaskStartTool(ctx: PluginContext) {
   return (toolCtx: ToolContext) => ({
@@ -130,6 +131,24 @@ Examples:
         transitioned, level: levelHint ?? null,
       });
 
+      await recordAndApplyInterventionEvent({
+        workspaceDir,
+        channelId,
+        messageThreadId,
+        project,
+        workflow,
+        provider,
+        issue: await provider.getIssue(issueId),
+        sessionKey: toolCtx.sessionKey,
+      }, {
+        eventType: "workflow.requeue",
+        issueId,
+        fromState: currentLabel,
+        toState: targetLabel,
+        source: "system",
+        data: { transitioned, levelHint: levelHint ?? null },
+      }).catch(() => {});
+
       const levelMsg = levelHint ? ` (level hint: ${levelHint})` : "";
       const announcement = transitioned
         ? `▶️ #${issueId} moved to "${targetLabel}"${levelMsg} — heartbeat will dispatch.`
@@ -153,7 +172,7 @@ Examples:
  * - ACTIVE: error (already being worked on)
  * - TERMINAL: error (issue is closed)
  */
-function resolveTarget(
+export function resolveTarget(
   workflow: WorkflowConfig,
   currentLabel: string,
   currentState: StateConfig,

--- a/lib/tools/worker/work-finish.ts
+++ b/lib/tools/worker/work-finish.ts
@@ -281,6 +281,7 @@ export function createWorkFinishTool(ctx: PluginContext) {
         level: slotLevel,
         slotIndex,
         runtime: ctx.runtime,
+        agentId: toolCtx.agentId,
         workflow,
         createdTasks,
         runCommand: ctx.runCommand,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1851,9 +1851,6 @@
       "cpu": [
         "arm"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1870,9 +1867,6 @@
       "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -1891,9 +1885,6 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1910,9 +1901,6 @@
       "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
       "cpu": [
         "riscv64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -1931,9 +1919,6 @@
       "cpu": [
         "s390x"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1950,9 +1935,6 @@
       "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -1971,9 +1953,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1991,9 +1970,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2010,9 +1986,6 @@
       "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
       "cpu": [
         "arm"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -2037,9 +2010,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2062,9 +2032,6 @@
       "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
       "cpu": [
         "ppc64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -2089,9 +2056,6 @@
       "cpu": [
         "riscv64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2114,9 +2078,6 @@
       "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
       "cpu": [
         "s390x"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -2141,9 +2102,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2167,9 +2125,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2192,9 +2147,6 @@
       "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -2633,9 +2585,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2652,9 +2601,6 @@
       "integrity": "sha512-0/Gi5Xq2V6goXBop19ePoHvXsmJD9SzFlO3S+d6+T2b+BlPcpOu3Oa0wTjl+cZrLAAEzA86aPNBI+VVAFDFPKw==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2673,9 +2619,6 @@
       "cpu": [
         "riscv64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2693,9 +2636,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2712,9 +2652,6 @@
       "integrity": "sha512-xVUtnoMQ8v2JVyfJLKKXACA6avdnchdbBkTsZs8BgJQo29qwCp5NIHAUO8gbJ40iaEGToW5RlmVk2M9V0HsHEw==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -3019,9 +2956,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3042,9 +2976,6 @@
       "integrity": "sha512-PXy0UT1J/8MPG8UAkWp6Fd51ZtIZINFzIjGH909JjQrtCuJf3X6nanHYdz1A+Wq9o4aoPAw1YEUpFS1lelsVlg==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -3067,9 +2998,6 @@
       "cpu": [
         "riscv64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3091,9 +3019,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3114,9 +3039,6 @@
       "integrity": "sha512-Z5KzqBK/XzPz5+SFHKz7yKqClEQ8pOiEDdgk5SlphBLVNb8JFIJkxhtJKSvnJyHh2rjVgiFmvtJzMF0gNwwKyQ==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -3199,9 +3121,6 @@
         "arm64",
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3220,9 +3139,6 @@
         "arm",
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3239,9 +3155,6 @@
       "integrity": "sha512-OXYf8rVfoDyvN+YrfKk8F9An9a5GOxVIM8OcR1U911tc0oRNf8yfJrQ8KrM75R26gwq0Y6YZwVTP0vRCInwWOw==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -3260,9 +3173,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3280,9 +3190,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3299,9 +3206,6 @@
       "integrity": "sha512-HDLAw4ZhwJuhKuF6n4x520yZXAQZahUOXtCGvPubjfpmIOElKrfDvCVlRsthAP0JwcwINzIQlVys3boMIXfBgw==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -3955,9 +3859,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3974,9 +3875,6 @@
       "integrity": "sha512-37iO/Dp6m5DDaC2sf3zPtx/hl9FV3Xze4xoYidrxxS9bgP3S8ALroxRK6xBG/1TtfXKTvolvp+IjrUU6ujIGmA==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -3995,9 +3893,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4014,9 +3909,6 @@
       "integrity": "sha512-e9FBWDe+lv7QKAwtKOt6A2W/fyy/aEEfr0g6j/hWzvQcrzHCsz07BNQYlNOjTfeytrtLU7k449H1PI95jA4OjQ==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -5022,9 +4914,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5041,9 +4930,6 @@
       "integrity": "sha512-pudzQCP9rZItwW4qHHvciMwtNd9kWH4l73g6Id1LRpe6sc8jiFBV7W+YXITj2PZbI0by6XPfkRP6Dk5IkGOuAw==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -5062,9 +4948,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5081,9 +4964,6 @@
       "integrity": "sha512-wPR5/2QmsF7sR0WUaCwbk4XI3TLcxK9PVK8mhgcAYyuRpbhcVgNGWXs8ulcyMSXve5pFRJAFAuMTGCEb014peg==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,


### PR DESCRIPTION
## Summary
- add a structured orchestrator intervention event timeline plus persisted intervention policies
- evaluate bounded, audited intervention actions on live workflow events like dispatch, worker finish, and review transitions
- wake the chat-backed orchestrator session on matched live intervention policies, and route follow-up issue creation through the workflow's configured initial hold state
- document the intervention model and add coverage for policy execution and tool behavior

## Validation
- npm run build
- npx tsc --noEmit --pretty false 2>&1 | rg 'lib/(orchestrator-intervention|services/heartbeat/review|services/heartbeat/passes|dispatch/session|services/pipeline|tools/worker/work-finish)'
- npm run check *(still blocked by pre-existing repo type/test dependency errors outside this change, including vitest/module resolution issues and existing work-finish tests)*
