### PR TITLE
fix: prevent blocked refining issues from auto-requeue

### DIFF
--- a/lib/orchestrator-intervention/engine.test.ts
+++ b/lib/orchestrator-intervention/engine.test.ts
@@ -91,6 +91,47 @@ describe("orchestrator intervention engine", () => {
     }
   });
 
+  it("does not auto-queue a refining issue via queue_issue after a blocked hold event", async () => {
+    const h = await createTestHarness();
+    try {
+      const issue = h.provider.seedIssue({ iid: 78, title: "Blocked", labels: ["Refining"] });
+      await upsertInterventionPolicy(h.workspaceDir, h.project.slug, {
+        id: "queue-blocked",
+        title: "Queue blocked issues",
+        mode: "auto",
+        issueId: 78,
+        event: { type: "workflow.hold", result: "blocked" },
+        action: { type: "queue_issue", issueId: 78 },
+      });
+
+      const executions = await recordAndApplyInterventionEvent({
+        workspaceDir: h.workspaceDir,
+        channelId: h.channelId,
+        agentId: "main",
+        project: h.project,
+        workflow: h.workflow,
+        provider: h.provider,
+        issue,
+        runCommand: h.runCommand,
+      }, {
+        eventType: "workflow.hold",
+        issueId: 78,
+        result: "blocked",
+        fromState: "Doing",
+        toState: "Refining",
+        source: "worker",
+      });
+
+      assert.equal(executions[0]?.executed, false);
+      assert.match(executions[0]?.error ?? "", /automatic queue_issue is not allowed from HOLD state/i);
+      const updated = await h.provider.getIssue(78);
+      assert.ok(updated.labels.includes("Refining"));
+      assert.ok(!updated.labels.includes("To Do"));
+    } finally {
+      await h.cleanup();
+    }
+  });
+
   it("creates follow-up issues in the workflow initial hold state, not the first hold state by order", async () => {
     const h = await createTestHarness();
     try {

--- a/lib/orchestrator-intervention/engine.test.ts
+++ b/lib/orchestrator-intervention/engine.test.ts
@@ -48,7 +48,7 @@ describe("orchestrator intervention engine", () => {
     }
   });
 
-  it("requeues a refining issue when a hold policy matches", async () => {
+  it("does not auto-requeue a refining issue when a hold policy matches", async () => {
     const h = await createTestHarness();
     try {
       const issue = h.provider.seedIssue({ iid: 77, title: "Blocked", labels: ["Refining"] });
@@ -79,12 +79,13 @@ describe("orchestrator intervention engine", () => {
         source: "worker",
       });
 
-      assert.equal(executions[0]?.executed, true);
+      assert.equal(executions[0]?.executed, false);
+      assert.match(executions[0]?.error ?? "", /not allowed from HOLD state/i);
       const updated = await h.provider.getIssue(77);
-      assert.ok(updated.labels.includes("To Do"));
+      assert.ok(updated.labels.includes("Refining"));
+      assert.ok(!updated.labels.includes("To Do"));
       const comments = await h.provider.listComments(77);
-      assert.equal(comments.length, 1);
-      assert.match(comments[0]!.body, /Requeued after blocked/);
+      assert.equal(comments.length, 0);
     } finally {
       await h.cleanup();
     }

--- a/lib/orchestrator-intervention/engine.ts
+++ b/lib/orchestrator-intervention/engine.ts
@@ -195,6 +195,9 @@ async function executePolicyAction(
       if (!currentLabel) throw new Error(`issue #${targetIssueId} has no recognized workflow label`);
       const currentState = findStateByLabel(ctx.workflow, currentLabel);
       if (!currentState) throw new Error(`unknown state for ${currentLabel}`);
+      if (currentState.type === StateType.HOLD) {
+        throw new Error(`automatic queue_issue is not allowed from HOLD state ${currentLabel}; require explicit human restart via task_start(confirmHoldRestart=true)`);
+      }
       const target = resolveTarget(ctx.workflow, currentLabel, currentState);
       if (target.transitioned) {
         await ctx.provider.transitionLabel(targetIssueId, currentLabel, target.targetLabel);

--- a/lib/orchestrator-intervention/engine.ts
+++ b/lib/orchestrator-intervention/engine.ts
@@ -172,6 +172,9 @@ async function executePolicyAction(
       if (!currentLabel) throw new Error("issue has no recognized workflow label");
       const currentState = findStateByLabel(ctx.workflow, currentLabel);
       if (!currentState) throw new Error(`unknown state for ${currentLabel}`);
+      if (currentState.type === StateType.HOLD) {
+        throw new Error(`automatic requeue is not allowed from HOLD state ${currentLabel}; require explicit human restart via task_start(confirmHoldRestart=true)`);
+      }
       const target = resolveTarget(ctx.workflow, currentLabel, currentState);
       if (target.transitioned) {
         await ctx.provider.transitionLabel(issue.iid, currentLabel, target.targetLabel);

--- a/lib/tools/tasks/orchestrator-intervention.test.ts
+++ b/lib/tools/tasks/orchestrator-intervention.test.ts
@@ -12,7 +12,7 @@ const pluginCtx = {
 };
 
 describe("orchestrator_intervention tool", () => {
-  it("saves and lists policies", async () => {
+  it("saves and lists safe policies", async () => {
     const h = await createTestHarness();
     try {
       const tool = createOrchestratorInterventionTool(pluginCtx as any)({
@@ -24,9 +24,9 @@ describe("orchestrator_intervention tool", () => {
         channelId: h.channelId,
         action: "set_policy",
         policy: {
-          title: "Requeue blocked dev",
+          title: "Comment on blocked dev",
           event: { type: "workflow.hold", role: "developer", result: "blocked" },
-          action: { type: "requeue", message: "Try again" },
+          action: { type: "comment", message: "Need human decision" },
         },
       });
 
@@ -37,7 +37,32 @@ describe("orchestrator_intervention tool", () => {
 
       const details = listed.details as { policies: Array<{ title: string }> };
       assert.equal(details.policies.length, 1);
-      assert.equal(details.policies[0]?.title, "Requeue blocked dev");
+      assert.equal(details.policies[0]?.title, "Comment on blocked dev");
+    } finally {
+      await h.cleanup();
+    }
+  });
+
+  it("rejects auto requeue policies for hold events", async () => {
+    const h = await createTestHarness();
+    try {
+      const tool = createOrchestratorInterventionTool(pluginCtx as any)({
+        workspaceDir: h.workspaceDir,
+        messageChannel: "telegram",
+      });
+
+      await assert.rejects(
+        tool.execute("1", {
+          channelId: h.channelId,
+          action: "set_policy",
+          policy: {
+            title: "Requeue blocked dev",
+            event: { type: "workflow.hold", role: "developer", result: "blocked" },
+            action: { type: "requeue", message: "Try again" },
+          },
+        }),
+        /not allowed for workflow\.hold policies/,
+      );
     } finally {
       await h.cleanup();
     }

--- a/lib/tools/tasks/orchestrator-intervention.test.ts
+++ b/lib/tools/tasks/orchestrator-intervention.test.ts
@@ -67,4 +67,29 @@ describe("orchestrator_intervention tool", () => {
       await h.cleanup();
     }
   });
+
+  it("rejects auto queue_issue policies for hold events", async () => {
+    const h = await createTestHarness();
+    try {
+      const tool = createOrchestratorInterventionTool(pluginCtx as any)({
+        workspaceDir: h.workspaceDir,
+        messageChannel: "telegram",
+      });
+
+      await assert.rejects(
+        tool.execute("1", {
+          channelId: h.channelId,
+          action: "set_policy",
+          policy: {
+            title: "Queue blocked dev",
+            event: { type: "workflow.hold", role: "developer", result: "blocked" },
+            action: { type: "queue_issue", issueId: 42 },
+          },
+        }),
+        /not allowed for workflow\.hold policies/,
+      );
+    } finally {
+      await h.cleanup();
+    }
+  });
 });

--- a/lib/tools/tasks/orchestrator-intervention.ts
+++ b/lib/tools/tasks/orchestrator-intervention.ts
@@ -131,6 +131,13 @@ Supported action types: ${ORCHESTRATOR_INTERVENTION_ACTION_TYPES.join(", ")}`,
         action: payload.action as OrchestratorInterventionPolicy["action"],
         updatedBy: toolCtx.sessionKey ?? toolCtx.agentId,
       };
+      if (policy.mode === "auto"
+        && policy.event.type === "workflow.hold"
+        && (policy.action.type === "requeue" || policy.action.type === "queue_issue")) {
+        throw new Error(
+          `auto ${policy.action.type} is not allowed for workflow.hold policies. Hold states like Refining require explicit human restart.`,
+        );
+      }
       const saved = await upsertInterventionPolicy(workspaceDir, project.slug, policy);
       await auditLog(workspaceDir, "orchestrator_intervention_policy_set", {
         project: project.name,

--- a/lib/tools/tasks/task-start.test.ts
+++ b/lib/tools/tasks/task-start.test.ts
@@ -1,0 +1,31 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { StateType } from "../../workflow/types.js";
+import { assertExplicitHoldRestart, resolveTarget } from "./task-start.js";
+import { DEFAULT_WORKFLOW } from "../../workflow/defaults.js";
+
+describe("task_start", () => {
+  it("requires explicit confirmation to restart an issue from Refining", () => {
+    assert.throws(
+      () => assertExplicitHoldRestart(42, "Refining", { label: "Refining", type: StateType.HOLD, description: "hold" }, false),
+      /confirmHoldRestart: true/,
+    );
+  });
+
+  it("allows explicit restart from Refining when confirmHoldRestart is true", () => {
+    assert.doesNotThrow(() => {
+      assertExplicitHoldRestart(42, "Refining", { label: "Refining", type: StateType.HOLD, description: "hold" }, true);
+    });
+  });
+
+  it("resolves Refining to the developer queue when restart is explicitly confirmed", () => {
+    const target = resolveTarget(
+      DEFAULT_WORKFLOW,
+      "Refining",
+      DEFAULT_WORKFLOW.states.refining!,
+    );
+
+    assert.equal(target.transitioned, true);
+    assert.equal(target.targetLabel, "To Do");
+  });
+});

--- a/lib/tools/tasks/task-start.test.ts
+++ b/lib/tools/tasks/task-start.test.ts
@@ -7,14 +7,14 @@ import { DEFAULT_WORKFLOW } from "../../workflow/defaults.js";
 describe("task_start", () => {
   it("requires explicit confirmation to restart an issue from Refining", () => {
     assert.throws(
-      () => assertExplicitHoldRestart(42, "Refining", { label: "Refining", type: StateType.HOLD, description: "hold" }, false),
+      () => assertExplicitHoldRestart(42, "Refining", { label: "Refining", type: StateType.HOLD, description: "hold", color: "#000000" }, false),
       /confirmHoldRestart: true/,
     );
   });
 
   it("allows explicit restart from Refining when confirmHoldRestart is true", () => {
     assert.doesNotThrow(() => {
-      assertExplicitHoldRestart(42, "Refining", { label: "Refining", type: StateType.HOLD, description: "hold" }, true);
+      assertExplicitHoldRestart(42, "Refining", { label: "Refining", type: StateType.HOLD, description: "hold", color: "#000000" }, true);
     });
   });
 

--- a/lib/tools/tasks/task-start.test.ts
+++ b/lib/tools/tasks/task-start.test.ts
@@ -7,14 +7,20 @@ import { DEFAULT_WORKFLOW } from "../../workflow/defaults.js";
 describe("task_start", () => {
   it("requires explicit confirmation to restart an issue from Refining", () => {
     assert.throws(
-      () => assertExplicitHoldRestart(42, "Refining", { label: "Refining", type: StateType.HOLD, description: "hold", color: "#000000" }, false),
+      () => assertExplicitHoldRestart(42, DEFAULT_WORKFLOW, "Refining", { label: "Refining", type: StateType.HOLD, description: "hold", color: "#000000" }, false),
       /confirmHoldRestart: true/,
     );
   });
 
+  it("allows the normal Planning start path without confirmHoldRestart", () => {
+    assert.doesNotThrow(() => {
+      assertExplicitHoldRestart(42, DEFAULT_WORKFLOW, "Planning", DEFAULT_WORKFLOW.states.planning!, false);
+    });
+  });
+
   it("allows explicit restart from Refining when confirmHoldRestart is true", () => {
     assert.doesNotThrow(() => {
-      assertExplicitHoldRestart(42, "Refining", { label: "Refining", type: StateType.HOLD, description: "hold", color: "#000000" }, true);
+      assertExplicitHoldRestart(42, DEFAULT_WORKFLOW, "Refining", { label: "Refining", type: StateType.HOLD, description: "hold", color: "#000000" }, true);
     });
   });
 

--- a/lib/tools/tasks/task-start.ts
+++ b/lib/tools/tasks/task-start.ts
@@ -39,7 +39,8 @@ Optionally set a level hint (e.g. "junior", "senior") so the heartbeat dispatche
 
 Examples:
 - Start work: { channelId: "-1003844794417", issueId: 42 } → advances to next queue
-- With level: { channelId: "-1003844794417", issueId: 42, level: "junior" } → advances + hints junior`,
+- With level: { channelId: "-1003844794417", issueId: 42, level: "junior" } → advances + hints junior
+- Restart from hold: { channelId: "-1003844794417", issueId: 42, confirmHoldRestart: true } → explicitly leaves Planning/Refining`,
     parameters: {
       type: "object",
       required: ["channelId", "issueId"],
@@ -60,6 +61,10 @@ Examples:
           type: "string",
           description: "Optional level hint for dispatch (e.g. 'junior', 'senior'). Applied as a label so the heartbeat respects it.",
         },
+        confirmHoldRestart: {
+          type: "boolean",
+          description: "Required when restarting an issue from a HOLD state (Planning, Refining). Makes human intent explicit and prevents accidental auto-requeue.",
+        },
       },
     },
 
@@ -67,6 +72,7 @@ Examples:
       const channelId = resolveChannelId(toolCtx, params.channelId as string | undefined);
       const issueId = params.issueId as number;
       const levelHint = params.level as string | undefined;
+      const confirmHoldRestart = params.confirmHoldRestart === true;
       const workspaceDir = requireWorkspaceDir(toolCtx);
 
       const messageThreadId = params.messageThreadId as number | undefined;
@@ -91,6 +97,7 @@ Examples:
       if (!currentState) {
         throw new Error(`No state config for label "${currentLabel}".`);
       }
+      assertExplicitHoldRestart(issueId, currentLabel, currentState, confirmHoldRestart);
 
       // Determine target based on current state type
       const { targetLabel, targetState, transitioned } = resolveTarget(
@@ -172,6 +179,17 @@ Examples:
  * - ACTIVE: error (already being worked on)
  * - TERMINAL: error (issue is closed)
  */
+export function assertExplicitHoldRestart(
+  issueId: number,
+  currentLabel: string,
+  currentState: StateConfig,
+  confirmHoldRestart: boolean,
+): void {
+  if (currentState.type === StateType.HOLD && !confirmHoldRestart) {
+    throw new Error(`Issue #${issueId} is in hold state "${currentLabel}". Restart requires explicit confirmHoldRestart: true.`);
+  }
+}
+
 export function resolveTarget(
   workflow: WorkflowConfig,
   currentLabel: string,

--- a/lib/tools/tasks/task-start.ts
+++ b/lib/tools/tasks/task-start.ts
@@ -21,7 +21,6 @@ import {
 import {
   getCurrentStateLabel,
   findStateByLabel,
-  findStateKeyByLabel,
   getRoleLabelColor,
 } from "../../workflow/index.js";
 import { getLevelsForRole } from "../../roles/index.js";
@@ -40,7 +39,7 @@ Optionally set a level hint (e.g. "junior", "senior") so the heartbeat dispatche
 Examples:
 - Start work: { channelId: "-1003844794417", issueId: 42 } → advances to next queue
 - With level: { channelId: "-1003844794417", issueId: 42, level: "junior" } → advances + hints junior
-- Restart from hold: { channelId: "-1003844794417", issueId: 42, confirmHoldRestart: true } → explicitly leaves Planning/Refining`,
+- Restart from Refining: { channelId: "-1003844794417", issueId: 42, confirmHoldRestart: true } → explicitly leaves blocked/rework hold`,
     parameters: {
       type: "object",
       required: ["channelId", "issueId"],
@@ -63,7 +62,7 @@ Examples:
         },
         confirmHoldRestart: {
           type: "boolean",
-          description: "Required when restarting an issue from a HOLD state (Planning, Refining). Makes human intent explicit and prevents accidental auto-requeue.",
+          description: "Required when restarting an issue from blocked/rework hold states like Refining. Normal Planning starts do not need it.",
         },
       },
     },
@@ -97,7 +96,7 @@ Examples:
       if (!currentState) {
         throw new Error(`No state config for label "${currentLabel}".`);
       }
-      assertExplicitHoldRestart(issueId, currentLabel, currentState, confirmHoldRestart);
+      assertExplicitHoldRestart(issueId, workflow, currentLabel, currentState, confirmHoldRestart);
 
       // Determine target based on current state type
       const { targetLabel, targetState, transitioned } = resolveTarget(
@@ -181,13 +180,19 @@ Examples:
  */
 export function assertExplicitHoldRestart(
   issueId: number,
+  workflow: WorkflowConfig,
   currentLabel: string,
   currentState: StateConfig,
   confirmHoldRestart: boolean,
 ): void {
-  if (currentState.type === StateType.HOLD && !confirmHoldRestart) {
-    throw new Error(`Issue #${issueId} is in hold state "${currentLabel}". Restart requires explicit confirmHoldRestart: true.`);
-  }
+  if (currentState.type !== StateType.HOLD) return;
+
+  const initialState = workflow.states[workflow.initial];
+  const initialHoldLabel = initialState?.label;
+  if (currentLabel === initialHoldLabel) return;
+  if (confirmHoldRestart) return;
+
+  throw new Error(`Issue #${issueId} is in hold state "${currentLabel}". Restart requires explicit confirmHoldRestart: true.`);
 }
 
 export function resolveTarget(


### PR DESCRIPTION
## Summary
- require explicit confirmation before `task_start` can move a HOLD-state issue back into a runnable queue
- block orchestrator intervention auto-actions from moving HOLD-state issues back into queue states, covering both `requeue` and `queue_issue`
- add regression tests for blocked/refining cycles and hold-policy validation

## Testing
- `npx tsx --test lib/orchestrator-intervention/engine.test.ts lib/tools/tasks/orchestrator-intervention.test.ts lib/tools/tasks/task-start.test.ts`

Closes #225