### PR TITLE
Fix blocked-hold orphan requeue race

### DIFF
--- a/lib/services/heartbeat/health.test.ts
+++ b/lib/services/heartbeat/health.test.ts
@@ -102,6 +102,37 @@ describe("scanOrphanedLabels", () => {
       });
     });
 
+    it("should not overwrite a live Refining hold when active-label listing is stale", async () => {
+      h.provider.seedIssue({ iid: 42, title: "Blocked task", labels: ["Doing"] });
+
+      const originalListIssuesByLabel = h.provider.listIssuesByLabel.bind(h.provider);
+      h.provider.listIssuesByLabel = async (label: string) => {
+        const issues = await originalListIssuesByLabel(label);
+        const issue = await h.provider.getIssue(42);
+        issue.labels = ["Refining"];
+        return issues.map((candidate) => candidate.iid === 42 ? { ...candidate, labels: ["Doing"] } : candidate);
+      };
+
+      const fixes = await scanOrphanedLabels({
+        workspaceDir: h.workspaceDir,
+        projectSlug: h.project.slug,
+        project: h.project,
+        role: "developer",
+        autoFix: true,
+        provider: h.provider,
+        workflow: h.workflow,
+      });
+
+      assert.strictEqual(fixes.length, 1);
+      assert.strictEqual(fixes[0]!.fixed, false);
+      assert.strictEqual(fixes[0]!.labelReverted, undefined, "Should not requeue after live hold landed");
+
+      const issue = await h.provider.getIssue(42);
+      assert.ok(issue.labels.includes("Refining"), `Expected Refining to be preserved, got: ${issue.labels}`);
+      assert.ok(!issue.labels.includes("To Do"), `Should not requeue blocked issue, got: ${issue.labels}`);
+      assert.strictEqual(h.provider.callsTo("transitionLabel").length, 0, "Should not transition label after hold landed");
+    });
+
     it("should revert to 'To Improve' when issue has open PR (feedback cycle)", async () => {
       h.provider.seedIssue({ iid: 42, title: "Test issue", labels: ["Doing"] });
       h.provider.setPrStatus(42, { state: PrState.OPEN, url: "https://github.com/test/pr/1" });

--- a/lib/services/heartbeat/health.ts
+++ b/lib/services/heartbeat/health.ts
@@ -686,13 +686,17 @@ export async function scanOrphanedLabels(opts: {
 
       if (autoFix) {
         try {
-          const revertTarget = await resolveOrphanRevertLabel(
-            provider, issue.iid, role, queueLabel, workflow,
-          );
-          await provider.transitionLabel(issue.iid, activeLabel, revertTarget);
-          fix.fixed = true;
-          fix.labelReverted = `${activeLabel} → ${revertTarget}`;
-          fix.issue.expectedLabel = revertTarget;
+          const liveIssue = await fetchIssue(provider, issue.iid);
+          const liveLabel = liveIssue ? getCurrentStateLabel(liveIssue.labels, workflow) : null;
+          if (liveLabel === activeLabel) {
+            const revertTarget = await resolveOrphanRevertLabel(
+              provider, issue.iid, role, queueLabel, workflow,
+            );
+            await provider.transitionLabel(issue.iid, activeLabel, revertTarget);
+            fix.fixed = true;
+            fix.labelReverted = `${activeLabel} → ${revertTarget}`;
+            fix.issue.expectedLabel = revertTarget;
+          }
         } catch {
           fix.labelRevertFailed = true;
         }


### PR DESCRIPTION
## Summary
- guard orphaned-label auto-fix with a fresh live-state read before requeueing
- preserve live Refining holds when the active-label listing is stale
- add regression coverage for the stale orphan listing path behind the blocked-hold redispatch loop family

## Testing
- npx tsx --test lib/services/heartbeat/health.test.ts

## Issue
- closes #227