### PR TITLE
fix: bootstrap worker issue worktrees

### DIFF
--- a/defaults/devclaw/prompts/developer.md
+++ b/defaults/devclaw/prompts/developer.md
@@ -12,28 +12,27 @@ Read the comments carefully — they often contain clarifications, decisions, or
 
 ## Workflow
 
-### 1. Create a worktree
+### 1. Bootstrap the worker worktree
 
-**NEVER work in the main checkout.** Create a dedicated git worktree as a sibling to the repo:
+**NEVER work in the main checkout.** Use the bootstrap contract from the task message.
 
-```bash
-# Example: repo is at ~/git/myproject
-# Worktree goes to ~/git/myproject.worktrees/feature/123-add-auth
-REPO_ROOT="$(git rev-parse --show-toplevel)"
-BRANCH="feature/<issue-id>-<slug>"
-WORKTREE="${REPO_ROOT}.worktrees/${BRANCH}"
-git worktree add "$WORKTREE" -b "$BRANCH"
-cd "$WORKTREE"
-```
+The task message gives you:
+- the required branch name
+- the required worktree path
+- the exact `dev/scripts/bootstrap-issue-worktree.sh ...` command to run
 
-The `.worktrees/` directory sits NEXT TO the repo folder (not inside it). This keeps the main checkout clean for the orchestrator and other workers. If a worktree already exists from a previous task on the same branch, verify it's clean before reusing it.
+That bootstrap command is the source of truth. Run it before validation. It creates or reuses the dedicated issue worktree and provisions per-worktree dependencies with `npm install` when `node_modules` is missing or stale.
+
+The `.worktrees/` directory sits NEXT TO the repo folder (not inside it). This keeps the main checkout clean for the orchestrator and other workers.
 
 ### 2. Implement the changes
 
 - Read the issue description and comments thoroughly
 - Make the changes described in the issue
 - Follow existing code patterns and conventions in the project
-- Run tests/linting if the project has them configured
+- Run validation from the bootstrapped worktree
+- Required handoff target: `npm run build` must pass
+- Best-effort target: run `npm run check`
 
 ### 3. Commit and push
 
@@ -70,7 +69,19 @@ When your task message includes a **PR Feedback** section, it means a reviewer r
 5. Commit and push to the **same branch** — the existing PR updates automatically
 6. Call `work_finish` as usual
 
-### 5. Call work_finish
+### 5. Classify failures correctly
+
+Do not collapse every problem into a product blocker.
+
+- **environment/bootstrap failure**: worktree creation failed, dependencies could not be installed, required tooling is missing, or local validation cannot start
+- **ambient validation noise**: repo-wide failures already exist and are not caused by your issue changes
+- **issue-local implementation failure**: your issue changes are still incorrect or incomplete
+
+If `npm run check` is noisy for ambient reasons but your issue changes are correct and `npm run build` passes, summarize the ambient noise clearly and still complete the implementation normally.
+
+If you must block, include the category name in the `work_finish` summary.
+
+### 6. Call work_finish
 
 ```
 work_finish({ role: "developer", result: "done", projectSlug: "<from task message>", summary: "<what you did>" })

--- a/defaults/devclaw/prompts/tester.md
+++ b/defaults/devclaw/prompts/tester.md
@@ -1,10 +1,11 @@
 # TESTER Worker Instructions
 
-You test the deployed version and inspect code on the base branch.
+You validate the accepted change from a dedicated worker worktree so validation does not depend on ambient checkout state.
 
 ## Your Job
 
-- Pull latest from the base branch
+- Start from the worker bootstrap contract in the task message
+- Run validation from that dedicated worktree, not from an ambient repo checkout
 - Run tests and linting
 - Verify the changes address the issue requirements
 - Check for regressions in related functionality
@@ -21,6 +22,16 @@ You test the deployed version and inspect code on the base branch.
 If you discover unrelated bugs or needed improvements during your work, call `task_create`:
 
 `task_create({ projectSlug: "<from task message>", title: "Bug: ...", description: "..." })`
+
+## Validation classification
+
+Keep setup failures separate from product findings.
+
+- **environment/bootstrap failure**: worktree/bootstrap script failed, dependencies would not install, required tooling is missing, or the validation environment could not start
+- **ambient validation noise**: repo baseline failures not caused by this issue
+- **issue-local implementation failure**: the issue change itself breaks required behavior or validation
+
+If you block, include the category in your summary.
 
 ## Completing Your Task
 

--- a/dev/design/worker-worktree-bootstrap-contract.md
+++ b/dev/design/worker-worktree-bootstrap-contract.md
@@ -1,0 +1,90 @@
+# Worker worktree bootstrap contract
+
+This design closes the gap between ordinary implementation work and the local checkout state that worker validation depends on.
+
+Related issues:
+- #171, workers can validate different checkouts and silently disagree on results
+- #174, canonical issue checkout contract and worktree lifecycle enforcement
+- #238, bootstrap worker issue worktrees and separate environment failures from implementation blockers
+
+## Contract
+
+### 1. Dedicated worker worktrees are required
+
+Developer and tester validation must run from dedicated worker worktrees, not from an ambient checkout whose dependency state is unknown.
+
+### 2. Branch naming is canonical
+
+Default implementation branch:
+- `issue/<issue-id>-<slug>`
+
+Feedback-cycle branch:
+- reuse the existing PR branch exactly as given in PR feedback
+
+### 3. Dependency strategy is per-worktree install
+
+Each worker worktree provisions its own `node_modules`.
+
+Why:
+- it avoids hidden dependence on some other checkout's install state
+- it makes validation reproducible per worker
+- it keeps the failure surface local to the worktree instead of leaking across branches
+
+### 4. Bootstrap is a first-class step
+
+Workers should use:
+- `dev/scripts/bootstrap-issue-worktree.sh`
+
+The script:
+- creates or reuses the canonical worktree
+- reuses an existing local branch when present
+- creates the branch from the configured base branch otherwise
+- runs `npm install` when dependencies are missing or stale
+
+## Validation target
+
+Minimum developer handoff target:
+- `npm run build` passes in the worker worktree
+
+Best-effort target:
+- `npm run check`
+
+If the repository baseline is already noisy, workers should distinguish that noise from issue-local failures instead of misclassifying it as a product blocker for the issue.
+
+## Failure classes
+
+### environment/bootstrap failure
+
+Examples:
+- worktree creation failure
+- dependency install failure
+- missing local tooling
+- validation command cannot start because the local environment is incomplete
+
+These are setup problems. They should not silently present as issue-specific product failures.
+
+### ambient validation noise
+
+Examples:
+- pre-existing repo-wide `npm run check` failures unrelated to the issue
+- flaky unrelated checks already failing on the same base before the issue changes
+
+These should be reported explicitly as baseline noise.
+
+### issue-local implementation failure
+
+Examples:
+- the issue's own changes fail `npm run build`
+- the fix is incomplete
+- the issue changes cause validation regressions in touched scope
+
+These are real implementation blockers.
+
+## Messaging rule
+
+Blocked or hold summaries should state which category applies:
+- `environment/bootstrap failure`
+- `ambient validation noise`
+- `issue-local implementation failure`
+
+That keeps Refining or follow-up discussion focused on the real problem.

--- a/dev/scripts/bootstrap-issue-worktree.sh
+++ b/dev/scripts/bootstrap-issue-worktree.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -lt 4 ]]; then
+  echo "usage: $0 <repo-root> <issue-id> <issue-title> <base-branch> [branch-name]" >&2
+  exit 2
+fi
+
+REPO_ROOT="$1"
+ISSUE_ID="$2"
+ISSUE_TITLE="$3"
+BASE_BRANCH="$4"
+BRANCH_NAME="${5:-}"
+
+slugify() {
+  printf '%s' "$1" \
+    | tr '[:upper:]' '[:lower:]' \
+    | sed -E 's/[^a-z0-9]+/-/g; s/^-+//; s/-+$//; s/(.{48}).*/\1/'
+}
+
+if [[ -z "$BRANCH_NAME" ]]; then
+  BRANCH_NAME="issue/${ISSUE_ID}-$(slugify "$ISSUE_TITLE")"
+fi
+
+WORKTREE="${REPO_ROOT}.worktrees/${BRANCH_NAME}"
+LOCKFILE="${WORKTREE}/package-lock.json"
+NODE_MODULES="${WORKTREE}/node_modules"
+
+mkdir -p "$(dirname "$WORKTREE")"
+
+git -C "$REPO_ROOT" fetch origin "$BASE_BRANCH" >/dev/null 2>&1 || true
+
+if [[ -d "$WORKTREE/.git" || -f "$WORKTREE/.git" ]]; then
+  :
+elif git -C "$REPO_ROOT" show-ref --verify --quiet "refs/heads/$BRANCH_NAME"; then
+  git -C "$REPO_ROOT" worktree add "$WORKTREE" "$BRANCH_NAME"
+else
+  git -C "$REPO_ROOT" worktree add "$WORKTREE" -b "$BRANCH_NAME" "$BASE_BRANCH"
+fi
+
+cd "$WORKTREE"
+
+if [[ ! -d "$NODE_MODULES" || ( -f "$LOCKFILE" && "$LOCKFILE" -nt "$NODE_MODULES" ) || package.json -nt "$NODE_MODULES" ]]; then
+  npm install
+fi
+
+printf 'BOOTSTRAPPED_WORKTREE=%s\n' "$WORKTREE"
+printf 'BOOTSTRAPPED_BRANCH=%s\n' "$BRANCH_NAME"

--- a/dev/scripts/bootstrap-issue-worktree.sh
+++ b/dev/scripts/bootstrap-issue-worktree.sh
@@ -28,14 +28,32 @@ NODE_MODULES="${WORKTREE}/node_modules"
 
 mkdir -p "$(dirname "$WORKTREE")"
 
-git -C "$REPO_ROOT" fetch origin "$BASE_BRANCH" >/dev/null 2>&1 || true
+REMOTE_BASE_REF="refs/remotes/origin/${BASE_BRANCH}"
+LOCAL_BASE_REF="refs/heads/${BASE_BRANCH}"
+BASE_START_POINT=""
+
+if git -C "$REPO_ROOT" fetch origin "$BASE_BRANCH" >/dev/null 2>&1; then
+  if git -C "$REPO_ROOT" show-ref --verify --quiet "$REMOTE_BASE_REF"; then
+    BASE_START_POINT="origin/${BASE_BRANCH}"
+  fi
+fi
+
+if [[ -z "$BASE_START_POINT" ]] && git -C "$REPO_ROOT" show-ref --verify --quiet "$LOCAL_BASE_REF"; then
+  BASE_START_POINT="$BASE_BRANCH"
+  printf 'bootstrap warning: using local %s because origin/%s is unavailable\n' "$BASE_BRANCH" "$BASE_BRANCH" >&2
+fi
+
+if [[ -z "$BASE_START_POINT" ]]; then
+  printf 'bootstrap error: could not resolve base branch %s from origin or local refs\n' "$BASE_BRANCH" >&2
+  exit 1
+fi
 
 if [[ -d "$WORKTREE/.git" || -f "$WORKTREE/.git" ]]; then
   :
 elif git -C "$REPO_ROOT" show-ref --verify --quiet "refs/heads/$BRANCH_NAME"; then
   git -C "$REPO_ROOT" worktree add "$WORKTREE" "$BRANCH_NAME"
 else
-  git -C "$REPO_ROOT" worktree add "$WORKTREE" -b "$BRANCH_NAME" "$BASE_BRANCH"
+  git -C "$REPO_ROOT" worktree add "$WORKTREE" -b "$BRANCH_NAME" "$BASE_START_POINT"
 fi
 
 cd "$WORKTREE"

--- a/lib/dispatch/message-builder.ts
+++ b/lib/dispatch/message-builder.ts
@@ -3,6 +3,7 @@
  */
 import type { ResolvedRoleConfig } from "../config/index.js";
 import { formatPrContext, formatPrFeedback, type PrContext, type PrFeedback } from "./pr-context.js";
+import { buildBootstrapContractSection } from "./worktree-bootstrap.js";
 import { getFallbackEmoji } from "../roles/index.js";
 
 /**
@@ -84,6 +85,17 @@ export function buildTaskMessage(opts: {
     }
   }
   if (opts.attachmentContext) parts.push(opts.attachmentContext);
+
+  if (role === "developer" || role === "tester") {
+    parts.push(...buildBootstrapContractSection({
+      repo,
+      baseBranch,
+      role,
+      issueId,
+      issueTitle,
+      feedbackBranchName: opts.prFeedback?.branchName,
+    }));
+  }
 
   parts.push(
     ``,

--- a/lib/dispatch/worktree-bootstrap-script.test.ts
+++ b/lib/dispatch/worktree-bootstrap-script.test.ts
@@ -1,0 +1,67 @@
+import assert from "node:assert/strict";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { execFileSync, execSync } from "node:child_process";
+import { afterEach, describe, it } from "node:test";
+
+const SCRIPT = path.resolve("dev/scripts/bootstrap-issue-worktree.sh");
+
+const cleanupPaths: string[] = [];
+
+afterEach(async () => {
+  while (cleanupPaths.length) {
+    const target = cleanupPaths.pop();
+    if (!target) continue;
+    await fs.rm(target, { recursive: true, force: true });
+  }
+});
+
+describe("bootstrap-issue-worktree.sh", () => {
+  it("creates new issue branches from fetched origin/<base-branch>", async () => {
+    const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "devclaw-bootstrap-script-"));
+    cleanupPaths.push(tmp);
+
+    const remote = path.join(tmp, "remote.git");
+    const seed = path.join(tmp, "seed");
+    const repo = path.join(tmp, "repo");
+    await fs.mkdir(remote, { recursive: true });
+
+    execSync(`git init --bare ${JSON.stringify(remote)}`);
+    execSync(`git init ${JSON.stringify(seed)}`);
+    execSync(`git -C ${JSON.stringify(seed)} config user.name 'DevClaw Test'`);
+    execSync(`git -C ${JSON.stringify(seed)} config user.email 'devclaw@example.com'`);
+    await fs.writeFile(path.join(seed, "package.json"), '{"name":"bootstrap-test","version":"1.0.0"}\n');
+    await fs.writeFile(path.join(seed, "package-lock.json"), '{"name":"bootstrap-test","lockfileVersion":3}\n');
+    await fs.mkdir(path.join(seed, "node_modules"), { recursive: true });
+    await fs.writeFile(path.join(seed, "node_modules", ".keep"), "ok\n");
+    execSync(`git -C ${JSON.stringify(seed)} add package.json package-lock.json node_modules/.keep`);
+    execSync(`git -C ${JSON.stringify(seed)} commit -m 'seed base'`);
+    execSync(`git -C ${JSON.stringify(seed)} branch -M main`);
+    execSync(`git -C ${JSON.stringify(seed)} remote add origin ${JSON.stringify(remote)}`);
+    execSync(`git -C ${JSON.stringify(seed)} push origin main`);
+
+    execSync(`git clone ${JSON.stringify(remote)} ${JSON.stringify(repo)}`);
+    execSync(`git -C ${JSON.stringify(repo)} checkout -b main origin/main`);
+
+    const baseHead = execSync(`git -C ${JSON.stringify(repo)} rev-parse HEAD`, { encoding: "utf8" }).trim();
+
+    await fs.writeFile(path.join(seed, "README.md"), 'fresh upstream\n');
+    execSync(`git -C ${JSON.stringify(seed)} add README.md`);
+    execSync(`git -C ${JSON.stringify(seed)} commit -m 'upstream advance'`);
+    execSync(`git -C ${JSON.stringify(seed)} push origin main`);
+    const originHead = execSync(`git -C ${JSON.stringify(seed)} rev-parse HEAD`, { encoding: "utf8" }).trim();
+    assert.notEqual(originHead, baseHead);
+
+    execFileSync(SCRIPT, [repo, "238", "Bootstrap worker issue worktrees", "main"], {
+      cwd: path.resolve("."),
+      encoding: "utf8",
+    });
+
+    const branchHead = execSync(
+      `git -C ${JSON.stringify(repo)} rev-parse refs/heads/issue/238-bootstrap-worker-issue-worktrees`,
+      { encoding: "utf8" },
+    ).trim();
+    assert.equal(branchHead, originHead);
+  });
+});

--- a/lib/dispatch/worktree-bootstrap.test.ts
+++ b/lib/dispatch/worktree-bootstrap.test.ts
@@ -1,0 +1,34 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { buildIssueBranchName, buildWorktreePath, buildBootstrapContractSection } from "./worktree-bootstrap.js";
+
+describe("worktree bootstrap contract", () => {
+  it("builds canonical issue branch names", () => {
+    assert.equal(
+      buildIssueBranchName(238, "Auto-bootstrap worker issue worktrees and separate environment/setup failures"),
+      "issue/238-auto-bootstrap-worker-issue-worktrees-and-separa"
+    );
+  });
+
+  it("builds worktree path from repo and branch", () => {
+    assert.equal(
+      buildWorktreePath("/repo/devclaw", "issue/238-example"),
+      "/repo/devclaw.worktrees/issue/238-example"
+    );
+  });
+
+  it("includes dependency strategy and failure classes", () => {
+    const section = buildBootstrapContractSection({
+      repo: "/repo/devclaw",
+      baseBranch: "devclaw-local-dev",
+      role: "developer",
+      issueId: 238,
+      issueTitle: "Bootstrap worker issue worktrees",
+    }).join("\n");
+
+    assert.match(section, /per-worktree install/);
+    assert.match(section, /npm run build/);
+    assert.match(section, /ambient validation noise/);
+    assert.match(section, /environment\/bootstrap failure/);
+  });
+});

--- a/lib/dispatch/worktree-bootstrap.ts
+++ b/lib/dispatch/worktree-bootstrap.ts
@@ -1,0 +1,73 @@
+/**
+ * worktree-bootstrap.ts — Canonical worker checkout/bootstrap contract text.
+ */
+
+function slugify(input: string): string {
+  return input
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 48) || "task";
+}
+
+export function buildIssueBranchName(issueId: number, issueTitle: string): string {
+  return `issue/${issueId}-${slugify(issueTitle)}`;
+}
+
+export function buildWorktreePath(repo: string, branchName: string): string {
+  return `${repo}.worktrees/${branchName}`;
+}
+
+export function buildBootstrapContractSection(opts: {
+  repo: string;
+  baseBranch: string;
+  role: string;
+  issueId: number;
+  issueTitle: string;
+  feedbackBranchName?: string;
+}): string[] {
+  const branchName = opts.feedbackBranchName || buildIssueBranchName(opts.issueId, opts.issueTitle);
+  const worktreePath = buildWorktreePath(opts.repo, branchName);
+  const bootstrapScript = `${opts.repo}/dev/scripts/bootstrap-issue-worktree.sh`;
+  const isFeedbackCycle = !!opts.feedbackBranchName;
+
+  const lines = [
+    "",
+    "## Worker checkout and bootstrap contract",
+    "",
+    `- Required branch: \`${branchName}\``,
+    `- Required worktree: \`${worktreePath}\``,
+    "- Dependency strategy: per-worktree install. Each worker worktree must provision its own `node_modules` before validation.",
+    "- Bootstrap rule: run the bootstrap script below before validation. It creates or reuses the worktree and runs `npm install` when dependencies are missing or stale.",
+    "",
+    "```bash",
+    `${bootstrapScript} ${JSON.stringify(opts.repo)} ${opts.issueId} ${JSON.stringify(opts.issueTitle)} ${JSON.stringify(opts.baseBranch)}${isFeedbackCycle ? ` ${JSON.stringify(branchName)}` : ""}`,
+    "```",
+    "",
+    "After the script finishes, run validation from the bootstrapped worktree it prints.",
+    "",
+    "### Validation target",
+    "",
+    "- Required developer handoff target: `npm run build` passes in the worker worktree.",
+    "- Best-effort target: run `npm run check` from the same worktree.",
+    "- If `npm run check` fails because of pre-existing repo-wide noise unrelated to this issue, treat that as ambient validation noise, document it clearly, and do not silently convert it into an issue-local blocker.",
+    "",
+    "### Failure classification",
+    "",
+    "- `environment/bootstrap failure`: worktree creation failed, dependencies could not be installed, required local tooling is missing, or the validation environment cannot start.",
+    "- `ambient validation noise`: the repo baseline is already noisy, and the failing evidence is not caused by this issue's changes.",
+    "- `issue-local implementation failure`: the issue's own changes are incorrect, incomplete, or break required validation.",
+    "",
+    "If you must block, say which category applies in the `work_finish` summary so the issue is not misrouted.",
+  ];
+
+  if (opts.role === "tester") {
+    lines.splice(
+      13,
+      0,
+      "- Tester target: validate from a dedicated worker worktree too, not from an ambient repo checkout with unknown dependency state.",
+    );
+  }
+
+  return lines;
+}


### PR DESCRIPTION
## Summary
- add a canonical worker checkout/bootstrap contract section to developer and tester task messages
- add a bootstrap script that creates or reuses issue worktrees and provisions per-worktree dependencies
- document validation targets and failure classes so environment/bootstrap noise is separated from issue-local blockers

## Testing
- npx tsx --test lib/dispatch/worktree-bootstrap.test.ts
- npm run build

Addresses issue #238