### PR TITLE
feat: add shared deployer engine

### DIFF
--- a/defaults/devclaw/workflow.yaml
+++ b/defaults/devclaw/workflow.yaml
@@ -245,3 +245,76 @@ workflow:
       color: "#f39c12"
       on:
         APPROVE: todo
+
+deployment:
+  lanes:
+    build:
+      aliases: [candidate]
+      description: Candidate built from merged work
+      legacyBranch: development
+    staging:
+      aliases: [stage]
+      rollbackTargets: [build]
+      legacyUrl: https://staging.example.com
+    production:
+      aliases: [prod]
+      humanOnly: true
+      protected: true
+      rollbackTargets: [staging]
+      legacyUrl: https://app.example.com
+  commands:
+    deploy-to-build:
+      run: echo "Deploy ${CANDIDATE_REF} to ${TARGET_LANE}"
+    promote-to-staging:
+      run: echo "Promote ${CANDIDATE_REF} from ${SOURCE_LANE} to ${TARGET_LANE}"
+    accept-on-staging:
+      run: echo "Accept ${CANDIDATE_REF} on ${TARGET_LANE}"
+    rollback-from-production:
+      run: echo "Rollback ${TARGET_LANE} to ${SOURCE_LANE} using ${CANDIDATE_REF}"
+  evidenceProfiles:
+    promotion:
+      required: [command, candidate]
+      commentSummary: true
+    acceptance:
+      required: [command, candidate]
+      commentSummary: true
+    rollback:
+      required: [command, candidate]
+      commentSummary: true
+  transitions:
+    - action: deploy
+      to: build
+      command: deploy-to-build
+      evidence: promotion
+    - action: promote
+      from: build
+      to: staging
+      command: promote-to-staging
+      evidence: promotion
+    - action: accept
+      from: staging
+      to: staging
+      command: accept-on-staging
+      evidence: acceptance
+    - action: rollback
+      from: staging
+      to: production
+      command: rollback-from-production
+      evidence: rollback
+  workflow:
+    states:
+      promoting:
+        action: promote
+        sourceLane: build
+        targetLane: staging
+        issueLinkage: workflow
+      accepting:
+        action: accept
+        sourceLane: staging
+        targetLane: staging
+        issueLinkage: workflow
+  candidate:
+    sources: [issueCandidate, issuePr, gitHead]
+  policy:
+    allowDirectWithoutIssue: true
+    requireHumanForProtectedLanes: true

--- a/defaults/devclaw/workflow.yaml
+++ b/defaults/devclaw/workflow.yaml
@@ -270,7 +270,7 @@ deployment:
     accept-on-staging:
       run: echo "Accept ${CANDIDATE_REF} on ${TARGET_LANE}"
     rollback-from-production:
-      run: echo "Rollback ${TARGET_LANE} to ${SOURCE_LANE} using ${CANDIDATE_REF}"
+      run: echo "Rollback ${CANDIDATE_REF} from ${SOURCE_LANE} to ${TARGET_LANE}"
   evidenceProfiles:
     promotion:
       required: [command, candidate]
@@ -297,8 +297,8 @@ deployment:
       command: accept-on-staging
       evidence: acceptance
     - action: rollback
-      from: staging
-      to: production
+      from: production
+      to: staging
       command: rollback-from-production
       evidence: rollback
   workflow:

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -548,6 +548,12 @@ The source path is logged for production traceability: `Bootstrap hook: injected
 
 The Deployer uses a dedicated `deployer.md` prompt surface.
 
+Delivery execution now runs through one shared deployer engine:
+- workflow-backed delivery states call a thin workflow wrapper
+- direct operational deploys call a thin `deploy_run` tool wrapper
+- both paths resolve lanes, transitions, candidate identity, commands, and evidence from `deployment:` config
+- both paths emit the same durable deploy receipt shape
+
 ## Data flow map
 
 Every piece of data and where it lives:

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -129,6 +129,15 @@ DevClaw ships with four built-in roles, defined in `lib/roles/registry.ts`. All 
 
 Roles are extensible — add a new entry to `ROLE_REGISTRY` and corresponding workflow states to get a new role. The `workflow.yaml` config can also override levels, models, and emoji per role, or disable a role entirely (`tester: false`).
 
+## Deployer runtime
+
+Delivery work now flows through one shared deployer engine with two thin entrypoints:
+
+- workflow-backed deployer states such as `Promoting` and `Accepting`
+- the direct `deploy_run` tool for explicit operational deploy commands
+
+The `deployment:` config block is the semantic source of truth for lane aliases, legal transitions, candidate resolution, command selection, rollback policy, and evidence requirements. Both entrypoints emit the same durable receipt shape, and receipts are finalized after optional linked issue comments so on-disk audit data matches the issue-visible outcome.
+
 ## System overview
 
 ```mermaid

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -136,7 +136,7 @@ Delivery work now flows through one shared deployer engine with two thin entrypo
 - workflow-backed deployer states such as `Promoting` and `Accepting`
 - the direct `deploy_run` tool for explicit operational deploy commands
 
-The `deployment:` config block is the semantic source of truth for lane aliases, legal transitions, candidate resolution, command selection, rollback policy, and evidence requirements. Both entrypoints emit the same durable receipt shape, and receipts are finalized after optional linked issue comments so on-disk audit data matches the issue-visible outcome.
+The `deployment:` config block is the semantic source of truth for lane aliases, legal transitions, candidate resolution, command selection, rollback policy, and evidence requirements. Both entrypoints emit the same durable receipt shape, receipts are finalized after optional linked issue comments so on-disk audit data matches the issue-visible outcome, and command templates run with deploy values injected through env rather than shell-string interpolation.
 
 ## System overview
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -107,14 +107,21 @@ deployment:
   lanes:
     build: { aliases: [candidate] }
     staging: { aliases: [stage], rollbackTargets: [build] }
+    production: { aliases: [prod], rollbackTargets: [staging] }
   commands:
     promote-to-staging:
       run: echo "Promote ${CANDIDATE_REF} from ${SOURCE_LANE} to ${TARGET_LANE}"
+    rollback-production-to-staging:
+      run: echo "Rollback ${CANDIDATE_REF} from ${SOURCE_LANE} to ${TARGET_LANE}"
   transitions:
     - action: promote
       from: build
       to: staging
       command: promote-to-staging
+    - action: rollback
+      from: production
+      to: staging
+      command: rollback-production-to-staging
   workflow:
     states:
       promoting:
@@ -123,7 +130,11 @@ deployment:
         targetLane: staging
 ```
 
+For every deploy action, `sourceLane` means the origin lane and `targetLane` means the destination lane. Rollback uses the same directionality, for example `production -> staging`.
+
 Legacy project metadata like `deployBranch` and `deployUrl` still acts as a fallback default, but it is no longer the semantic source of truth.
+
+Receipts are persisted after any linked issue comment is posted, so the durable JSON receipt and issue summary stay aligned.
 
 For the operator-facing contract, see [`../dev/design/deployer-contract.md`](../dev/design/deployer-contract.md).
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -132,6 +132,8 @@ deployment:
 
 For every deploy action, `sourceLane` means the origin lane and `targetLane` means the destination lane. Rollback uses the same directionality, for example `production -> staging`.
 
+Deploy commands are executed as fixed shell programs with dynamic values passed through environment variables like `CANDIDATE_REF`, `SOURCE_LANE`, and `TARGET_LANE`. That keeps configured commands ergonomic while avoiding direct string interpolation of tool input into the shell program text.
+
 Legacy project metadata like `deployBranch` and `deployUrl` still acts as a fallback default, but it is no longer the semantic source of truth.
 
 Receipts are persisted after any linked issue comment is posted, so the durable JSON receipt and issue summary stay aligned.

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -100,6 +100,31 @@ Release-agent configuration should also define:
 - required release evidence or proof receipts
 - retry and override behavior for repeated promotions
 
+The first-class `deployment:` block is the semantic source of truth for lanes, transitions, commands, workflow-state mapping, candidate resolution order, and direct-deploy policy.
+
+```yaml
+deployment:
+  lanes:
+    build: { aliases: [candidate] }
+    staging: { aliases: [stage], rollbackTargets: [build] }
+  commands:
+    promote-to-staging:
+      run: echo "Promote ${CANDIDATE_REF} from ${SOURCE_LANE} to ${TARGET_LANE}"
+  transitions:
+    - action: promote
+      from: build
+      to: staging
+      command: promote-to-staging
+  workflow:
+    states:
+      promoting:
+        action: promote
+        sourceLane: build
+        targetLane: staging
+```
+
+Legacy project metadata like `deployBranch` and `deployUrl` still acts as a fallback default, but it is no longer the semantic source of truth.
+
 For the operator-facing contract, see [`../dev/design/deployer-contract.md`](../dev/design/deployer-contract.md).
 
 ### Timeouts

--- a/docs/TOOLS.md
+++ b/docs/TOOLS.md
@@ -343,12 +343,14 @@ Direct operational deploy entrypoint backed by the shared deployer engine.
 | Parameter | Type | Required | Description |
 |---|---|---|---|
 | `channelId` | string | Yes | Current chat/group ID |
-| `action` | `promote` \| `accept` \| `rollback` | Yes | Deploy action |
-| `targetLane` | string | Yes | Canonical lane or alias |
-| `sourceLane` | string | No | Source lane or alias |
+| `action` | `deploy` \| `promote` \| `accept` \| `rollback` | Yes | Deploy action |
+| `targetLane` | string | Yes | Destination lane or alias |
+| `sourceLane` | string | No | Origin lane or alias |
 | `candidateRef` | string | No | Explicit candidate identity |
 | `issueId` | number | No | Optional issue linkage for comment receipts |
 | `dryRun` | boolean | No | Resolve and receipt without executing the command |
+
+`deploy_run` uses the same shared engine and receipt model as workflow-backed delivery. When issue linkage is enabled, the durable receipt is written only after the linked comment outcome is known.
 
 **What it does atomically:**
 

--- a/docs/TOOLS.md
+++ b/docs/TOOLS.md
@@ -336,6 +336,20 @@ One-time project setup. Creates state labels, scaffolds project directory with o
 | `deployUrl` | string | No | Deployment URL |
 | `roleExecution` | `"parallel"` \| `"sequential"` | No | DEVELOPER/TESTER parallelism. Default: `"parallel"`. |
 
+### `deploy_run`
+
+Direct operational deploy entrypoint backed by the shared deployer engine.
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `channelId` | string | Yes | Current chat/group ID |
+| `action` | `promote` \| `accept` \| `rollback` | Yes | Deploy action |
+| `targetLane` | string | Yes | Canonical lane or alias |
+| `sourceLane` | string | No | Source lane or alias |
+| `candidateRef` | string | No | Explicit candidate identity |
+| `issueId` | number | No | Optional issue linkage for comment receipts |
+| `dryRun` | boolean | No | Resolve and receipt without executing the command |
+
 **What it does atomically:**
 
 1. Validates project not already registered

--- a/index.ts
+++ b/index.ts
@@ -34,6 +34,7 @@ import { createOnboardTool } from "./lib/tools/admin/onboard.js";
 import { createAutoConfigureModelsTool } from "./lib/tools/admin/autoconfigure-models.js";
 import { createWorkflowGuideTool } from "./lib/tools/admin/workflow-guide.js";
 import { createConfigTool } from "./lib/tools/admin/config.js";
+import { createDeployRunTool } from "./lib/tools/deployer/deploy-run.js";
 
 // Infrastructure
 import { registerCli } from "./lib/setup/cli.js";
@@ -128,6 +129,7 @@ const plugin = {
     api.registerTool(createAutoConfigureModelsTool(ctx), { names: ["autoconfigure_models"] });
     api.registerTool(createWorkflowGuideTool(ctx), { names: ["workflow_guide"] });
     api.registerTool(createConfigTool(ctx), { names: ["config"] });
+    api.registerTool(createDeployRunTool(ctx), { names: ["deploy_run"] });
 
     // CLI, services & hooks
     api.registerCli(({ program }: { program: any }) => registerCli(program, ctx), {
@@ -138,7 +140,7 @@ const plugin = {
     registerAttachmentHook(api, ctx);
 
     api.logger.info(
-      `DevClaw plugin registered (24 tools, 1 CLI command group, 1 service, 3 hooks) | build=${formatBuildProvenanceSummary(provenance)} | provenance=${JSON.stringify(provenance)}`,
+      `DevClaw plugin registered (25 tools, 1 CLI command group, 1 service, 3 hooks) | build=${formatBuildProvenanceSummary(provenance)} | provenance=${JSON.stringify(provenance)}`,
     );
   },
 };

--- a/lib/config/loader.ts
+++ b/lib/config/loader.ts
@@ -85,7 +85,7 @@ function buildDefaultConfig(): DevClawConfig {
       completionResults: [...reg.completionResults],
     };
   }
-  return { roles, workflow: DEFAULT_WORKFLOW };
+  return { roles, workflow: DEFAULT_WORKFLOW, deployment: {} };
 }
 
 /**
@@ -209,7 +209,10 @@ function resolve(config: DevClawConfig): ResolvedConfig {
   };
 
   return {
-    roles, workflow, timeouts,
+    roles,
+    workflow,
+    deployment: config.deployment ?? {},
+    timeouts,
     instanceName: config.instance?.name,
   };
 }

--- a/lib/config/merge.test.ts
+++ b/lib/config/merge.test.ts
@@ -1,0 +1,68 @@
+import { describe, it } from "node:test";
+import assert from "node:assert";
+import { mergeConfig } from "./merge.js";
+
+describe("mergeConfig deployment merging", () => {
+  it("deep-merges individual deployment lane objects", () => {
+    const merged = mergeConfig({
+      deployment: {
+        lanes: {
+          production: {
+            aliases: ["prod"],
+            protected: true,
+            rollbackTargets: ["staging"],
+          },
+        },
+      },
+    }, {
+      deployment: {
+        lanes: {
+          production: {
+            humanOnly: true,
+          },
+        },
+      },
+    });
+
+    assert.deepStrictEqual(merged.deployment?.lanes?.production, {
+      aliases: ["prod"],
+      protected: true,
+      rollbackTargets: ["staging"],
+      humanOnly: true,
+    });
+  });
+
+  it("deep-merges deployment workflow state objects", () => {
+    const merged = mergeConfig({
+      deployment: {
+        workflow: {
+          states: {
+            promoting: {
+              action: "promote",
+              sourceLane: "build",
+              targetLane: "staging",
+              issueLinkage: "workflow",
+            },
+          },
+        },
+      },
+    }, {
+      deployment: {
+        workflow: {
+          states: {
+            promoting: {
+              issueLinkage: "comment",
+            } as any,
+          },
+        },
+      },
+    });
+
+    assert.deepStrictEqual(merged.deployment?.workflow?.states?.promoting, {
+      action: "promote",
+      sourceLane: "build",
+      targetLane: "staging",
+      issueLinkage: "comment",
+    });
+  });
+});

--- a/lib/config/merge.ts
+++ b/lib/config/merge.ts
@@ -73,6 +73,38 @@ export function mergeConfig(
     }
   }
 
+  if (base.deployment || overlay.deployment) {
+    merged.deployment = {
+      ...base.deployment,
+      ...overlay.deployment,
+      lanes: base.deployment?.lanes || overlay.deployment?.lanes
+        ? { ...base.deployment?.lanes, ...overlay.deployment?.lanes }
+        : undefined,
+      commands: base.deployment?.commands || overlay.deployment?.commands
+        ? { ...base.deployment?.commands, ...overlay.deployment?.commands }
+        : undefined,
+      evidenceProfiles: base.deployment?.evidenceProfiles || overlay.deployment?.evidenceProfiles
+        ? { ...base.deployment?.evidenceProfiles, ...overlay.deployment?.evidenceProfiles }
+        : undefined,
+      workflow: base.deployment?.workflow || overlay.deployment?.workflow
+        ? {
+            ...base.deployment?.workflow,
+            ...overlay.deployment?.workflow,
+            states: base.deployment?.workflow?.states || overlay.deployment?.workflow?.states
+              ? { ...base.deployment?.workflow?.states, ...overlay.deployment?.workflow?.states }
+              : undefined,
+          }
+        : undefined,
+      candidate: base.deployment?.candidate || overlay.deployment?.candidate
+        ? { ...base.deployment?.candidate, ...overlay.deployment?.candidate }
+        : undefined,
+      policy: base.deployment?.policy || overlay.deployment?.policy
+        ? { ...base.deployment?.policy, ...overlay.deployment?.policy }
+        : undefined,
+      transitions: overlay.deployment?.transitions ?? base.deployment?.transitions,
+    };
+  }
+
   // Merge timeouts
   if (base.timeouts || overlay.timeouts) {
     merged.timeouts = { ...base.timeouts, ...overlay.timeouts };

--- a/lib/config/merge.ts
+++ b/lib/config/merge.ts
@@ -7,7 +7,7 @@
  * - `false` for a role: marks it as disabled
  * - Primitives: override
  */
-import type { DevClawConfig, RoleOverride } from "./types.js";
+import type { DeploymentConfig, DevClawConfig, RoleOverride } from "./types.js";
 
 /**
  * Merge a config overlay on top of a base config.
@@ -74,35 +74,7 @@ export function mergeConfig(
   }
 
   if (base.deployment || overlay.deployment) {
-    merged.deployment = {
-      ...base.deployment,
-      ...overlay.deployment,
-      lanes: base.deployment?.lanes || overlay.deployment?.lanes
-        ? { ...base.deployment?.lanes, ...overlay.deployment?.lanes }
-        : undefined,
-      commands: base.deployment?.commands || overlay.deployment?.commands
-        ? { ...base.deployment?.commands, ...overlay.deployment?.commands }
-        : undefined,
-      evidenceProfiles: base.deployment?.evidenceProfiles || overlay.deployment?.evidenceProfiles
-        ? { ...base.deployment?.evidenceProfiles, ...overlay.deployment?.evidenceProfiles }
-        : undefined,
-      workflow: base.deployment?.workflow || overlay.deployment?.workflow
-        ? {
-            ...base.deployment?.workflow,
-            ...overlay.deployment?.workflow,
-            states: base.deployment?.workflow?.states || overlay.deployment?.workflow?.states
-              ? { ...base.deployment?.workflow?.states, ...overlay.deployment?.workflow?.states }
-              : undefined,
-          }
-        : undefined,
-      candidate: base.deployment?.candidate || overlay.deployment?.candidate
-        ? { ...base.deployment?.candidate, ...overlay.deployment?.candidate }
-        : undefined,
-      policy: base.deployment?.policy || overlay.deployment?.policy
-        ? { ...base.deployment?.policy, ...overlay.deployment?.policy }
-        : undefined,
-      transitions: overlay.deployment?.transitions ?? base.deployment?.transitions,
-    };
+    merged.deployment = mergeDeploymentConfig(base.deployment, overlay.deployment);
   }
 
   // Merge timeouts
@@ -132,4 +104,46 @@ function mergeRoleOverride(
     ...(overlay.levels ? { levels: overlay.levels } : {}),
     ...(overlay.completionResults ? { completionResults: overlay.completionResults } : {}),
   };
+}
+
+function mergeDeploymentConfig(
+  base?: DeploymentConfig,
+  overlay?: DeploymentConfig,
+): DeploymentConfig {
+  return {
+    ...base,
+    ...overlay,
+    lanes: mergeRecordObjects(base?.lanes, overlay?.lanes),
+    commands: mergeRecordObjects(base?.commands, overlay?.commands),
+    evidenceProfiles: mergeRecordObjects(base?.evidenceProfiles, overlay?.evidenceProfiles),
+    workflow: base?.workflow || overlay?.workflow
+      ? {
+          ...base?.workflow,
+          ...overlay?.workflow,
+          states: mergeRecordObjects(base?.workflow?.states, overlay?.workflow?.states),
+        }
+      : undefined,
+    candidate: base?.candidate || overlay?.candidate
+      ? { ...base?.candidate, ...overlay?.candidate }
+      : undefined,
+    policy: base?.policy || overlay?.policy
+      ? { ...base?.policy, ...overlay?.policy }
+      : undefined,
+    transitions: overlay?.transitions ?? base?.transitions,
+  };
+}
+
+function mergeRecordObjects<T extends object>(
+  base?: Record<string, T>,
+  overlay?: Record<string, T>,
+): Record<string, T> | undefined {
+  if (!base && !overlay) return undefined;
+
+  const merged: Record<string, T> = { ...(base ?? {}) };
+  for (const [key, value] of Object.entries(overlay ?? {})) {
+    merged[key] = key in merged
+      ? { ...merged[key], ...value }
+      : value;
+  }
+  return merged;
 }

--- a/lib/config/schema.test.ts
+++ b/lib/config/schema.test.ts
@@ -1,6 +1,6 @@
 import { describe, it } from "node:test";
 import assert from "node:assert";
-import { validateWorkflowIntegrity } from "./schema.js";
+import { validateConfig, validateWorkflowIntegrity } from "./schema.js";
 import { DEFAULT_WORKFLOW } from "../workflow/index.js";
 
 describe("validateWorkflowIntegrity delivery role validation", () => {
@@ -24,5 +24,27 @@ describe("validateWorkflowIntegrity delivery role validation", () => {
 
     assert.ok(errors.includes("workflow.delivery.acceptance.queueState must reference a deployer-owned state"));
     assert.ok(errors.includes("workflow.delivery.acceptance.activeState must reference a deployer-owned state"));
+  });
+});
+
+describe("deployment config validation", () => {
+  it("rejects duplicate lane aliases", () => {
+    assert.throws(() => validateConfig({
+      deployment: {
+        lanes: {
+          one: { aliases: ["prod"] },
+          two: { aliases: ["prod"] },
+        },
+      },
+    }), /alias "prod" is used by both/);
+  });
+
+  it("rejects transition references to missing commands", () => {
+    assert.throws(() => validateConfig({
+      deployment: {
+        lanes: { build: {}, staging: {} },
+        transitions: [{ action: "promote", from: "build", to: "staging", command: "missing" }],
+      },
+    }), /command "missing" does not exist/);
   });
 });

--- a/lib/config/schema.ts
+++ b/lib/config/schema.ts
@@ -78,6 +78,58 @@ const TimeoutConfigSchema = z.object({
   sessionContextBudget: z.number().min(0).max(1).optional(),
 }).optional();
 
+const DeploymentLaneSchema = z.object({
+  aliases: z.array(z.string()).optional(),
+  description: z.string().optional(),
+  humanOnly: z.boolean().optional(),
+  protected: z.boolean().optional(),
+  rollbackTargets: z.array(z.string()).optional(),
+  legacyBranch: z.string().optional(),
+  legacyUrl: z.string().optional(),
+});
+
+const DeploymentCommandSchema = z.object({
+  run: z.string(),
+  cwd: z.string().optional(),
+  timeoutMs: z.number().positive().optional(),
+});
+
+const DeploymentEvidenceProfileSchema = z.object({
+  required: z.array(z.string()).optional(),
+  commentSummary: z.boolean().optional(),
+});
+
+const DeploymentTransitionSchema = z.object({
+  action: z.enum(["deploy", "promote", "accept", "rollback"]),
+  from: z.string().optional(),
+  to: z.string(),
+  command: z.string(),
+  evidence: z.string().optional(),
+  requireCandidate: z.boolean().optional(),
+});
+
+const DeploymentSchema = z.object({
+  lanes: z.record(z.string(), DeploymentLaneSchema).optional(),
+  commands: z.record(z.string(), DeploymentCommandSchema).optional(),
+  evidenceProfiles: z.record(z.string(), DeploymentEvidenceProfileSchema).optional(),
+  transitions: z.array(DeploymentTransitionSchema).optional(),
+  workflow: z.object({
+    states: z.record(z.string(), z.object({
+      action: z.enum(["deploy", "promote", "accept", "rollback"]),
+      targetLane: z.string(),
+      sourceLane: z.string().optional(),
+      issueLinkage: z.enum(["none", "comment", "workflow"]).optional(),
+    })).optional(),
+  }).optional(),
+  candidate: z.object({
+    sources: z.array(z.enum(["explicit", "issueCandidate", "issuePr", "gitHead"])) .optional(),
+  }).optional(),
+  policy: z.object({
+    allowDirectWithoutIssue: z.boolean().optional(),
+    requireHumanForProtectedLanes: z.boolean().optional(),
+  }).optional(),
+}).optional();
+
 const InstanceConfigSchema = z.object({
   name: z.string().optional(),
 }).optional();
@@ -85,6 +137,7 @@ const InstanceConfigSchema = z.object({
 export const DevClawConfigSchema = z.object({
   roles: z.record(z.string(), RoleOverrideSchema).optional(),
   workflow: WorkflowConfigSchema.partial().optional(),
+  deployment: DeploymentSchema,
   timeouts: TimeoutConfigSchema,
   instance: InstanceConfigSchema,
 });
@@ -94,7 +147,51 @@ export const DevClawConfigSchema = z.object({
  * Returns the validated config or throws with a descriptive error.
  */
 export function validateConfig(raw: unknown): void {
-  DevClawConfigSchema.parse(raw);
+  const parsed = DevClawConfigSchema.parse(raw);
+  const deployment = parsed.deployment;
+  if (!deployment) return;
+
+  const laneKeys = new Set(Object.keys(deployment.lanes ?? {}));
+  const aliases = new Map<string, string>();
+  for (const [lane, cfg] of Object.entries(deployment.lanes ?? {})) {
+    for (const alias of [lane, ...(cfg.aliases ?? [])]) {
+      const normalized = alias.trim().toLowerCase();
+      const existing = aliases.get(normalized);
+      if (existing && existing !== lane) {
+        throw new Error(`Invalid deployment config: alias "${alias}" is used by both "${existing}" and "${lane}"`);
+      }
+      aliases.set(normalized, lane);
+    }
+    for (const rollbackTarget of cfg.rollbackTargets ?? []) {
+      if (!laneKeys.has(rollbackTarget)) {
+        throw new Error(`Invalid deployment config: lane "${lane}" rollback target "${rollbackTarget}" does not exist`);
+      }
+    }
+  }
+
+  for (const transition of deployment.transitions ?? []) {
+    if (transition.from && !laneKeys.has(transition.from)) {
+      throw new Error(`Invalid deployment config: transition from lane "${transition.from}" does not exist`);
+    }
+    if (!laneKeys.has(transition.to)) {
+      throw new Error(`Invalid deployment config: transition to lane "${transition.to}" does not exist`);
+    }
+    if (!deployment.commands?.[transition.command]) {
+      throw new Error(`Invalid deployment config: transition command "${transition.command}" does not exist`);
+    }
+    if (transition.evidence && !deployment.evidenceProfiles?.[transition.evidence]) {
+      throw new Error(`Invalid deployment config: transition evidence profile "${transition.evidence}" does not exist`);
+    }
+  }
+
+  for (const [stateKey, stateCfg] of Object.entries(deployment.workflow?.states ?? {})) {
+    if (!laneKeys.has(stateCfg.targetLane)) {
+      throw new Error(`Invalid deployment config: workflow state "${stateKey}" target lane "${stateCfg.targetLane}" does not exist`);
+    }
+    if (stateCfg.sourceLane && !laneKeys.has(stateCfg.sourceLane)) {
+      throw new Error(`Invalid deployment config: workflow state "${stateKey}" source lane "${stateCfg.sourceLane}" does not exist`);
+    }
+  }
 }
 
 /**

--- a/lib/config/types.ts
+++ b/lib/config/types.ts
@@ -6,6 +6,64 @@
  */
 import type { WorkflowConfig } from "../workflow/index.js";
 
+export type DeploymentAction = "deploy" | "promote" | "accept" | "rollback";
+export type CandidateSource = "explicit" | "issueCandidate" | "issuePr" | "gitHead";
+export type IssueLinkageMode = "none" | "comment" | "workflow";
+
+export type DeploymentLaneConfig = {
+  aliases?: string[];
+  description?: string;
+  humanOnly?: boolean;
+  protected?: boolean;
+  rollbackTargets?: string[];
+  legacyBranch?: string;
+  legacyUrl?: string;
+};
+
+export type DeploymentCommandConfig = {
+  run: string;
+  cwd?: string;
+  timeoutMs?: number;
+};
+
+export type DeploymentEvidenceProfile = {
+  required?: string[];
+  commentSummary?: boolean;
+};
+
+export type DeploymentTransitionConfig = {
+  action: DeploymentAction;
+  from?: string;
+  to: string;
+  command: string;
+  evidence?: string;
+  requireCandidate?: boolean;
+};
+
+export type DeploymentWorkflowStateConfig = {
+  action: DeploymentAction;
+  targetLane: string;
+  sourceLane?: string;
+  issueLinkage?: IssueLinkageMode;
+};
+
+export type DeploymentConfig = {
+  lanes?: Record<string, DeploymentLaneConfig>;
+  commands?: Record<string, DeploymentCommandConfig>;
+  evidenceProfiles?: Record<string, DeploymentEvidenceProfile>;
+  transitions?: DeploymentTransitionConfig[];
+  workflow?: {
+    states?: Record<string, DeploymentWorkflowStateConfig>;
+  };
+  candidate?: {
+    sources?: CandidateSource[];
+  };
+  policy?: {
+    allowDirectWithoutIssue?: boolean;
+    requireHumanForProtectedLanes?: boolean;
+  };
+};
+
 /**
  * Role override in workflow.yaml. All fields optional — only override what you need.
  * Set to `false` to disable a role entirely for a project.
@@ -53,6 +111,7 @@ export type InstanceConfig = {
 export type DevClawConfig = {
   roles?: Record<string, RoleOverride | false>;
   workflow?: Partial<WorkflowConfig>;
+  deployment?: DeploymentConfig;
   timeouts?: TimeoutConfig;
   instance?: InstanceConfig;
 };
@@ -79,6 +138,7 @@ export type ResolvedTimeouts = {
 export type ResolvedConfig = {
   roles: Record<string, ResolvedRoleConfig>;
   workflow: WorkflowConfig;
+  deployment: DeploymentConfig;
   timeouts: ResolvedTimeouts;
   /** Instance name override from config. Undefined = use auto-generated from instance.json. */
   instanceName?: string;

--- a/lib/deployer/engine.test.ts
+++ b/lib/deployer/engine.test.ts
@@ -36,7 +36,11 @@ describe("deploy engine", () => {
     const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), "devclaw-deploy-engine-"));
     const provider = new TestProvider();
     provider.seedIssue({ iid: 7, labels: ["Promoting"] });
-    const runCommand = async () => ({ stdout: "ok\n", stderr: "", code: 0, signal: null, killed: false as const });
+    let executedCommand: string[] | undefined;
+    const runCommand = async (argv: string[]) => {
+      executedCommand = argv;
+      return { stdout: "ok\n", stderr: "", code: 0, signal: null, killed: false as const };
+    };
     const project = { name: "demo", deployBranch: "main", deployUrl: "", repo: "/tmp/repo" } as any;
 
     const direct = await runDeployEngine({
@@ -74,5 +78,57 @@ describe("deploy engine", () => {
     assert.equal(direct.receipt.candidate?.ref, "sha123");
     assert.equal(workflow.receipt.issueLinkage, "workflow");
     assert.ok(workflow.receipt.linkedIssueCommentId);
+    assert.ok(direct.receipt.receiptPath);
+    assert.equal(direct.receipt.linkedIssueCommentId, undefined);
+    assert.match(executedCommand?.[2] ?? "", /'sha123'/);
+  });
+
+  it("persists linked issue comment ids into the durable receipt", async () => {
+    const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), "devclaw-deploy-receipt-"));
+    const provider = new TestProvider();
+    provider.seedIssue({ iid: 9, labels: ["Promoting"] });
+    const project = { name: "demo", deployBranch: "main", deployUrl: "", repo: "/tmp/repo" } as any;
+
+    const result = await runWorkflowDeployment({
+      workspaceDir,
+      project,
+      repoPath: "/tmp/repo",
+      provider,
+      issueId: 9,
+      currentStateKey: "promoting",
+      config: deployment,
+      runCommand: (async () => ({ stdout: "ok\n", stderr: "", code: 0, signal: null, killed: false as const })) as any,
+    });
+
+    const persisted = JSON.parse(await fs.readFile(result.receipt.receiptPath!, "utf-8"));
+    assert.equal(persisted.linkedIssueCommentId, result.receipt.linkedIssueCommentId);
+    assert.ok(persisted.linkedIssueCommentId);
+  });
+
+  it("shell-escapes interpolated candidate values before execution", async () => {
+    const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), "devclaw-deploy-escape-"));
+    let executed: string[] | undefined;
+    const project = { name: "demo", deployBranch: "main", deployUrl: "", repo: "/tmp/repo" } as any;
+
+    await runDeployEngine({
+      workspaceDir,
+      project,
+      repoPath: "/tmp/repo",
+      config: deployment,
+      runCommand: (async (argv: string[]) => {
+        executed = argv;
+        return { stdout: "ok\n", stderr: "", code: 0, signal: null, killed: false as const };
+      }) as any,
+      request: {
+        action: "promote",
+        sourceLane: "build",
+        targetLane: "staging",
+        candidateRef: "bad'; touch /tmp/pwned; echo '",
+        invocation: { kind: "direct" },
+      },
+    });
+
+    assert.ok(executed);
+    assert.match(executed?.[2] ?? "", /'bad'"'"'; touch \/tmp\/pwned; echo '"'"''/);
   });
 });

--- a/lib/deployer/engine.test.ts
+++ b/lib/deployer/engine.test.ts
@@ -37,8 +37,10 @@ describe("deploy engine", () => {
     const provider = new TestProvider();
     provider.seedIssue({ iid: 7, labels: ["Promoting"] });
     let executedCommand: string[] | undefined;
-    const runCommand = async (argv: string[]) => {
+    let executedEnv: Record<string, string> | undefined;
+    const runCommand = async (argv: string[], opts?: { env?: Record<string, string> }) => {
       executedCommand = argv;
+      executedEnv = opts?.env;
       return { stdout: "ok\n", stderr: "", code: 0, signal: null, killed: false as const };
     };
     const project = { name: "demo", deployBranch: "main", deployUrl: "", repo: "/tmp/repo" } as any;
@@ -80,7 +82,8 @@ describe("deploy engine", () => {
     assert.ok(workflow.receipt.linkedIssueCommentId);
     assert.ok(direct.receipt.receiptPath);
     assert.equal(direct.receipt.linkedIssueCommentId, undefined);
-    assert.match(executedCommand?.[2] ?? "", /'sha123'/);
+    assert.equal(executedCommand?.[2], 'echo "promote ${CANDIDATE_REF} ${SOURCE_LANE} ${TARGET_LANE}"');
+    assert.equal(executedEnv?.CANDIDATE_REF, "sha123");
   });
 
   it("persists linked issue comment ids into the durable receipt", async () => {
@@ -105,9 +108,10 @@ describe("deploy engine", () => {
     assert.ok(persisted.linkedIssueCommentId);
   });
 
-  it("shell-escapes interpolated candidate values before execution", async () => {
+  it("passes dynamic deploy values via env instead of interpolating them into the shell program", async () => {
     const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), "devclaw-deploy-escape-"));
     let executed: string[] | undefined;
+    let executedEnv: Record<string, string> | undefined;
     const project = { name: "demo", deployBranch: "main", deployUrl: "", repo: "/tmp/repo" } as any;
 
     await runDeployEngine({
@@ -115,8 +119,9 @@ describe("deploy engine", () => {
       project,
       repoPath: "/tmp/repo",
       config: deployment,
-      runCommand: (async (argv: string[]) => {
+      runCommand: (async (argv: string[], opts?: { env?: Record<string, string> }) => {
         executed = argv;
+        executedEnv = opts?.env;
         return { stdout: "ok\n", stderr: "", code: 0, signal: null, killed: false as const };
       }) as any,
       request: {
@@ -129,6 +134,7 @@ describe("deploy engine", () => {
     });
 
     assert.ok(executed);
-    assert.match(executed?.[2] ?? "", /'bad'"'"'; touch \/tmp\/pwned; echo '"'"''/);
+    assert.equal(executed?.[2], 'echo "promote ${CANDIDATE_REF} ${SOURCE_LANE} ${TARGET_LANE}"');
+    assert.equal(executedEnv?.CANDIDATE_REF, "bad'; touch /tmp/pwned; echo '");
   });
 });

--- a/lib/deployer/engine.test.ts
+++ b/lib/deployer/engine.test.ts
@@ -1,0 +1,78 @@
+import { describe, it } from "node:test";
+import assert from "node:assert";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { runDeployEngine } from "./engine.js";
+import { runWorkflowDeployment } from "./workflow.js";
+import { TestProvider } from "../testing/test-provider.js";
+import type { DeploymentConfig } from "../config/types.js";
+
+const deployment: DeploymentConfig = {
+  lanes: {
+    build: { aliases: ["candidate"] },
+    staging: { aliases: ["stage"], rollbackTargets: ["build"] },
+  },
+  commands: {
+    promote: { run: 'echo "promote ${CANDIDATE_REF} ${SOURCE_LANE} ${TARGET_LANE}"' },
+  },
+  evidenceProfiles: {
+    proof: { required: ["command", "candidate"], commentSummary: true },
+  },
+  transitions: [
+    { action: "promote", from: "build", to: "staging", command: "promote", evidence: "proof" },
+  ],
+  workflow: {
+    states: {
+      promoting: { action: "promote", sourceLane: "build", targetLane: "staging", issueLinkage: "workflow" },
+    },
+  },
+  candidate: { sources: ["explicit"] },
+  policy: { allowDirectWithoutIssue: true },
+};
+
+describe("deploy engine", () => {
+  it("returns normalized receipt fields for direct and workflow runs", async () => {
+    const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), "devclaw-deploy-engine-"));
+    const provider = new TestProvider();
+    provider.seedIssue({ iid: 7, labels: ["Promoting"] });
+    const runCommand = async () => ({ stdout: "ok\n", stderr: "", code: 0, signal: null, killed: false as const });
+    const project = { name: "demo", deployBranch: "main", deployUrl: "", repo: "/tmp/repo" } as any;
+
+    const direct = await runDeployEngine({
+      workspaceDir,
+      project,
+      repoPath: "/tmp/repo",
+      config: deployment,
+      provider,
+      runCommand: runCommand as any,
+      request: {
+        action: "promote",
+        sourceLane: "build",
+        targetLane: "staging",
+        candidateRef: "sha123",
+        issueId: 7,
+        issueLinkage: "comment",
+        invocation: { kind: "direct" },
+      },
+    });
+
+    const workflow = await runWorkflowDeployment({
+      workspaceDir,
+      project,
+      repoPath: "/tmp/repo",
+      provider,
+      issueId: 7,
+      currentStateKey: "promoting",
+      config: deployment,
+      runCommand: runCommand as any,
+    });
+
+    assert.equal(direct.receipt.action, workflow.receipt.action);
+    assert.equal(direct.receipt.targetLane, workflow.receipt.targetLane);
+    assert.equal(direct.receipt.transitionKey, workflow.receipt.transitionKey);
+    assert.equal(direct.receipt.candidate?.ref, "sha123");
+    assert.equal(workflow.receipt.issueLinkage, "workflow");
+    assert.ok(workflow.receipt.linkedIssueCommentId);
+  });
+});

--- a/lib/deployer/engine.ts
+++ b/lib/deployer/engine.ts
@@ -1,0 +1,82 @@
+import type { Project } from "../projects/index.js";
+import type { RunCommand } from "../context.js";
+import type { DeploymentConfig } from "../config/types.js";
+import type { IssueProvider } from "../providers/provider.js";
+import { writeDeployReceipt } from "./receipt.js";
+import { resolveDeployDecision } from "./resolve.js";
+import type { DeployEngineResult, DeployReceipt, DeployRequest } from "./types.js";
+
+function interpolate(template: string, vars: Record<string, string>): string {
+  return template.replace(/\$\{([A-Z_]+)\}/g, (_m, key) => vars[key] ?? "");
+}
+
+export async function runDeployEngine(opts: {
+  workspaceDir: string;
+  project: Project;
+  repoPath: string;
+  config: DeploymentConfig;
+  request: DeployRequest;
+  runCommand: RunCommand;
+  provider?: IssueProvider;
+}): Promise<DeployEngineResult> {
+  const decision = await resolveDeployDecision({
+    request: opts.request,
+    config: opts.config,
+    project: opts.project,
+    provider: opts.provider,
+    repoPath: opts.repoPath,
+    runCommand: opts.runCommand,
+  });
+
+  const vars = {
+    ACTION: decision.action,
+    SOURCE_LANE: decision.sourceLane ?? "",
+    TARGET_LANE: decision.targetLane,
+    CANDIDATE_REF: decision.candidate?.ref ?? "",
+    ISSUE_ID: String(opts.request.issueId ?? ""),
+    PROJECT: opts.project.name,
+  };
+
+  const command = interpolate(decision.command, vars);
+  let stdout = "";
+  let stderr = "";
+  let exitCode = 0;
+
+  if (!opts.request.dryRun) {
+    const result = await opts.runCommand(["bash", "-lc", command], {
+      cwd: decision.cwd ?? opts.repoPath,
+      timeoutMs: decision.timeoutMs,
+    });
+    stdout = result.stdout ?? "";
+    stderr = result.stderr ?? "";
+    exitCode = result.code ?? 0;
+  }
+
+  const receipt: DeployReceipt = {
+    id: `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`,
+    timestamp: new Date().toISOString(),
+    project: opts.project.name,
+    issueId: opts.request.issueId,
+    invocation: opts.request.invocation,
+    action: decision.action,
+    issueLinkage: decision.issueLinkage,
+    sourceLane: decision.sourceLane,
+    targetLane: decision.targetLane,
+    transitionKey: decision.transitionKey,
+    candidate: decision.candidate,
+    commandId: decision.commandId,
+    command,
+    cwd: decision.cwd ?? opts.repoPath,
+    dryRun: !!opts.request.dryRun,
+    exitCode,
+    stdout,
+    stderr,
+    success: exitCode === 0,
+    evidenceProfile: decision.evidenceProfile,
+    evidence: opts.config.evidenceProfiles?.[decision.evidenceProfile ?? ""]?.required ?? [],
+    configSnapshot: { policy: opts.config.policy },
+  };
+
+  receipt.receiptPath = await writeDeployReceipt(opts.workspaceDir, opts.project.name, receipt);
+  return { decision, receipt };
+}

--- a/lib/deployer/engine.ts
+++ b/lib/deployer/engine.ts
@@ -4,10 +4,14 @@ import type { DeploymentConfig } from "../config/types.js";
 import type { IssueProvider } from "../providers/provider.js";
 import { writeDeployReceipt } from "./receipt.js";
 import { resolveDeployDecision } from "./resolve.js";
-import type { DeployEngineResult, DeployReceipt, DeployRequest } from "./types.js";
+import type { DeployEngineResult, DeployReceipt, DeployReceiptFinalizer, DeployRequest } from "./types.js";
+
+function shellEscape(value: string): string {
+  return `'${value.replace(/'/g, `'"'"'`)}'`;
+}
 
 function interpolate(template: string, vars: Record<string, string>): string {
-  return template.replace(/\$\{([A-Z_]+)\}/g, (_m, key) => vars[key] ?? "");
+  return template.replace(/\$\{([A-Z_]+)\}/g, (_m, key) => shellEscape(vars[key] ?? ""));
 }
 
 export async function runDeployEngine(opts: {
@@ -18,6 +22,7 @@ export async function runDeployEngine(opts: {
   request: DeployRequest;
   runCommand: RunCommand;
   provider?: IssueProvider;
+  finalizeReceipt?: DeployReceiptFinalizer;
 }): Promise<DeployEngineResult> {
   const decision = await resolveDeployDecision({
     request: opts.request,
@@ -76,6 +81,10 @@ export async function runDeployEngine(opts: {
     evidence: opts.config.evidenceProfiles?.[decision.evidenceProfile ?? ""]?.required ?? [],
     configSnapshot: { policy: opts.config.policy },
   };
+
+  if (opts.finalizeReceipt) {
+    await opts.finalizeReceipt(receipt);
+  }
 
   receipt.receiptPath = await writeDeployReceipt(opts.workspaceDir, opts.project.name, receipt);
   return { decision, receipt };

--- a/lib/deployer/engine.ts
+++ b/lib/deployer/engine.ts
@@ -6,12 +6,8 @@ import { writeDeployReceipt } from "./receipt.js";
 import { resolveDeployDecision } from "./resolve.js";
 import type { DeployEngineResult, DeployReceipt, DeployReceiptFinalizer, DeployRequest } from "./types.js";
 
-function shellEscape(value: string): string {
-  return `'${value.replace(/'/g, `'"'"'`)}'`;
-}
-
-function interpolate(template: string, vars: Record<string, string>): string {
-  return template.replace(/\$\{([A-Z_]+)\}/g, (_m, key) => shellEscape(vars[key] ?? ""));
+function buildDeployEnv(vars: Record<string, string>): NodeJS.ProcessEnv {
+  return Object.fromEntries(Object.entries(vars).map(([key, value]) => [key, value]));
 }
 
 export async function runDeployEngine(opts: {
@@ -42,7 +38,8 @@ export async function runDeployEngine(opts: {
     PROJECT: opts.project.name,
   };
 
-  const command = interpolate(decision.command, vars);
+  const command = decision.command;
+  const commandEnv = buildDeployEnv(vars);
   let stdout = "";
   let stderr = "";
   let exitCode = 0;
@@ -51,6 +48,7 @@ export async function runDeployEngine(opts: {
     const result = await opts.runCommand(["bash", "-lc", command], {
       cwd: decision.cwd ?? opts.repoPath,
       timeoutMs: decision.timeoutMs,
+      env: commandEnv,
     });
     stdout = result.stdout ?? "";
     stderr = result.stderr ?? "";

--- a/lib/deployer/receipt.test.ts
+++ b/lib/deployer/receipt.test.ts
@@ -1,0 +1,34 @@
+import { describe, it } from "node:test";
+import assert from "node:assert";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { writeDeployReceipt } from "./receipt.js";
+
+describe("deploy receipts", () => {
+  it("writes a durable receipt file", async () => {
+    const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), "devclaw-deploy-"));
+    const receiptPath = await writeDeployReceipt(workspaceDir, "demo", {
+      id: "r1",
+      timestamp: new Date().toISOString(),
+      project: "demo",
+      invocation: { kind: "direct" },
+      action: "promote",
+      issueLinkage: "none",
+      sourceLane: "build",
+      targetLane: "staging",
+      transitionKey: "promote:build->staging",
+      candidate: { ref: "abc", source: "explicit" },
+      commandId: "cmd",
+      command: "echo ok",
+      dryRun: true,
+      exitCode: 0,
+      stdout: "",
+      stderr: "",
+      success: true,
+      evidence: ["command"],
+    });
+    const content = await fs.readFile(receiptPath, "utf-8");
+    assert.match(content, /"transitionKey": "promote:build->staging"/);
+  });
+});

--- a/lib/deployer/receipt.ts
+++ b/lib/deployer/receipt.ts
@@ -1,0 +1,42 @@
+import { mkdir, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { DATA_DIR } from "../setup/migrate-layout.js";
+import { log as auditLog } from "../audit.js";
+import type { DeployReceipt } from "./types.js";
+
+export async function writeDeployReceipt(workspaceDir: string, projectName: string, receipt: DeployReceipt): Promise<string> {
+  const dir = join(workspaceDir, DATA_DIR, "deploy", projectName);
+  await mkdir(dir, { recursive: true });
+  const filePath = join(dir, `${receipt.timestamp.replace(/[:.]/g, "-")}-${receipt.id}.json`);
+  await writeFile(filePath, JSON.stringify(receipt, null, 2) + "\n", "utf-8");
+  await auditLog(workspaceDir, "deploy_receipt", {
+    project: projectName,
+    issueId: receipt.issueId ?? null,
+    receiptId: receipt.id,
+    action: receipt.action,
+    targetLane: receipt.targetLane,
+    sourceLane: receipt.sourceLane,
+    success: receipt.success,
+    receiptPath: filePath,
+    invocation: receipt.invocation.kind,
+  });
+  return filePath;
+}
+
+export function renderDeployReceiptSummary(receipt: DeployReceipt): string {
+  const lines = [
+    "## DevClaw Deploy Receipt",
+    "",
+    `- receipt: ${receipt.id}`,
+    `- action: ${receipt.action}`,
+    `- transition: ${receipt.sourceLane ?? "*"} -> ${receipt.targetLane}`,
+    `- candidate: ${receipt.candidate?.ref ?? "none"}`,
+    `- invocation: ${receipt.invocation.kind}`,
+    `- linkage: ${receipt.issueLinkage}`,
+    `- result: ${receipt.success ? "success" : "failed"}`,
+  ];
+  if (receipt.receiptPath) lines.push(`- receiptPath: ${receipt.receiptPath}`);
+  if (receipt.stdout.trim()) lines.push(`- stdout: \`${receipt.stdout.trim().slice(0, 200)}\``);
+  if (receipt.stderr.trim()) lines.push(`- stderr: \`${receipt.stderr.trim().slice(0, 200)}\``);
+  return lines.join("\n");
+}

--- a/lib/deployer/receipt.ts
+++ b/lib/deployer/receipt.ts
@@ -4,10 +4,14 @@ import { DATA_DIR } from "../setup/migrate-layout.js";
 import { log as auditLog } from "../audit.js";
 import type { DeployReceipt } from "./types.js";
 
+function getDeployReceiptPath(workspaceDir: string, projectName: string, receipt: DeployReceipt): string {
+  return join(workspaceDir, DATA_DIR, "deploy", projectName, `${receipt.timestamp.replace(/[:.]/g, "-")}-${receipt.id}.json`);
+}
+
 export async function writeDeployReceipt(workspaceDir: string, projectName: string, receipt: DeployReceipt): Promise<string> {
   const dir = join(workspaceDir, DATA_DIR, "deploy", projectName);
   await mkdir(dir, { recursive: true });
-  const filePath = join(dir, `${receipt.timestamp.replace(/[:.]/g, "-")}-${receipt.id}.json`);
+  const filePath = getDeployReceiptPath(workspaceDir, projectName, receipt);
   await writeFile(filePath, JSON.stringify(receipt, null, 2) + "\n", "utf-8");
   await auditLog(workspaceDir, "deploy_receipt", {
     project: projectName,
@@ -19,7 +23,14 @@ export async function writeDeployReceipt(workspaceDir: string, projectName: stri
     success: receipt.success,
     receiptPath: filePath,
     invocation: receipt.invocation.kind,
+    linkedIssueCommentId: receipt.linkedIssueCommentId ?? null,
   });
+  return filePath;
+}
+
+export async function updateDeployReceipt(workspaceDir: string, projectName: string, receipt: DeployReceipt): Promise<string> {
+  const filePath = receipt.receiptPath ?? getDeployReceiptPath(workspaceDir, projectName, receipt);
+  await writeFile(filePath, JSON.stringify(receipt, null, 2) + "\n", "utf-8");
   return filePath;
 }
 

--- a/lib/deployer/resolve.test.ts
+++ b/lib/deployer/resolve.test.ts
@@ -19,9 +19,10 @@ describe("deployer resolve helpers", () => {
     assert.equal(resolveLaneAlias(config, "missing"), null);
   });
 
-  it("validates rollback legality", () => {
-    assert.doesNotThrow(() => validateRollbackLegality(config, "build", "staging"));
-    assert.throws(() => validateRollbackLegality(config, "build", "production"), /not allowed/);
+  it("validates rollback legality with source as the rolled back lane and target as the destination lane", () => {
+    assert.doesNotThrow(() => validateRollbackLegality(config, "staging", "build"));
+    assert.throws(() => validateRollbackLegality(config, "production", "build"), /not allowed/);
+    assert.throws(() => validateRollbackLegality(config, null, "build"), /requires sourceLane/);
   });
 
   it("backfills legacy deployment defaults", () => {

--- a/lib/deployer/resolve.test.ts
+++ b/lib/deployer/resolve.test.ts
@@ -1,0 +1,34 @@
+import { describe, it } from "node:test";
+import assert from "node:assert";
+import { resolveLaneAlias, validateRollbackLegality, withLegacyDeploymentDefaults } from "./resolve.js";
+
+const config = {
+  lanes: {
+    build: { aliases: ["candidate"] },
+    staging: { aliases: ["stage"], rollbackTargets: ["build"] },
+    production: { aliases: ["prod"], rollbackTargets: ["staging"] },
+  },
+  commands: {},
+  transitions: [],
+};
+
+describe("deployer resolve helpers", () => {
+  it("resolves lane aliases", () => {
+    assert.equal(resolveLaneAlias(config, "stage"), "staging");
+    assert.equal(resolveLaneAlias(config, "production"), "production");
+    assert.equal(resolveLaneAlias(config, "missing"), null);
+  });
+
+  it("validates rollback legality", () => {
+    assert.doesNotThrow(() => validateRollbackLegality(config, "build", "staging"));
+    assert.throws(() => validateRollbackLegality(config, "build", "production"), /not allowed/);
+  });
+
+  it("backfills legacy deployment defaults", () => {
+    const legacy = withLegacyDeploymentDefaults({}, { name: "p", deployBranch: "main", deployUrl: "https://example.com" } as any);
+    assert.ok(legacy.transitions?.some((transition) => transition.action === "deploy"));
+    assert.ok(legacy.commands?.legacyDeploy);
+    assert.ok(legacy.commands?.legacyPromote);
+    assert.ok(legacy.lanes?.default);
+  });
+});

--- a/lib/deployer/resolve.ts
+++ b/lib/deployer/resolve.ts
@@ -1,0 +1,164 @@
+import type { Project } from "../projects/index.js";
+import type { RunCommand } from "../context.js";
+import type { DeploymentConfig, DeploymentAction } from "../config/types.js";
+import type { IssueProvider } from "../providers/provider.js";
+import { getCurrentCandidate } from "../workflow/index.js";
+import type { DeployCandidate, DeployDecision, DeployRequest } from "./types.js";
+
+export function withLegacyDeploymentDefaults(config: DeploymentConfig, project: Project): DeploymentConfig {
+  if ((config.transitions?.length ?? 0) > 0) return config;
+  return {
+    ...config,
+    lanes: {
+      default: {
+        aliases: ["legacy", project.deployBranch || "deploy"],
+        legacyBranch: project.deployBranch || undefined,
+        legacyUrl: project.deployUrl || undefined,
+      },
+      ...(config.lanes ?? {}),
+    },
+    commands: {
+      legacyDeploy: { run: `echo \"Legacy deploy ${"${CANDIDATE_REF}"} to ${"${TARGET_LANE}"} (${project.deployBranch || "unknown-branch"}) ${project.deployUrl || ""}\"` },
+      legacyPromote: { run: `echo \"Legacy promote ${"${CANDIDATE_REF}"} to ${"${TARGET_LANE}"} (${project.deployBranch || "unknown-branch"}) ${project.deployUrl || ""}\"` },
+      legacyAccept: { run: `echo \"Legacy accept ${"${CANDIDATE_REF}"} on ${"${TARGET_LANE}"}\"` },
+      legacyRollback: { run: `echo \"Legacy rollback ${"${CANDIDATE_REF}"} to ${"${TARGET_LANE}"}\"` },
+      ...(config.commands ?? {}),
+    },
+    evidenceProfiles: {
+      legacy: { required: ["command", "candidate"], commentSummary: true },
+      ...(config.evidenceProfiles ?? {}),
+    },
+    transitions: [
+      { action: "deploy", to: "default", command: "legacyDeploy", evidence: "legacy" },
+      { action: "promote", to: "default", command: "legacyPromote", evidence: "legacy" },
+      { action: "accept", to: "default", command: "legacyAccept", evidence: "legacy" },
+      { action: "rollback", to: "default", command: "legacyRollback", evidence: "legacy" },
+      ...(config.transitions ?? []),
+    ],
+  };
+}
+
+export function resolveLaneAlias(config: DeploymentConfig, laneOrAlias: string | undefined): string | null {
+  if (!laneOrAlias) return null;
+  const normalized = laneOrAlias.trim().toLowerCase();
+  for (const [lane, cfg] of Object.entries(config.lanes ?? {})) {
+    if (lane.toLowerCase() === normalized) return lane;
+    if ((cfg.aliases ?? []).some(alias => alias.trim().toLowerCase() === normalized)) return lane;
+  }
+  return null;
+}
+
+export function selectTransition(config: DeploymentConfig, action: DeploymentAction, sourceLane: string | null, targetLane: string) {
+  const match = (config.transitions ?? []).find((transition) => transition.action === action && transition.to === targetLane && (transition.from == null || transition.from === sourceLane));
+  if (!match) throw new Error(`No deployment transition configured for ${action} ${sourceLane ?? "*"} -> ${targetLane}`);
+  return match;
+}
+
+export function validateRollbackLegality(config: DeploymentConfig, sourceLane: string | null, targetLane: string): void {
+  if (!sourceLane) return;
+  const allowed = config.lanes?.[targetLane]?.rollbackTargets ?? [];
+  if (allowed.length > 0 && !allowed.includes(sourceLane)) {
+    throw new Error(`Rollback from ${targetLane} to ${sourceLane} is not allowed by deployment config`);
+  }
+}
+
+export function getEvidenceProfile(config: DeploymentConfig, profileName?: string): string[] {
+  return config.evidenceProfiles?.[profileName ?? ""]?.required ?? [];
+}
+
+export async function normalizeCandidate(opts: {
+  request: DeployRequest;
+  config: DeploymentConfig;
+  provider?: IssueProvider;
+  repoPath: string;
+  runCommand: RunCommand;
+}): Promise<DeployCandidate | null> {
+  const { request, config, provider, repoPath, runCommand } = opts;
+  const sources = config.candidate?.sources ?? ["explicit", "issueCandidate", "issuePr", "gitHead"];
+
+  for (const source of sources) {
+    if (source === "explicit" && request.candidateRef) {
+      return { ref: request.candidateRef, source: "explicit" };
+    }
+    if (source === "issueCandidate" && provider && request.issueId) {
+      const current = await getCurrentCandidate(provider, request.issueId);
+      if (current?.candidateId || current?.commitSha) {
+        return {
+          ref: current.candidateId ?? current.commitSha ?? "unknown-candidate",
+          source: "issueCandidate",
+          commitSha: current.commitSha,
+          prUrl: current.prUrl,
+        };
+      }
+    }
+    if (source === "issuePr" && provider && request.issueId) {
+      const pr = await provider.getPrStatus(request.issueId).catch(() => null);
+      if (pr?.url) {
+        return { ref: pr.sourceBranch ?? pr.url, source: "issuePr", prUrl: pr.url };
+      }
+    }
+    if (source === "gitHead") {
+      const head = await runCommand(["git", "rev-parse", "HEAD"], { cwd: repoPath, timeoutMs: 10_000 }).catch(() => null);
+      const sha = head?.stdout?.trim();
+      if (sha) return { ref: sha, source: "gitHead", commitSha: sha };
+    }
+  }
+
+  return null;
+}
+
+export async function resolveDeployDecision(opts: {
+  request: DeployRequest;
+  config: DeploymentConfig;
+  project: Project;
+  provider?: IssueProvider;
+  repoPath: string;
+  runCommand: RunCommand;
+}): Promise<DeployDecision> {
+  const config = withLegacyDeploymentDefaults(opts.config, opts.project);
+  const targetLane = resolveLaneAlias(config, opts.request.targetLane);
+  if (!targetLane) throw new Error(`Unknown deployment lane: ${opts.request.targetLane}`);
+  const sourceLane = resolveLaneAlias(config, opts.request.sourceLane) ?? null;
+
+  if (opts.request.action === "rollback") validateRollbackLegality(config, sourceLane, targetLane);
+
+  const laneCfg = config.lanes?.[targetLane];
+  if (laneCfg?.humanOnly || (laneCfg?.protected && config.policy?.requireHumanForProtectedLanes)) {
+    if (opts.request.invocation.kind === "direct") {
+      throw new Error(`Lane ${targetLane} is human-only for direct deploys`);
+    }
+  }
+
+  if (opts.request.invocation.kind === "direct" && !opts.request.issueId && config.policy?.allowDirectWithoutIssue === false) {
+    throw new Error("Direct deployment without an issue is disabled by policy");
+  }
+
+  const transition = selectTransition(config, opts.request.action, sourceLane, targetLane);
+  const commandCfg = config.commands?.[transition.command];
+  if (!commandCfg) throw new Error(`Deployment command ${transition.command} is not configured`);
+
+  const candidate = await normalizeCandidate({
+    request: opts.request,
+    config,
+    provider: opts.provider,
+    repoPath: opts.repoPath,
+    runCommand: opts.runCommand,
+  });
+  if ((transition.requireCandidate ?? true) && !candidate) {
+    throw new Error("Deployment candidate identity is required but could not be resolved");
+  }
+
+  return {
+    action: opts.request.action,
+    sourceLane,
+    targetLane,
+    transitionKey: `${opts.request.action}:${sourceLane ?? "*"}->${targetLane}`,
+    commandId: transition.command,
+    command: commandCfg.run,
+    cwd: commandCfg.cwd,
+    timeoutMs: commandCfg.timeoutMs ?? 600_000,
+    evidenceProfile: transition.evidence,
+    candidate,
+    issueLinkage: opts.request.issueLinkage ?? (opts.request.invocation.kind === "workflow" ? "workflow" : opts.request.issueId ? "comment" : "none"),
+  };
+}

--- a/lib/deployer/resolve.ts
+++ b/lib/deployer/resolve.ts
@@ -55,10 +55,12 @@ export function selectTransition(config: DeploymentConfig, action: DeploymentAct
 }
 
 export function validateRollbackLegality(config: DeploymentConfig, sourceLane: string | null, targetLane: string): void {
-  if (!sourceLane) return;
-  const allowed = config.lanes?.[targetLane]?.rollbackTargets ?? [];
-  if (allowed.length > 0 && !allowed.includes(sourceLane)) {
-    throw new Error(`Rollback from ${targetLane} to ${sourceLane} is not allowed by deployment config`);
+  if (!sourceLane) {
+    throw new Error("Rollback requires sourceLane to identify the lane being rolled back from");
+  }
+  const allowed = config.lanes?.[sourceLane]?.rollbackTargets ?? [];
+  if (allowed.length > 0 && !allowed.includes(targetLane)) {
+    throw new Error(`Rollback from ${sourceLane} to ${targetLane} is not allowed by deployment config`);
   }
 }
 
@@ -122,10 +124,11 @@ export async function resolveDeployDecision(opts: {
 
   if (opts.request.action === "rollback") validateRollbackLegality(config, sourceLane, targetLane);
 
-  const laneCfg = config.lanes?.[targetLane];
+  const policyLane = opts.request.action === "rollback" ? sourceLane ?? targetLane : targetLane;
+  const laneCfg = policyLane ? config.lanes?.[policyLane] : undefined;
   if (laneCfg?.humanOnly || (laneCfg?.protected && config.policy?.requireHumanForProtectedLanes)) {
     if (opts.request.invocation.kind === "direct") {
-      throw new Error(`Lane ${targetLane} is human-only for direct deploys`);
+      throw new Error(`Lane ${policyLane} is human-only for direct deploys`);
     }
   }
 

--- a/lib/deployer/types.ts
+++ b/lib/deployer/types.ts
@@ -64,6 +64,8 @@ export type DeployReceipt = {
   configSnapshot?: Pick<DeploymentConfig, "policy">;
 };
 
+export type DeployReceiptFinalizer = (receipt: DeployReceipt) => Promise<void>;
+
 export type DeployEngineResult = {
   decision: DeployDecision;
   receipt: DeployReceipt;

--- a/lib/deployer/types.ts
+++ b/lib/deployer/types.ts
@@ -1,0 +1,70 @@
+import type { DeploymentAction, DeploymentConfig, IssueLinkageMode } from "../config/types.js";
+
+export type DeployInvocationKind = "workflow" | "direct";
+
+export type DeployRequest = {
+  action: DeploymentAction;
+  targetLane: string;
+  sourceLane?: string;
+  candidateRef?: string;
+  dryRun?: boolean;
+  issueId?: number;
+  issueLinkage?: IssueLinkageMode;
+  invocation: {
+    kind: DeployInvocationKind;
+    stateKey?: string;
+  };
+};
+
+export type DeployCandidate = {
+  ref: string;
+  source: "explicit" | "issueCandidate" | "issuePr" | "gitHead" | "fallback";
+  commitSha?: string | null;
+  prUrl?: string | null;
+};
+
+export type DeployDecision = {
+  action: DeploymentAction;
+  sourceLane: string | null;
+  targetLane: string;
+  transitionKey: string;
+  commandId: string;
+  command: string;
+  cwd?: string;
+  timeoutMs: number;
+  evidenceProfile?: string;
+  candidate: DeployCandidate | null;
+  issueLinkage: IssueLinkageMode;
+};
+
+export type DeployReceipt = {
+  id: string;
+  timestamp: string;
+  project: string;
+  issueId?: number;
+  invocation: DeployRequest["invocation"];
+  action: DeploymentAction;
+  issueLinkage: IssueLinkageMode;
+  sourceLane: string | null;
+  targetLane: string;
+  transitionKey: string;
+  candidate: DeployCandidate | null;
+  commandId: string;
+  command: string;
+  cwd?: string;
+  dryRun: boolean;
+  exitCode: number;
+  stdout: string;
+  stderr: string;
+  success: boolean;
+  evidenceProfile?: string;
+  evidence: string[];
+  receiptPath?: string;
+  linkedIssueCommentId?: number | null;
+  configSnapshot?: Pick<DeploymentConfig, "policy">;
+};
+
+export type DeployEngineResult = {
+  decision: DeployDecision;
+  receipt: DeployReceipt;
+};

--- a/lib/deployer/workflow.ts
+++ b/lib/deployer/workflow.ts
@@ -1,0 +1,43 @@
+import type { IssueProvider } from "../providers/provider.js";
+import type { Project } from "../projects/index.js";
+import type { DeploymentConfig } from "../config/types.js";
+import type { RunCommand } from "../context.js";
+import { runDeployEngine } from "./engine.js";
+import { renderDeployReceiptSummary } from "./receipt.js";
+
+export async function runWorkflowDeployment(opts: {
+  workspaceDir: string;
+  project: Project;
+  repoPath: string;
+  provider: IssueProvider;
+  issueId: number;
+  currentStateKey: string;
+  config: DeploymentConfig;
+  runCommand: RunCommand;
+}): Promise<Awaited<ReturnType<typeof runDeployEngine>>> {
+  const mapping = opts.config.workflow?.states?.[opts.currentStateKey];
+  if (!mapping) {
+    throw new Error(`No deployment.workflow.states entry configured for ${opts.currentStateKey}`);
+  }
+
+  const result = await runDeployEngine({
+    workspaceDir: opts.workspaceDir,
+    project: opts.project,
+    repoPath: opts.repoPath,
+    config: opts.config,
+    provider: opts.provider,
+    runCommand: opts.runCommand,
+    request: {
+      action: mapping.action,
+      sourceLane: mapping.sourceLane,
+      targetLane: mapping.targetLane,
+      issueId: opts.issueId,
+      issueLinkage: mapping.issueLinkage ?? "workflow",
+      invocation: { kind: "workflow", stateKey: opts.currentStateKey },
+    },
+  });
+
+  const commentId = await opts.provider.addComment(opts.issueId, renderDeployReceiptSummary(result.receipt));
+  result.receipt.linkedIssueCommentId = commentId;
+  return result;
+}

--- a/lib/deployer/workflow.ts
+++ b/lib/deployer/workflow.ts
@@ -20,7 +20,7 @@ export async function runWorkflowDeployment(opts: {
     throw new Error(`No deployment.workflow.states entry configured for ${opts.currentStateKey}`);
   }
 
-  const result = await runDeployEngine({
+  return runDeployEngine({
     workspaceDir: opts.workspaceDir,
     project: opts.project,
     repoPath: opts.repoPath,
@@ -35,9 +35,8 @@ export async function runWorkflowDeployment(opts: {
       issueLinkage: mapping.issueLinkage ?? "workflow",
       invocation: { kind: "workflow", stateKey: opts.currentStateKey },
     },
+    finalizeReceipt: async (receipt) => {
+      receipt.linkedIssueCommentId = await opts.provider.addComment(opts.issueId, renderDeployReceiptSummary(receipt));
+    },
   });
-
-  const commentId = await opts.provider.addComment(opts.issueId, renderDeployReceiptSummary(result.receipt));
-  result.receipt.linkedIssueCommentId = commentId;
-  return result;
 }

--- a/lib/tools/deployer/deploy-run.ts
+++ b/lib/tools/deployer/deploy-run.ts
@@ -18,8 +18,8 @@ export function createDeployRunTool(ctx: PluginContext) {
         channelId: { type: "string" },
         messageThreadId: { type: "number" },
         action: { type: "string", enum: ["deploy", "promote", "accept", "rollback"] },
-        targetLane: { type: "string" },
-        sourceLane: { type: "string" },
+        targetLane: { type: "string", description: "Destination lane or alias" },
+        sourceLane: { type: "string", description: "Origin lane or alias" },
         candidateRef: { type: "string" },
         issueId: { type: "number" },
         issueLinkage: { type: "string", enum: ["none", "comment", "workflow"] },
@@ -60,13 +60,14 @@ export function createDeployRunTool(ctx: PluginContext) {
           issueLinkage,
           invocation: { kind: "direct" },
         },
+        finalizeReceipt: async (receipt) => {
+          if (params.issueId && issueLinkage !== "none") {
+            receipt.linkedIssueCommentId = await provider.addComment(params.issueId as number, renderDeployReceiptSummary(receipt));
+          }
+        },
       });
 
-      let linkedIssueCommentId: number | null = null;
-      if (params.issueId && issueLinkage !== "none") {
-        linkedIssueCommentId = await provider.addComment(params.issueId as number, renderDeployReceiptSummary(result.receipt));
-        result.receipt.linkedIssueCommentId = linkedIssueCommentId;
-      }
+      const linkedIssueCommentId = result.receipt.linkedIssueCommentId ?? null;
 
       return jsonResult({
         success: result.receipt.success,

--- a/lib/tools/deployer/deploy-run.ts
+++ b/lib/tools/deployer/deploy-run.ts
@@ -1,0 +1,88 @@
+import type { ToolContext } from "../../types.js";
+import type { PluginContext } from "../../context.js";
+import { jsonResult, requireWorkspaceDir, resolveChannelId, resolveProject, resolveProvider } from "../helpers.js";
+import { resolveRepoPath } from "../../projects/index.js";
+import { loadConfig } from "../../config/index.js";
+import { runDeployEngine } from "../../deployer/engine.js";
+import { renderDeployReceiptSummary } from "../../deployer/receipt.js";
+
+export function createDeployRunTool(ctx: PluginContext) {
+  return (_toolCtx: ToolContext) => ({
+    name: "deploy_run",
+    label: "Deploy Run",
+    description: "Run a direct deploy, promote, accept, or rollback operation using the shared deployer engine.",
+    parameters: {
+      type: "object",
+      required: ["channelId", "action", "targetLane"],
+      properties: {
+        channelId: { type: "string" },
+        messageThreadId: { type: "number" },
+        action: { type: "string", enum: ["deploy", "promote", "accept", "rollback"] },
+        targetLane: { type: "string" },
+        sourceLane: { type: "string" },
+        candidateRef: { type: "string" },
+        issueId: { type: "number" },
+        issueLinkage: { type: "string", enum: ["none", "comment", "workflow"] },
+        dryRun: { type: "boolean" },
+      },
+    },
+    async execute(_id: string, params: Record<string, unknown>) {
+      const workspaceDir = requireWorkspaceDir(_toolCtx);
+      const channelId = resolveChannelId(_toolCtx, params.channelId as string | undefined);
+      const messageThreadId = params.messageThreadId as number | undefined;
+      const channelType = (_toolCtx.messageChannel as string | undefined) ?? "telegram";
+      const accountId = _toolCtx.agentAccountId as string | undefined;
+      const { project } = await resolveProject(workspaceDir, channelId, { channel: channelType, accountId, messageThreadId });
+      const { provider } = await resolveProvider(project, ctx.runCommand);
+      const config = await loadConfig(workspaceDir, project.name);
+      const repoPath = resolveRepoPath(project.repo);
+
+      const issueLinkage = (params.issueLinkage as "none" | "comment" | "workflow" | undefined)
+        ?? (params.issueId ? "comment" : "none");
+      if ((issueLinkage === "comment" || issueLinkage === "workflow") && !params.issueId) {
+        throw new Error(`issueLinkage=${issueLinkage} requires issueId`);
+      }
+
+      const result = await runDeployEngine({
+        workspaceDir,
+        project,
+        repoPath,
+        config: config.deployment,
+        provider,
+        runCommand: ctx.runCommand,
+        request: {
+          action: params.action as "deploy" | "promote" | "accept" | "rollback",
+          targetLane: params.targetLane as string,
+          sourceLane: params.sourceLane as string | undefined,
+          candidateRef: params.candidateRef as string | undefined,
+          issueId: params.issueId as number | undefined,
+          dryRun: (params.dryRun as boolean) ?? false,
+          issueLinkage,
+          invocation: { kind: "direct" },
+        },
+      });
+
+      let linkedIssueCommentId: number | null = null;
+      if (params.issueId && issueLinkage !== "none") {
+        linkedIssueCommentId = await provider.addComment(params.issueId as number, renderDeployReceiptSummary(result.receipt));
+        result.receipt.linkedIssueCommentId = linkedIssueCommentId;
+      }
+
+      return jsonResult({
+        success: result.receipt.success,
+        action: result.receipt.action,
+        transition: {
+          sourceLane: result.receipt.sourceLane,
+          targetLane: result.receipt.targetLane,
+          transitionKey: result.receipt.transitionKey,
+        },
+        candidate: result.receipt.candidate,
+        receiptId: result.receipt.id,
+        receiptPath: result.receipt.receiptPath,
+        issueLinkage: result.receipt.issueLinkage,
+        linkedIssueCommentId,
+        dryRun: result.receipt.dryRun,
+      });
+    },
+  });
+}

--- a/lib/tools/worker/work-finish.test.ts
+++ b/lib/tools/worker/work-finish.test.ts
@@ -11,10 +11,9 @@
  */
 import { describe, it, before, after } from "node:test";
 import assert from "node:assert";
-import { mkdtemp, writeFile, readFile } from "node:fs/promises";
+import { mkdtemp, writeFile, readFile, rm } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
-import { rmdir } from "node:fs/promises";
 
 // Helper to create a mock audit log with a merge_conflict transition
 async function createMockAuditLog(workspaceDir: string, issueId: number, hasMergeConflict: boolean): Promise<void> {
@@ -74,7 +73,7 @@ describe("work_finish: PR validation and conflict resolution", () => {
   after(async () => {
     // Clean up
     try {
-      await rmdir(tempDir, { recursive: true });
+      await rm(tempDir, { recursive: true, force: true });
     } catch {
       // ignore
     }
@@ -243,12 +242,12 @@ describe("work_finish: PR validation and conflict resolution", () => {
 
     it("should handle non-Error exceptions gracefully", () => {
       // Test that non-Error objects don't cause issues
-      const notAnError = "some string";
+      const notAnError: unknown = "some string";
       
       const shouldRethrow = 
         notAnError instanceof Error && 
-        ((notAnError as any).message?.startsWith("Cannot mark work_finish(done)") || 
-         (notAnError as any).message?.startsWith("Cannot complete work_finish(done)"));
+        (notAnError.message.startsWith("Cannot mark work_finish(done)") || 
+         notAnError.message.startsWith("Cannot complete work_finish(done)"));
       
       assert.ok(!shouldRethrow, "Should not re-throw non-Error objects");
     });

--- a/lib/tools/worker/work-finish.ts
+++ b/lib/tools/worker/work-finish.ts
@@ -18,7 +18,9 @@ import { log as auditLog } from "../../audit.js";
 import { DATA_DIR } from "../../setup/migrate-layout.js";
 import { requireWorkspaceDir, resolveChannelId, resolveProject, resolveProvider } from "../helpers.js";
 import { getAllRoleIds, isValidResult, getCompletionResults } from "../../roles/index.js";
-import { getCurrentStateLabel, loadWorkflow } from "../../workflow/index.js";
+import { findStateKeyByLabel, getCurrentStateLabel, loadWorkflow } from "../../workflow/index.js";
+import { loadConfig } from "../../config/index.js";
+import { runWorkflowDeployment } from "../../deployer/workflow.js";
 
 /**
  * Get the current git branch name.
@@ -261,6 +263,7 @@ export function createWorkFinishTool(ctx: PluginContext) {
 
       const { provider } = await resolveProvider(project, ctx.runCommand);
       const workflow = await loadWorkflow(workspaceDir, project.name);
+      const resolvedConfig = await loadConfig(workspaceDir, project.name);
       const issue = await provider.getIssue(issueId);
       const currentLabel = getCurrentStateLabel(issue.labels, workflow);
 
@@ -269,6 +272,25 @@ export function createWorkFinishTool(ctx: PluginContext) {
 
       const repoPath = resolveRepoPath(project.repo);
       const pluginConfig = ctx.pluginConfig;
+
+      if (role === "deployer" && result === "done" && currentLabel) {
+        const stateKey = findStateKeyByLabel(workflow, currentLabel);
+        if (stateKey && resolvedConfig.deployment.workflow?.states?.[stateKey]) {
+          const deployResult = await runWorkflowDeployment({
+            workspaceDir,
+            project,
+            repoPath,
+            provider,
+            issueId,
+            currentStateKey: stateKey,
+            config: resolvedConfig.deployment,
+            runCommand: ctx.runCommand,
+          });
+          if (!deployResult.receipt.success) {
+            throw new Error(`Deployment command failed for ${stateKey}: ${deployResult.receipt.stderr || deployResult.receipt.stdout || deployResult.receipt.exitCode}`);
+          }
+        }
+      }
 
       // For developers marking work as done, validate that a PR exists
       if (role === "developer" && result === "done") {


### PR DESCRIPTION
## Summary
- add first-class deployment config, shared deployer engine, workflow wrapper, direct deploy tool, receipts, and docs/tests
- finalize receipt persistence after optional issue comment linkage and normalize rollback semantics across workflow and direct paths
- deep-merge deployment config overlays so per-project lane/state overrides inherit predictably

## Validation
- `npm run build` ✅
- `npm run check` ⚠️ ambient validation noise from missing or unresolved deps in existing files: `openclaw/plugin-sdk/process/exec`, `openclaw/plugin-sdk/msteams`, and several `vitest` imports

Addresses issue #237
