### PR TITLE
feat: add shared deployer engine

### DIFF
--- a/lib/deployer/engine.test.ts
+++ b/lib/deployer/engine.test.ts
@@ -7,6 +7,7 @@ import { runDeployEngine } from "./engine.js";
 import { runWorkflowDeployment } from "./workflow.js";
 import { TestProvider } from "../testing/test-provider.js";
 import type { DeploymentConfig } from "../config/types.js";
+import { renderCandidateRecord } from "../workflow/candidate-provenance.js";
 
 const deployment: DeploymentConfig = {
   lanes: {
@@ -27,7 +28,7 @@ const deployment: DeploymentConfig = {
       promoting: { action: "promote", sourceLane: "build", targetLane: "staging", issueLinkage: "workflow" },
     },
   },
-  candidate: { sources: ["explicit"] },
+  candidate: { sources: ["explicit", "issueCandidate"] },
   policy: { allowDirectWithoutIssue: true },
 };
 
@@ -36,6 +37,12 @@ describe("deploy engine", () => {
     const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), "devclaw-deploy-engine-"));
     const provider = new TestProvider();
     provider.seedIssue({ iid: 7, labels: ["Promoting"] });
+    await provider.addComment(7, renderCandidateRecord({
+      issueId: 7,
+      candidateId: "sha123",
+      commitSha: "sha123",
+      status: "active",
+    }));
     let executedCommand: string[] | undefined;
     let executedEnv: Record<string, string> | undefined;
     const runCommand = async (argv: string[], opts?: { env?: Record<string, string> }) => {
@@ -78,6 +85,7 @@ describe("deploy engine", () => {
     assert.equal(direct.receipt.targetLane, workflow.receipt.targetLane);
     assert.equal(direct.receipt.transitionKey, workflow.receipt.transitionKey);
     assert.equal(direct.receipt.candidate?.ref, "sha123");
+    assert.equal(workflow.receipt.candidate?.ref, "sha123");
     assert.equal(workflow.receipt.issueLinkage, "workflow");
     assert.ok(workflow.receipt.linkedIssueCommentId);
     assert.ok(direct.receipt.receiptPath);
@@ -90,6 +98,12 @@ describe("deploy engine", () => {
     const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), "devclaw-deploy-receipt-"));
     const provider = new TestProvider();
     provider.seedIssue({ iid: 9, labels: ["Promoting"] });
+    await provider.addComment(9, renderCandidateRecord({
+      issueId: 9,
+      candidateId: "sha123",
+      commitSha: "sha123",
+      status: "active",
+    }));
     const project = { name: "demo", deployBranch: "main", deployUrl: "", repo: "/tmp/repo" } as any;
 
     const result = await runWorkflowDeployment({

--- a/lib/deployer/workflow.ts
+++ b/lib/deployer/workflow.ts
@@ -2,6 +2,7 @@ import type { IssueProvider } from "../providers/provider.js";
 import type { Project } from "../projects/index.js";
 import type { DeploymentConfig } from "../config/types.js";
 import type { RunCommand } from "../context.js";
+import { getCurrentCandidate } from "../workflow/candidate-provenance.js";
 import { runDeployEngine } from "./engine.js";
 import { renderDeployReceiptSummary } from "./receipt.js";
 
@@ -20,6 +21,9 @@ export async function runWorkflowDeployment(opts: {
     throw new Error(`No deployment.workflow.states entry configured for ${opts.currentStateKey}`);
   }
 
+  const currentCandidate = await getCurrentCandidate(opts.provider, opts.issueId);
+  const candidateRef = currentCandidate?.candidateId ?? currentCandidate?.commitSha ?? undefined;
+
   return runDeployEngine({
     workspaceDir: opts.workspaceDir,
     project: opts.project,
@@ -31,6 +35,7 @@ export async function runWorkflowDeployment(opts: {
       action: mapping.action,
       sourceLane: mapping.sourceLane,
       targetLane: mapping.targetLane,
+      candidateRef,
       issueId: opts.issueId,
       issueLinkage: mapping.issueLinkage ?? "workflow",
       invocation: { kind: "workflow", stateKey: opts.currentStateKey },

--- a/lib/tools/worker/work-finish.test.ts
+++ b/lib/tools/worker/work-finish.test.ts
@@ -11,22 +11,15 @@
  */
 import { describe, it, before, after } from "node:test";
 import assert from "node:assert";
-import { mkdtemp, writeFile, readFile, rm } from "node:fs/promises";
+import { mkdtemp, writeFile, readFile, rm, mkdir } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 
 // Helper to create a mock audit log with a merge_conflict transition
 async function createMockAuditLog(workspaceDir: string, issueId: number, hasMergeConflict: boolean): Promise<void> {
   const logDir = join(workspaceDir, "devclaw", "log");
-  
-  // Ensure directory exists
-  try {
-    await writeFile(join(workspaceDir, "devclaw", "placeholder"), "");
-  } catch {
-    // ignore
-  }
-  
-  const auditPath = join(workspaceDir, "devclaw", "log", "audit.log");
+  await mkdir(logDir, { recursive: true });
+  const auditPath = join(logDir, "audit.log");
   const entries = [];
   
   // Add some dummy entries
@@ -141,7 +134,9 @@ describe("work_finish: PR validation and conflict resolution", () => {
     });
 
     it("should skip malformed JSON lines in audit log", async () => {
-      const auditPath = join(tempDir, "devclaw", "log", "audit.log");
+      const logDir = join(tempDir, "devclaw", "log");
+      await mkdir(logDir, { recursive: true });
+      const auditPath = join(logDir, "audit.log");
       const entries = [
         JSON.stringify({ event: "valid", issueId: 999 }),
         "{ invalid json",


### PR DESCRIPTION
Addresses issue #237

## Summary
- add first-class deployment config, resolver, shared deploy engine, receipts, workflow wrapper, and direct deploy tool
- route workflow-backed delivery through the shared engine and persist finalized receipt linkage data
- fix workflow candidate propagation so issue-backed delivery works when candidate resolution is configured as explicit-only for the engine input contract

## Validation
- npm run build
- npx --yes tsx --test lib/deployer/*.test.ts lib/tools/worker/work-finish.test.ts