### PR TITLE
fix: canonical PR ledger routing integrity

### DIFF
--- a/lib/dispatch/index.ts
+++ b/lib/dispatch/index.ts
@@ -150,7 +150,6 @@ export async function dispatchTask(
     ).catch(() => {});
     existingSessionKey = null;
   }
-
   const sessionAction = existingSessionKey ? "send" : "spawn";
 
   // Fetch comments to include in task context
@@ -158,9 +157,9 @@ export async function dispatchTask(
 
   // Fetch PR context based on workflow role semantics (no hardcoded role/label checks)
   const prFeedback = isFeedbackState(workflow, fromLabel)
-    ? await fetchPrFeedback(provider, issueId) : undefined;
+    ? await fetchPrFeedback(provider, issueId, { workspaceDir, projectSlug: project.slug }) : undefined;
   const prContext = hasReviewCheck(workflow, role)
-    ? await fetchPrContext(provider, issueId) : undefined;
+    ? await fetchPrContext(provider, issueId, { workspaceDir, projectSlug: project.slug }) : undefined;
 
   // Fetch attachment context (best-effort — never blocks dispatch)
   let attachmentContext: string | undefined;

--- a/lib/dispatch/message-builder.ts
+++ b/lib/dispatch/message-builder.ts
@@ -53,6 +53,7 @@ export function buildTaskMessage(opts: {
       `> **⚠️ FEEDBACK CYCLE — This issue is returning from review.**`,
       `> The original description above is for context only.`,
       `> Your job is to address the PR Review Feedback and Comments below.`,
+      `> Reuse the existing canonical PR and branch unless the task explicitly says to replace them.`,
       `> When feedback conflicts with the original description, follow the feedback.`,
     );
   }

--- a/lib/dispatch/pr-context.test.ts
+++ b/lib/dispatch/pr-context.test.ts
@@ -212,6 +212,36 @@ describe("canonical PR dispatch routing", () => {
     }
   });
 
+  it("returns authoritative canonical PR context only with a loaded diff", async () => {
+    const workspaceDir = await mkdtemp(path.join(os.tmpdir(), "devclaw-pr-context-success-"));
+    try {
+      const provider = new TestProvider();
+      provider.seedIssue({ iid: 76, title: "Canonical review", labels: ["To Review"] });
+      provider.setPrStatus(76, {
+        state: PrState.OPEN,
+        url: "https://example.com/pr/76",
+        number: 76,
+        sourceBranch: "issue/76-canonical-review",
+      });
+      provider.prDiffs.set(76, "diff --git a/a.ts b/a.ts");
+      await recordCanonicalPr(workspaceDir, "test-project", 76, {
+        number: 76,
+        url: "https://example.com/pr/76",
+        title: "Canonical review",
+        sourceBranch: "issue/76-canonical-review",
+      }, PrState.OPEN);
+
+      const prContext = await fetchPrContext(provider, 76, { workspaceDir, projectSlug: "test-project" });
+      assert.deepStrictEqual(prContext, {
+        url: "https://example.com/pr/76",
+        diff: "diff --git a/a.ts b/a.ts",
+        canonical: true,
+      });
+    } finally {
+      await rm(workspaceDir, { recursive: true, force: true });
+    }
+  });
+
   it("preserves canonical feedback routing even when comments are empty", async () => {
     const workspaceDir = await mkdtemp(path.join(os.tmpdir(), "devclaw-pr-feedback-"));
     try {
@@ -238,5 +268,24 @@ describe("canonical PR dispatch routing", () => {
     } finally {
       await rm(workspaceDir, { recursive: true, force: true });
     }
+  });
+
+  it("keeps legacy issue-scoped review context non-canonical", async () => {
+    const provider = new TestProvider();
+    provider.seedIssue({ iid: 80, title: "Legacy review", labels: ["To Review"] });
+    provider.setPrStatus(80, {
+      state: PrState.OPEN,
+      url: "https://example.com/pr/80",
+      number: 80,
+      sourceBranch: "issue/80-legacy-review",
+    });
+    provider.prDiffs.set(80, "diff --git a/legacy.ts b/legacy.ts");
+
+    const prContext = await fetchPrContext(provider, 80);
+    assert.deepStrictEqual(prContext, {
+      url: "https://example.com/pr/80",
+      diff: "diff --git a/legacy.ts b/legacy.ts",
+      canonical: false,
+    });
   });
 });

--- a/lib/dispatch/pr-context.test.ts
+++ b/lib/dispatch/pr-context.test.ts
@@ -1,8 +1,15 @@
-import { describe, it, expect } from "vitest";
-import { formatPrFeedback, type PrFeedback } from "./pr-context.js";
+import { describe, it } from "node:test";
+import assert from "node:assert";
+import { mkdtemp, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { fetchPrContext, fetchPrFeedback, formatPrFeedback, type PrFeedback } from "./pr-context.js";
+import { TestProvider } from "../testing/test-provider.js";
+import { PrState } from "../providers/provider.js";
+import { recordCanonicalPr } from "../services/canonical-pr.js";
 
 describe("formatPrFeedback", () => {
-  it("returns empty array when no comments", () => {
+  it("preserves canonical PR context even when no comments were retrieved", () => {
     const feedback: PrFeedback = {
       url: "https://github.com/user/repo/pull/123",
       branchName: "feature/123-test",
@@ -10,7 +17,10 @@ describe("formatPrFeedback", () => {
       comments: [],
     };
     const result = formatPrFeedback(feedback, "main");
-    expect(result).toEqual([]);
+    const text = result.join("\n");
+    assert.match(text, /https:\/\/github.com\/user\/repo\/pull\/123/);
+    assert.match(text, /No review comment bodies were retrieved/);
+    assert.match(text, /feature\/123-test/);
   });
 
   it("includes branch name in conflict resolution instructions", () => {
@@ -30,10 +40,10 @@ describe("formatPrFeedback", () => {
     const result = formatPrFeedback(feedback, "main");
     const text = result.join("\n");
 
-    expect(text).toContain("feature/456-test");
-    expect(text).toContain("🔹 Branch: `feature/456-test`");
-    expect(text).toContain("git checkout feature/456-test");
-    expect(text).toContain("git push --force-with-lease origin feature/456-test");
+    assert.match(text, /feature\/456-test/);
+    assert.match(text, /🔹 Branch: `feature\/456-test`/);
+    assert.match(text, /git checkout feature\/456-test/);
+    assert.match(text, /git push --force-with-lease origin feature\/456-test/);
   });
 
   it("uses fallback branch name when not provided", () => {
@@ -52,8 +62,8 @@ describe("formatPrFeedback", () => {
     const result = formatPrFeedback(feedback, "main");
     const text = result.join("\n");
 
-    expect(text).toContain("your-branch");
-    expect(text).toContain("🔹 Branch: `your-branch`");
+    assert.match(text, /your-branch/);
+    assert.match(text, /🔹 Branch: `your-branch`/);
   });
 
   it("includes step-by-step instructions for conflict resolution", () => {
@@ -73,17 +83,14 @@ describe("formatPrFeedback", () => {
     const result = formatPrFeedback(feedback, "develop");
     const text = result.join("\n");
 
-    // Check all steps are present
-    expect(text).toContain("1. Fetch and check out the PR branch");
-    expect(text).toContain("2. Rebase onto `develop`");
-    expect(text).toContain("3. Resolve any conflicts");
-    expect(text).toContain("4. Force-push to the SAME branch");
-    expect(text).toContain("5. Verify the PR shows as mergeable");
-
-    // Check warning about not creating new PR
-    expect(text).toContain("⚠️ Do NOT create a new PR");
-    expect(text).toContain("Do NOT switch branches");
-    expect(text).toContain("Update THIS PR only");
+    assert.match(text, /1\. Fetch and check out the PR branch/);
+    assert.match(text, /2\. Rebase onto `develop`/);
+    assert.match(text, /3\. Resolve any conflicts/);
+    assert.match(text, /4\. Force-push to the SAME branch/);
+    assert.match(text, /5\. Verify the PR shows as mergeable/);
+    assert.match(text, /⚠️ Do NOT create a new PR/);
+    assert.match(text, /Do NOT switch branches/);
+    assert.match(text, /Update THIS canonical PR only/);
   });
 
   it("correctly formats changes_requested feedback", () => {
@@ -103,10 +110,9 @@ describe("formatPrFeedback", () => {
     const result = formatPrFeedback(feedback, "main");
     const text = result.join("\n");
 
-    expect(text).toContain("⚠️ Changes were requested");
-    expect(text).toContain("Please make these changes");
-    // Should NOT have conflict resolution instructions
-    expect(text).not.toContain("Conflict Resolution Instructions");
+    assert.match(text, /⚠️ Changes were requested/);
+    assert.match(text, /Please make these changes/);
+    assert.doesNotMatch(text, /Conflict Resolution Instructions/);
   });
 
   it("includes comment location information when available", () => {
@@ -128,7 +134,7 @@ describe("formatPrFeedback", () => {
     const result = formatPrFeedback(feedback, "main");
     const text = result.join("\n");
 
-    expect(text).toContain("(src/index.ts:42)");
+    assert.match(text, /\(src\/index\.ts:42\)/);
   });
 
   it("uses correct base branch in rebase command", () => {
@@ -146,14 +152,64 @@ describe("formatPrFeedback", () => {
       ],
     };
 
-    // Test with "main" base branch
     let result = formatPrFeedback(feedback, "main");
     let text = result.join("\n");
-    expect(text).toContain("git rebase main");
+    assert.match(text, /git rebase main/);
 
-    // Test with "develop" base branch
     result = formatPrFeedback(feedback, "develop");
     text = result.join("\n");
-    expect(text).toContain("git rebase develop");
+    assert.match(text, /git rebase develop/);
+  });
+});
+
+describe("canonical PR dispatch routing", () => {
+  it("fails closed when canonical status lookup no longer resolves", async () => {
+    const workspaceDir = await mkdtemp(path.join(os.tmpdir(), "devclaw-pr-context-"));
+    try {
+      const provider = new TestProvider();
+      provider.seedIssue({ iid: 77, title: "Review me", labels: ["To Review"] });
+      provider.setLinkedPrs(77, [{ number: 77, url: "https://example.com/pr/77", title: "Review me", sourceBranch: "issue/77-review-me" }]);
+      await recordCanonicalPr(workspaceDir, "test-project", 77, {
+        number: 77,
+        url: "https://example.com/pr/77",
+        title: "Review me",
+        sourceBranch: "issue/77-review-me",
+      }, PrState.OPEN);
+
+      await assert.rejects(
+        () => fetchPrContext(provider, 77, { workspaceDir, projectSlug: "test-project" }),
+        /stored PR https:\/\/example\.com\/pr\/77 no longer resolves/,
+      );
+    } finally {
+      await rm(workspaceDir, { recursive: true, force: true });
+    }
+  });
+
+  it("preserves canonical feedback routing even when comments are empty", async () => {
+    const workspaceDir = await mkdtemp(path.join(os.tmpdir(), "devclaw-pr-feedback-"));
+    try {
+      const provider = new TestProvider();
+      provider.seedIssue({ iid: 78, title: "Needs changes", labels: ["To Improve"] });
+      provider.setPrStatus(78, {
+        state: PrState.CHANGES_REQUESTED,
+        url: "https://example.com/pr/78",
+        number: 78,
+        sourceBranch: "issue/78-needs-changes",
+      });
+      await recordCanonicalPr(workspaceDir, "test-project", 78, {
+        number: 78,
+        url: "https://example.com/pr/78",
+        title: "Needs changes",
+        sourceBranch: "issue/78-needs-changes",
+      }, PrState.CHANGES_REQUESTED);
+
+      const feedback = await fetchPrFeedback(provider, 78, { workspaceDir, projectSlug: "test-project" });
+      assert.ok(feedback);
+      assert.strictEqual(feedback?.url, "https://example.com/pr/78");
+      assert.strictEqual(feedback?.reason, "changes_requested");
+      assert.deepStrictEqual(feedback?.comments, []);
+    } finally {
+      await rm(workspaceDir, { recursive: true, force: true });
+    }
   });
 });

--- a/lib/dispatch/pr-context.test.ts
+++ b/lib/dispatch/pr-context.test.ts
@@ -185,6 +185,33 @@ describe("canonical PR dispatch routing", () => {
     }
   });
 
+  it("fails closed when canonical diff lookup cannot load URL-scoped context", async () => {
+    const workspaceDir = await mkdtemp(path.join(os.tmpdir(), "devclaw-pr-context-diff-"));
+    try {
+      const provider = new TestProvider();
+      provider.seedIssue({ iid: 79, title: "Needs diff", labels: ["To Review"] });
+      provider.setPrStatus(79, {
+        state: PrState.OPEN,
+        url: "https://example.com/pr/79",
+        number: 79,
+        sourceBranch: "issue/79-needs-diff",
+      });
+      await recordCanonicalPr(workspaceDir, "test-project", 79, {
+        number: 79,
+        url: "https://example.com/pr/79",
+        title: "Needs diff",
+        sourceBranch: "issue/79-needs-diff",
+      }, PrState.OPEN);
+
+      await assert.rejects(
+        () => fetchPrContext(provider, 79, { workspaceDir, projectSlug: "test-project" }),
+        /has no URL-scoped diff context/,
+      );
+    } finally {
+      await rm(workspaceDir, { recursive: true, force: true });
+    }
+  });
+
   it("preserves canonical feedback routing even when comments are empty", async () => {
     const workspaceDir = await mkdtemp(path.join(os.tmpdir(), "devclaw-pr-feedback-"));
     try {

--- a/lib/dispatch/pr-context.ts
+++ b/lib/dispatch/pr-context.ts
@@ -8,6 +8,7 @@
  */
 import type { IssueProvider } from "../providers/provider.js";
 import { PrState } from "../providers/provider.js";
+import { resolveCanonicalPrForIssue } from "../services/canonical-pr.js";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -32,8 +33,9 @@ export type PrContext = {
 
 /**
  * Fetch PR review feedback for an issue returning from review.
- * Returns undefined if no PR or no review comments found.
- * Best-effort: swallows errors (caller can still work from issue context).
+ * Returns undefined if no PR found, or if the PR is not currently in a
+ * feedback-worthy state.
+ * Canonical routing errors are allowed to bubble so dispatch fails closed.
  *
  * Includes explicit branch name in feedback to prevent developers from working
  * on the wrong PR when multiple PRs exist for the same issue (#482).
@@ -41,50 +43,70 @@ export type PrContext = {
 export async function fetchPrFeedback(
   provider: IssueProvider,
   issueId: number,
+  opts?: { workspaceDir?: string; projectSlug?: string },
 ): Promise<PrFeedback | undefined> {
-  try {
-    const prStatus = await provider.getPrStatus(issueId);
-    if (!prStatus.url || prStatus.state === PrState.MERGED || prStatus.state === PrState.CLOSED) {
-      return undefined;
-    }
-    const reviewComments = await provider.getPrReviewComments(issueId);
-    if (reviewComments.length === 0) return undefined;
+  let canonicalUrl: string | undefined;
+  if (opts?.workspaceDir && opts?.projectSlug) {
+    canonicalUrl = (await resolveCanonicalPrForIssue({ workspaceDir: opts.workspaceDir, projectSlug: opts.projectSlug, issueId, provider, allowBackfill: false })).url;
+  }
 
-    const reason = prStatus.mergeable === false ? "merge_conflict" as const
-      : (prStatus.state === PrState.CHANGES_REQUESTED || prStatus.state === PrState.HAS_COMMENTS) ? "changes_requested" as const
-      : "rejected" as const;
-
-    return {
-      url: prStatus.url,
-      branchName: prStatus.sourceBranch,
-      reason,
-      comments: reviewComments.map((c) => ({
-        id: c.id, author: c.author, body: c.body, state: c.state,
-        path: c.path, line: c.line,
-      })),
-    };
-  } catch {
+  const prStatus = canonicalUrl
+    ? await provider.getPrStatusByUrl(canonicalUrl)
+    : await provider.getPrStatus(issueId);
+  if (canonicalUrl && !prStatus) {
+    throw new Error(`Canonical PR routing integrity failure for issue #${issueId}: stored PR ${canonicalUrl} no longer resolves.`);
+  }
+  if (!prStatus?.url || prStatus.state === PrState.MERGED || prStatus.state === PrState.CLOSED) {
     return undefined;
   }
+
+  const reason = prStatus.mergeable === false ? "merge_conflict" as const
+    : (prStatus.state === PrState.CHANGES_REQUESTED || prStatus.state === PrState.HAS_COMMENTS) ? "changes_requested" as const
+    : undefined;
+  if (!reason) return undefined;
+
+  const reviewComments = opts?.workspaceDir && opts?.projectSlug
+    ? await provider.getPrReviewCommentsByUrl(prStatus.url)
+    : await provider.getPrReviewComments(issueId);
+
+  return {
+    url: prStatus.url,
+    branchName: prStatus.sourceBranch,
+    reason,
+    comments: reviewComments.map((c) => ({
+      id: c.id, author: c.author, body: c.body, state: c.state,
+      path: c.path, line: c.line,
+    })),
+  };
 }
 
 /**
  * Fetch PR context (URL + diff) for code review.
  * Returns undefined if no PR found.
- * Best-effort: swallows errors (caller can still work from issue context).
+ * Canonical routing errors are allowed to bubble so dispatch fails closed.
  */
 export async function fetchPrContext(
   provider: IssueProvider,
   issueId: number,
+  opts?: { workspaceDir?: string; projectSlug?: string },
 ): Promise<PrContext | undefined> {
-  try {
-    const prStatus = await provider.getPrStatus(issueId);
-    if (!prStatus.url) return undefined;
-    const diff = await provider.getPrDiff(issueId) ?? undefined;
-    return { url: prStatus.url, diff };
-  } catch {
-    return undefined;
+  const canonicalRouting = !!(opts?.workspaceDir && opts?.projectSlug);
+  const canonicalUrl = canonicalRouting
+    ? (await resolveCanonicalPrForIssue({ workspaceDir: opts.workspaceDir!, projectSlug: opts.projectSlug!, issueId, provider, allowBackfill: false })).url
+    : undefined;
+  const prStatus = canonicalUrl
+    ? await provider.getPrStatusByUrl(canonicalUrl)
+    : await provider.getPrStatus(issueId);
+  if (canonicalUrl && !prStatus) {
+    throw new Error(`Canonical PR routing integrity failure for issue #${issueId}: stored PR ${canonicalUrl} no longer resolves.`);
   }
+  if (!prStatus?.url) return undefined;
+
+  const diff = canonicalRouting
+    ? await provider.getPrDiffByUrl(prStatus.url) ?? undefined
+    : await provider.getPrDiff(issueId) ?? undefined;
+
+  return { url: prStatus.url, diff };
 }
 
 // ---------------------------------------------------------------------------
@@ -110,8 +132,6 @@ export function formatPrContext(prContext: PrContext): string[] {
  * Format PR review feedback section for task message.
  */
 export function formatPrFeedback(prFeedback: PrFeedback, baseBranch: string): string[] {
-  if (prFeedback.comments.length === 0) return [];
-
   const reasonLabel = prFeedback.reason === "merge_conflict"
     ? "⚠️ Merge conflicts detected"
     : prFeedback.reason === "changes_requested"
@@ -124,9 +144,13 @@ export function formatPrFeedback(prFeedback: PrFeedback, baseBranch: string): st
     `🔗 ${prFeedback.url}`,
   ];
 
-  for (const c of prFeedback.comments) {
-    const location = c.path ? ` (${c.path}${c.line ? `:${c.line}` : ""})` : "";
-    parts.push(``, `**${c.author}** [${c.state}]${location}:`, c.body);
+  if (prFeedback.comments.length > 0) {
+    for (const c of prFeedback.comments) {
+      const location = c.path ? ` (${c.path}${c.line ? `:${c.line}` : ""})` : "";
+      parts.push(``, `**${c.author}** [${c.state}]${location}:`, c.body);
+    }
+  } else {
+    parts.push(``, `_No review comment bodies were retrieved, but this canonical PR still needs attention._`);
   }
 
   if (prFeedback.reason === "merge_conflict") {
@@ -135,7 +159,7 @@ export function formatPrFeedback(prFeedback: PrFeedback, baseBranch: string): st
     parts.push(
       ``, `### Conflict Resolution Instructions`,
       ``,
-      `**Important:** You must update the EXISTING PR branch, not create a new one.`,
+      `**Important:** You must update the EXISTING canonical PR branch, not create a new one.`,
       ``,
       `🔹 PR: ${prFeedback.url}`,
       `🔹 Branch: \`${branchName}\``,
@@ -174,7 +198,7 @@ export function formatPrFeedback(prFeedback: PrFeedback, baseBranch: string): st
       `   # Status should be "Mergeable" or "Open"`,
       `   \`\`\``,
       ``,
-      `⚠️ Do NOT create a new PR. Do NOT switch branches. Update THIS PR only.`,
+      `⚠️ Do NOT create a new PR unless the task explicitly calls for replacement. Do NOT switch branches. Update THIS canonical PR only.`,
     );
   }
 

--- a/lib/dispatch/pr-context.ts
+++ b/lib/dispatch/pr-context.ts
@@ -103,10 +103,14 @@ export async function fetchPrContext(
   if (!prStatus?.url) return undefined;
 
   const diff = canonicalRouting
-    ? await provider.getPrDiffByUrl(prStatus.url) ?? undefined
-    : await provider.getPrDiff(issueId) ?? undefined;
+    ? await provider.getPrDiffByUrl(prStatus.url)
+    : await provider.getPrDiff(issueId);
 
-  return { url: prStatus.url, diff };
+  if (canonicalUrl && diff == null) {
+    throw new Error(`Canonical PR routing integrity failure for issue #${issueId}: stored PR ${canonicalUrl} has no URL-scoped diff context.`);
+  }
+
+  return { url: prStatus.url, diff: diff ?? undefined };
 }
 
 // ---------------------------------------------------------------------------

--- a/lib/dispatch/pr-context.ts
+++ b/lib/dispatch/pr-context.ts
@@ -22,10 +22,17 @@ export type PrFeedback = {
   comments: Array<{ id: number; author: string; body: string; state: string; path?: string; line?: number }>;
 };
 
-export type PrContext = {
-  url: string;
-  diff?: string;
-};
+export type PrContext =
+  | {
+    url: string;
+    diff: string;
+    canonical: true;
+  }
+  | {
+    url: string;
+    diff?: string;
+    canonical: false;
+  };
 
 // ---------------------------------------------------------------------------
 // Fetching
@@ -110,7 +117,11 @@ export async function fetchPrContext(
     throw new Error(`Canonical PR routing integrity failure for issue #${issueId}: stored PR ${canonicalUrl} has no URL-scoped diff context.`);
   }
 
-  return { url: prStatus.url, diff: diff ?? undefined };
+  if (canonicalUrl) {
+    return { url: prStatus.url, diff, canonical: true };
+  }
+
+  return { url: prStatus.url, diff: diff ?? undefined, canonical: false };
 }
 
 // ---------------------------------------------------------------------------

--- a/lib/providers/github.ts
+++ b/lib/providers/github.ts
@@ -6,6 +6,7 @@ import {
   type Issue,
   type StateLabel,
   type IssueComment,
+  type PrIdentity,
   type PrStatus,
   type PrReviewComment,
   PrState,
@@ -41,6 +42,14 @@ export class GitHubProvider implements IssueProvider {
   private workflow: WorkflowConfig;
   private runCommand: RunCommand;
   private targetRepo?: string;
+
+  private isGhNotFoundError(error: unknown): boolean {
+    const message = error instanceof Error ? error.message : String(error);
+    return message.includes("Could not resolve to a PullRequest") ||
+      message.includes("no pull requests found") ||
+      message.includes("HTTP 404") ||
+      message.includes("Not Found");
+  }
 
   constructor(opts: { repoPath: string; runCommand: RunCommand; workflow?: WorkflowConfig; target?: ProviderTarget }) {
     this.repoPath = opts.repoPath;
@@ -341,41 +350,57 @@ export class GitHubProvider implements IssueProvider {
     return prs[0].url;
   }
 
+  async getLinkedPrs(issueId: number): Promise<PrIdentity[]> {
+    const prs = await this.findPrsForIssue<{ number: number; title: string; body: string; headRefName: string; url: string }>(
+      issueId,
+      "all",
+      "number,title,body,headRefName,url",
+    );
+    return prs.map((pr) => ({
+      number: pr.number,
+      url: pr.url,
+      title: pr.title,
+      sourceBranch: pr.headRefName,
+      repo: this.targetRepo,
+    }));
+  }
+
+  async getPrByUrl(prUrl: string): Promise<PrIdentity | null> {
+    try {
+      const raw = await this.gh(["pr", "view", prUrl, "--json", "number,title,headRefName,url"]);
+      const pr = JSON.parse(raw) as { number: number; title: string; headRefName: string; url: string };
+      return { number: pr.number, url: pr.url, title: pr.title, sourceBranch: pr.headRefName, repo: this.targetRepo };
+    } catch (err) {
+      if (this.isGhNotFoundError(err)) return null;
+      throw err;
+    }
+  }
+
+  async getPrByNumber(prNumber: number): Promise<PrIdentity | null> {
+    try {
+      const raw = await this.gh(["pr", "view", String(prNumber), "--json", "number,title,headRefName,url"]);
+      const pr = JSON.parse(raw) as { number: number; title: string; headRefName: string; url: string };
+      return { number: pr.number, url: pr.url, title: pr.title, sourceBranch: pr.headRefName, repo: this.targetRepo };
+    } catch (err) {
+      if (this.isGhNotFoundError(err)) return null;
+      throw err;
+    }
+  }
+
   async getPrStatus(issueId: number): Promise<PrStatus> {
     // Check open PRs first — include mergeable for conflict detection
     type OpenPr = { title: string; body: string; headRefName: string; url: string; number: number; reviewDecision: string; mergeable: string };
     const open = await this.findPrsForIssue<OpenPr>(issueId, "open", "title,body,headRefName,url,number,reviewDecision,mergeable");
     if (open.length > 0) {
       const pr = open[0];
-      let state: PrState;
-      if (pr.reviewDecision === "APPROVED") {
-        state = PrState.APPROVED;
-      } else if (pr.reviewDecision === "CHANGES_REQUESTED") {
-        state = PrState.CHANGES_REQUESTED;
-      } else {
-        // No branch protection → reviewDecision may be empty. Check individual reviews.
-        const hasChangesRequested = await this.hasChangesRequestedReview(pr.number);
-        if (hasChangesRequested) {
-          state = PrState.CHANGES_REQUESTED;
-        } else {
-          // Check for unacknowledged COMMENTED reviews (feedback without formal "Request changes")
-          const hasReviewFeedback = await this.hasUnacknowledgedReviews(pr.number);
-          if (hasReviewFeedback) {
-            state = PrState.HAS_COMMENTS;
-          } else {
-            // Fall through to conversation comment detection
-            const hasComments = await this.hasConversationComments(pr.number);
-            state = hasComments ? PrState.HAS_COMMENTS : PrState.OPEN;
-          }
-        }
-      }
-
-      // Conflict detection: "CONFLICTING" means merge conflicts, "UNKNOWN" means still computing
-      const mergeable = pr.mergeable === "CONFLICTING" ? false
-        : pr.mergeable === "MERGEABLE" ? true
-        : undefined; // UNKNOWN or missing — don't assume
-
-      return { state, url: pr.url, title: pr.title, sourceBranch: pr.headRefName, mergeable };
+      return this.buildOpenPrStatus({
+        number: pr.number,
+        title: pr.title,
+        sourceBranch: pr.headRefName,
+        url: pr.url,
+        reviewDecision: pr.reviewDecision,
+        mergeable: pr.mergeable,
+      });
     }
     // Check merged PRs — also fetch reviewDecision to detect approved-then-merged vs self-merged.
     type MergedPr = { title: string; body: string; headRefName: string; url: string; reviewDecision: string | null };
@@ -390,9 +415,61 @@ export class GitHubProvider implements IssueProvider {
     const allPrs = await this.findPrsViaTimeline(issueId, "all");
     const closedPr = allPrs?.find((pr) => pr.state === "CLOSED");
     if (closedPr) {
-      return { state: PrState.CLOSED, url: closedPr.url, title: closedPr.title, sourceBranch: closedPr.headRefName };
+      return { state: PrState.CLOSED, url: closedPr.url, number: closedPr.number, title: closedPr.title, sourceBranch: closedPr.headRefName };
     }
     return { state: PrState.CLOSED, url: null };
+  }
+
+  async getPrStatusByUrl(prUrl: string): Promise<PrStatus | null> {
+    try {
+      const raw = await this.gh(["pr", "view", prUrl, "--json", "number,title,headRefName,url,state,reviewDecision,mergeable"]);
+      const pr = JSON.parse(raw) as { number: number; title: string; headRefName: string; url: string; state: string; reviewDecision: string | null; mergeable: string | null };
+      if (pr.state === "MERGED") {
+        return { state: PrState.MERGED, url: pr.url, number: pr.number, title: pr.title, sourceBranch: pr.headRefName };
+      }
+      if (pr.state === "CLOSED") {
+        return { state: PrState.CLOSED, url: pr.url, number: pr.number, title: pr.title, sourceBranch: pr.headRefName };
+      }
+      return this.buildOpenPrStatus({
+        number: pr.number,
+        title: pr.title,
+        sourceBranch: pr.headRefName,
+        url: pr.url,
+        reviewDecision: pr.reviewDecision,
+        mergeable: pr.mergeable,
+      });
+    } catch (err) {
+      if (this.isGhNotFoundError(err)) return null;
+      throw err;
+    }
+  }
+
+  private async buildOpenPrStatus(pr: { number: number; title: string; sourceBranch?: string; url: string; reviewDecision?: string | null; mergeable?: string | null }): Promise<PrStatus> {
+    let state: PrState;
+    if (pr.reviewDecision === "APPROVED") {
+      state = PrState.APPROVED;
+    } else if (pr.reviewDecision === "CHANGES_REQUESTED") {
+      state = PrState.CHANGES_REQUESTED;
+    } else {
+      const hasChangesRequested = await this.hasChangesRequestedReview(pr.number);
+      if (hasChangesRequested) {
+        state = PrState.CHANGES_REQUESTED;
+      } else {
+        const hasReviewFeedback = await this.hasUnacknowledgedReviews(pr.number);
+        if (hasReviewFeedback) {
+          state = PrState.HAS_COMMENTS;
+        } else {
+          const hasComments = await this.hasConversationComments(pr.number);
+          state = hasComments ? PrState.HAS_COMMENTS : PrState.OPEN;
+        }
+      }
+    }
+
+    const mergeable = pr.mergeable === "CONFLICTING" ? false
+      : pr.mergeable === "MERGEABLE" ? true
+      : undefined;
+
+    return { state, url: pr.url, number: pr.number, title: pr.title, sourceBranch: pr.sourceBranch, mergeable };
   }
 
   /**
@@ -482,11 +559,12 @@ export class GitHubProvider implements IssueProvider {
     } catch { return []; }
   }
 
-  async mergePr(issueId: number): Promise<void> {
-    type OpenPr = { title: string; body: string; headRefName: string; url: string };
-    const prs = await this.findPrsForIssue<OpenPr>(issueId, "open", "title,body,headRefName,url");
-    if (prs.length === 0) throw new Error(`No open PR found for issue #${issueId}`);
-    await this.gh(["pr", "merge", prs[0].url, "--merge"]);
+  async mergePr(issueId: number, opts?: { prUrl?: string; prNumber?: number }): Promise<void> {
+    const prUrl = opts?.prUrl ?? (opts?.prNumber ? (await this.getPrByNumber(opts.prNumber))?.url : null);
+    if (!prUrl) {
+      throw new Error(`Canonical PR identity is required to merge issue #${issueId}.`);
+    }
+    await this.gh(["pr", "merge", prUrl, "--merge"]);
   }
 
   async getPrDiff(issueId: number): Promise<string | null> {
@@ -498,66 +576,67 @@ export class GitHubProvider implements IssueProvider {
     } catch { return null; }
   }
 
-  async getPrReviewComments(issueId: number): Promise<PrReviewComment[]> {
-    type OpenPr = { title: string; body: string; headRefName: string; number: number };
-    const prs = await this.findPrsForIssue<OpenPr>(issueId, "open", "title,body,headRefName,number");
-    if (prs.length === 0) return [];
-    const prNumber = prs[0].number;
+  async getPrDiffByUrl(prUrl: string): Promise<string | null> {
+    const pr = await this.getPrByUrl(prUrl);
+    if (!pr) return null;
+    return await this.gh(["pr", "diff", String(pr.number)]);
+  }
+
+  private async getReviewCommentsForPrNumber(prNumber: number, opts?: { strict?: boolean }): Promise<PrReviewComment[]> {
+    const strict = opts?.strict ?? false;
     const comments: PrReviewComment[] = [];
 
     try {
-      // Review-level comments (top-level reviews: APPROVED, CHANGES_REQUESTED, COMMENTED)
       const reviewsRaw = await this.gh(["api", `repos/:owner/:repo/pulls/${prNumber}/reviews`]);
       const reviews = JSON.parse(reviewsRaw) as Array<{
         id: number; user: { login: string }; body: string; state: string; submitted_at: string;
       }>;
       for (const r of reviews) {
-        if (r.state === "DISMISSED") continue; // Skip dismissed
-        if (!r.body && r.state === "COMMENTED") continue; // Skip empty COMMENTED reviews
-        comments.push({
-          id: r.id,
-          author: r.user.login,
-          body: r.body ?? "",
-          state: r.state,
-          created_at: r.submitted_at,
-        });
+        if (r.state === "DISMISSED") continue;
+        if (!r.body && r.state === "COMMENTED") continue;
+        comments.push({ id: r.id, author: r.user.login, body: r.body ?? "", state: r.state, created_at: r.submitted_at });
       }
-    } catch { /* best-effort */ }
+    } catch (err) {
+      if (strict) throw err;
+    }
 
     try {
-      // Inline (file-level) review comments
       const inlineRaw = await this.gh(["api", `repos/:owner/:repo/pulls/${prNumber}/comments`]);
       const inlines = JSON.parse(inlineRaw) as Array<{
         id: number; user: { login: string }; body: string; path: string; line: number | null; created_at: string;
       }>;
       for (const c of inlines) {
-        comments.push({
-          id: c.id,
-          author: c.user.login,
-          body: c.body,
-          state: "INLINE",
-          created_at: c.created_at,
-          path: c.path,
-          line: c.line ?? undefined,
-        });
+        comments.push({ id: c.id, author: c.user.login, body: c.body, state: "INLINE", created_at: c.created_at, path: c.path, line: c.line ?? undefined });
       }
-    } catch { /* best-effort */ }
-
-    // Top-level conversation comments (regular PR comments via Issues API)
-    const conversationComments = await this.fetchConversationComments(prNumber);
-    for (const c of conversationComments) {
-      comments.push({
-        id: c.id,
-        author: c.user.login,
-        body: c.body,
-        state: "COMMENTED",
-        created_at: c.created_at,
-      });
+    } catch (err) {
+      if (strict) throw err;
     }
 
-    // Sort by date
+    let conversationComments: Array<{ id: number; user: { login: string }; body: string; created_at: string }> = [];
+    try {
+      conversationComments = await this.fetchConversationComments(prNumber);
+    } catch (err) {
+      if (strict) throw err;
+    }
+    for (const c of conversationComments) {
+      comments.push({ id: c.id, author: c.user.login, body: c.body, state: "COMMENTED", created_at: c.created_at });
+    }
+
     comments.sort((a, b) => new Date(a.created_at).getTime() - new Date(b.created_at).getTime());
     return comments;
+  }
+
+  async getPrReviewComments(issueId: number): Promise<PrReviewComment[]> {
+    type OpenPr = { title: string; body: string; headRefName: string; number: number };
+    const prs = await this.findPrsForIssue<OpenPr>(issueId, "open", "title,body,headRefName,number");
+    if (prs.length === 0) return [];
+    return this.getReviewCommentsForPrNumber(prs[0].number);
+  }
+
+  async getPrReviewCommentsByUrl(prUrl: string): Promise<PrReviewComment[]> {
+    const pr = await this.getPrByUrl(prUrl);
+    if (!pr) return [];
+    return this.getReviewCommentsForPrNumber(pr.number, { strict: true });
   }
 
   async addComment(issueId: number, body: string): Promise<number> {

--- a/lib/providers/gitlab.ts
+++ b/lib/providers/gitlab.ts
@@ -6,6 +6,7 @@ import {
   type Issue,
   type StateLabel,
   type IssueComment,
+  type PrIdentity,
   type PrStatus,
   type PrReviewComment,
   PrState,
@@ -37,6 +38,11 @@ export class GitLabProvider implements IssueProvider {
   private workflow: WorkflowConfig;
   private runCommand: RunCommand;
   private targetRepo?: string;
+
+  private isGlabNotFoundError(error: unknown): boolean {
+    const message = error instanceof Error ? error.message : String(error);
+    return message.includes("404") || message.includes("Not Found") || message.includes("Merge request not found");
+  }
 
   constructor(opts: { repoPath: string; runCommand: RunCommand; workflow?: WorkflowConfig; target?: ProviderTarget }) {
     this.repoPath = opts.repoPath;
@@ -195,41 +201,95 @@ export class GitLabProvider implements IssueProvider {
     return merged[0]?.web_url ?? null;
   }
 
+  async getLinkedPrs(issueId: number): Promise<PrIdentity[]> {
+    const mrs = await this.getRelatedMRs(issueId);
+    return mrs.map((mr) => ({ number: mr.iid, url: mr.web_url, title: mr.title, sourceBranch: mr.source_branch, repo: this.targetRepo }));
+  }
+
+  async getPrByUrl(prUrl: string): Promise<PrIdentity | null> {
+    try {
+      const raw = await this.glab(["mr", "view", prUrl, "--output", "json"]);
+      const mr = JSON.parse(raw) as { iid: number; web_url: string; title: string; source_branch?: string };
+      return { number: mr.iid, url: mr.web_url, title: mr.title, sourceBranch: mr.source_branch, repo: this.targetRepo };
+    } catch (err) {
+      if (this.isGlabNotFoundError(err)) return null;
+      throw err;
+    }
+  }
+
+  async getPrByNumber(prNumber: number): Promise<PrIdentity | null> {
+    try {
+      const raw = await this.glab(["mr", "view", String(prNumber), "--output", "json"]);
+      const mr = JSON.parse(raw) as { iid: number; web_url: string; title: string; source_branch?: string };
+      return { number: mr.iid, url: mr.web_url, title: mr.title, sourceBranch: mr.source_branch, repo: this.targetRepo };
+    } catch (err) {
+      if (this.isGlabNotFoundError(err)) return null;
+      throw err;
+    }
+  }
+
   async getPrStatus(issueId: number): Promise<PrStatus> {
     const mrs = await this.getRelatedMRs(issueId);
     // Check open MRs first
     const open = mrs.find((mr) => mr.state === "opened");
     if (open) {
-      const approved = await this.isMrApproved(open.iid);
-
-      // Detect changes requested via unresolved discussion threads
-      let state: PrState;
-      if (approved) {
-        state = PrState.APPROVED;
-      } else {
-        const hasUnresolved = await this.hasUnresolvedDiscussions(open.iid);
-        if (hasUnresolved) {
-          state = PrState.CHANGES_REQUESTED;
-        } else {
-          // Check for top-level conversation comments from non-author users
-          const hasComments = await this.hasConversationComments(open.iid);
-          state = hasComments ? PrState.HAS_COMMENTS : PrState.OPEN;
-        }
-      }
-
-      // Detect merge conflicts
-      const mergeable = await this.isMrMergeable(open.iid);
-
-      return { state, url: open.web_url, title: open.title, sourceBranch: open.source_branch, mergeable };
+      return this.buildOpenMrStatus({
+        iid: open.iid,
+        title: open.title,
+        sourceBranch: open.source_branch,
+        url: open.web_url,
+      });
     }
     // Check merged MRs
     const merged = mrs.find((mr) => mr.state === "merged");
-    if (merged) return { state: PrState.MERGED, url: merged.web_url, title: merged.title, sourceBranch: merged.source_branch };
+    if (merged) return { state: PrState.MERGED, url: merged.web_url, number: merged.iid, title: merged.title, sourceBranch: merged.source_branch };
     // Check for closed-without-merge MRs. url: non-null = MR was explicitly closed;
     // url: null = no MR has ever been created for this issue.
     const closed = mrs.find((mr) => mr.state === "closed");
-    if (closed) return { state: PrState.CLOSED, url: closed.web_url, title: closed.title, sourceBranch: closed.source_branch };
+    if (closed) return { state: PrState.CLOSED, url: closed.web_url, number: closed.iid, title: closed.title, sourceBranch: closed.source_branch };
     return { state: PrState.CLOSED, url: null };
+  }
+
+  async getPrStatusByUrl(prUrl: string): Promise<PrStatus | null> {
+    const pr = await this.getPrByUrl(prUrl);
+    if (!pr) return null;
+    try {
+      const raw = await this.glab(["api", `projects/:id/merge_requests/${pr.number}?include_rebase_in_progress=true`]);
+      const mr = JSON.parse(raw) as { state: string; title?: string; source_branch?: string; web_url?: string };
+      const url = mr.web_url ?? pr.url;
+      const title = mr.title ?? pr.title ?? pr.url;
+      const sourceBranch = mr.source_branch ?? pr.sourceBranch;
+      if (mr.state === "merged") {
+        return { state: PrState.MERGED, url, number: pr.number, title, sourceBranch };
+      }
+      if (mr.state === "closed") {
+        return { state: PrState.CLOSED, url, number: pr.number, title, sourceBranch };
+      }
+      return this.buildOpenMrStatus({ iid: pr.number, title, sourceBranch, url });
+    } catch (err) {
+      if (this.isGlabNotFoundError(err)) return null;
+      throw err;
+    }
+  }
+
+  private async buildOpenMrStatus(pr: { iid: number; title: string; sourceBranch?: string; url: string }): Promise<PrStatus> {
+    const approved = await this.isMrApproved(pr.iid);
+
+    let state: PrState;
+    if (approved) {
+      state = PrState.APPROVED;
+    } else {
+      const hasUnresolved = await this.hasUnresolvedDiscussions(pr.iid);
+      if (hasUnresolved) {
+        state = PrState.CHANGES_REQUESTED;
+      } else {
+        const hasComments = await this.hasConversationComments(pr.iid);
+        state = hasComments ? PrState.HAS_COMMENTS : PrState.OPEN;
+      }
+    }
+
+    const mergeable = await this.isMrMergeable(pr.iid);
+    return { state, url: pr.url, number: pr.iid, title: pr.title, sourceBranch: pr.sourceBranch, mergeable };
   }
 
   /** Check if an MR has unresolved discussion threads (proxy for changes requested). */
@@ -316,11 +376,12 @@ export class GitLabProvider implements IssueProvider {
     } catch { return false; }
   }
 
-  async mergePr(issueId: number): Promise<void> {
-    const mrs = await this.getRelatedMRs(issueId);
-    const open = mrs.find((mr) => mr.state === "opened");
-    if (!open) throw new Error(`No open MR found for issue #${issueId}`);
-    await this.glab(["mr", "merge", String(open.iid)]);
+  async mergePr(issueId: number, opts?: { prUrl?: string; prNumber?: number }): Promise<void> {
+    const explicit = opts?.prNumber ?? (opts?.prUrl ? (await this.getPrByUrl(opts.prUrl))?.number : undefined);
+    if (!explicit) {
+      throw new Error(`Canonical PR identity is required to merge issue #${issueId}.`);
+    }
+    await this.glab(["mr", "merge", String(explicit)]);
   }
 
   async getPrDiff(issueId: number): Promise<string | null> {
@@ -332,14 +393,31 @@ export class GitLabProvider implements IssueProvider {
     } catch { return null; }
   }
 
+  async getPrDiffByUrl(prUrl: string): Promise<string | null> {
+    const pr = await this.getPrByUrl(prUrl);
+    if (!pr) return null;
+    return await this.glab(["mr", "diff", String(pr.number)]);
+  }
+
   async getPrReviewComments(issueId: number): Promise<PrReviewComment[]> {
     const mrs = await this.getRelatedMRs(issueId);
     const open = mrs.find((mr) => mr.state === "opened");
     if (!open) return [];
+    return this.getReviewCommentsForMrIid(open.iid);
+  }
+
+  async getPrReviewCommentsByUrl(prUrl: string): Promise<PrReviewComment[]> {
+    const pr = await this.getPrByUrl(prUrl);
+    if (!pr) return [];
+    return this.getReviewCommentsForMrIid(pr.number, { strict: true });
+  }
+
+  private async getReviewCommentsForMrIid(mrIid: number, opts?: { strict?: boolean }): Promise<PrReviewComment[]> {
+    const strict = opts?.strict ?? false;
     const comments: PrReviewComment[] = [];
 
     try {
-      const raw = await this.glab(["api", `projects/:id/merge_requests/${open.iid}/discussions`]);
+      const raw = await this.glab(["api", `projects/:id/merge_requests/${mrIid}/discussions`]);
       const discussions = JSON.parse(raw) as Array<{
         notes: Array<{
           id: number; author: { username: string }; body: string;
@@ -362,12 +440,17 @@ export class GitLabProvider implements IssueProvider {
           });
         }
       }
-    } catch { /* best-effort */ }
+    } catch (err) {
+      if (strict) throw err;
+    }
 
-    // Also include top-level conversation notes (regular MR comments, not threaded)
-    const conversationNotes = await this.fetchConversationComments(open.iid);
+    let conversationNotes: Array<{ id: number; author: { username: string }; body: string; created_at: string }> = [];
+    try {
+      conversationNotes = await this.fetchConversationComments(mrIid);
+    } catch (err) {
+      if (strict) throw err;
+    }
     for (const n of conversationNotes) {
-      // Avoid duplicates: discussions endpoint may already include these
       if (!comments.some((c) => c.id === n.id)) {
         comments.push({
           id: n.id,

--- a/lib/providers/provider-pr-status.test.ts
+++ b/lib/providers/provider-pr-status.test.ts
@@ -6,7 +6,7 @@
  *
  * Run with: npx tsx --test lib/providers/provider-pr-status.test.ts
  */
-import { describe, it, mock } from "node:test";
+import { describe, it } from "node:test";
 import assert from "node:assert";
 import type { RunCommand } from "../context.js";
 import { GitHubProvider } from "./github.js";
@@ -26,7 +26,6 @@ describe("GitHubProvider.getPrStatus — closed PR handling", () => {
   it("returns url:null when no PR has ever been created", async () => {
     const provider = new GitHubProvider({ repoPath: "/fake", runCommand: mockRunCommand });
 
-    // findPrsForIssue returns [] for open and merged, findPrsViaTimeline returns null (GraphQL unavailable)
     (provider as any).findPrsForIssue = async () => [];
     (provider as any).findPrsViaTimeline = async () => null;
 
@@ -103,7 +102,6 @@ describe("GitHubProvider.getPrStatus — closed PR handling", () => {
       }
       return [];
     };
-    // Simulate no changes-requested reviews and no comments
     (provider as any).hasChangesRequestedReview = async () => false;
     (provider as any).hasUnacknowledgedReviews = async () => false;
     (provider as any).hasConversationComments = async () => false;
@@ -146,7 +144,6 @@ describe("GitHubProvider.getPrStatus — closed PR handling", () => {
     const provider = new GitHubProvider({ repoPath: "/fake", runCommand: mockRunCommand });
 
     (provider as any).findPrsForIssue = async () => [];
-    // Timeline has only OPEN PRs — none should trigger closed-PR path
     (provider as any).findPrsViaTimeline = async (_id: number, state: string) => {
       if (state === "all") {
         return [{ number: 10, title: "", body: "", headRefName: "", url: "https://github.com/owner/repo/pull/10", mergedAt: null, reviewDecision: null, state: "OPEN", mergeable: null }];
@@ -156,8 +153,6 @@ describe("GitHubProvider.getPrStatus — closed PR handling", () => {
 
     const status = await provider.getPrStatus(42);
 
-    // OPEN PR in timeline but findPrsForIssue("open") returned [] → shouldn't reach here normally,
-    // but the CLOSED fallback path should not pick it up.
     assert.strictEqual(status.state, PrState.CLOSED);
     assert.strictEqual(status.url, null, "OPEN state in timeline should not match closed-PR path");
   });
@@ -183,7 +178,6 @@ describe("GitHubProvider.getPrStatus — closed PR handling", () => {
       }
       return [];
     };
-    // Simulate no changes-requested reviews and no comments
     (provider as any).hasChangesRequestedReview = async () => false;
     (provider as any).hasUnacknowledgedReviews = async () => false;
     (provider as any).hasConversationComments = async () => false;
@@ -257,6 +251,92 @@ describe("GitHubProvider.getPrStatus — closed PR handling", () => {
     assert.strictEqual(status.state, PrState.OPEN);
     assert.strictEqual(status.url, unknownPrUrl);
     assert.strictEqual(status.mergeable, undefined, "mergeable: UNKNOWN should remain undefined (no assumption)");
+  });
+});
+
+describe("GitHubProvider.getPrStatusByUrl", () => {
+  it("preserves comment-only feedback semantics for canonical PR routing", async () => {
+    const provider = new GitHubProvider({ repoPath: "/fake", runCommand: mockRunCommand });
+
+    (provider as any).gh = async () => JSON.stringify({
+      number: 44,
+      title: "feat: canonical pr",
+      headRefName: "issue/244-canonical-pr-ledger",
+      url: "https://github.com/owner/repo/pull/44",
+      state: "OPEN",
+      reviewDecision: null,
+      mergeable: "MERGEABLE",
+    });
+    (provider as any).hasChangesRequestedReview = async () => false;
+    (provider as any).hasUnacknowledgedReviews = async () => true;
+    (provider as any).hasConversationComments = async () => false;
+
+    const status = await provider.getPrStatusByUrl("https://github.com/owner/repo/pull/44");
+
+    assert.ok(status);
+    assert.strictEqual(status.state, PrState.HAS_COMMENTS);
+    assert.strictEqual(status.mergeable, true);
+  });
+
+  it("preserves changes-requested fallback when reviewDecision is empty", async () => {
+    const provider = new GitHubProvider({ repoPath: "/fake", runCommand: mockRunCommand });
+
+    (provider as any).gh = async () => JSON.stringify({
+      number: 45,
+      title: "feat: canonical pr",
+      headRefName: "issue/244-canonical-pr-ledger",
+      url: "https://github.com/owner/repo/pull/45",
+      state: "OPEN",
+      reviewDecision: null,
+      mergeable: "UNKNOWN",
+    });
+    (provider as any).hasChangesRequestedReview = async () => true;
+    (provider as any).hasUnacknowledgedReviews = async () => false;
+    (provider as any).hasConversationComments = async () => false;
+
+    const status = await provider.getPrStatusByUrl("https://github.com/owner/repo/pull/45");
+
+    assert.ok(status);
+    assert.strictEqual(status.state, PrState.CHANGES_REQUESTED);
+    assert.strictEqual(status.mergeable, undefined);
+  });
+});
+
+describe("GitHubProvider canonical URL helpers", () => {
+  it("throws when diff lookup fails after PR identity resolves", async () => {
+    const provider = new GitHubProvider({ repoPath: "/fake", runCommand: mockRunCommand });
+    (provider as any).getPrByUrl = async () => ({
+      number: 46,
+      url: "https://github.com/owner/repo/pull/46",
+      title: "feat: canonical pr",
+      sourceBranch: "issue/244-canonical-pr-ledger",
+    });
+    (provider as any).gh = async () => {
+      throw new Error("gh diff failed");
+    };
+
+    await assert.rejects(
+      provider.getPrDiffByUrl("https://github.com/owner/repo/pull/46"),
+      /gh diff failed/,
+    );
+  });
+
+  it("throws when review comment retrieval fails after PR identity resolves", async () => {
+    const provider = new GitHubProvider({ repoPath: "/fake", runCommand: mockRunCommand });
+    (provider as any).getPrByUrl = async () => ({
+      number: 47,
+      url: "https://github.com/owner/repo/pull/47",
+      title: "feat: canonical pr",
+      sourceBranch: "issue/244-canonical-pr-ledger",
+    });
+    (provider as any).gh = async () => {
+      throw new Error("gh reviews failed");
+    };
+
+    await assert.rejects(
+      provider.getPrReviewCommentsByUrl("https://github.com/owner/repo/pull/47"),
+      /gh reviews failed/,
+    );
   });
 });
 
@@ -352,7 +432,168 @@ describe("GitLabProvider.getPrStatus — closed MR handling", () => {
     const status = await provider.getPrStatus(42);
 
     assert.strictEqual(status.state, PrState.CLOSED);
-    // First closed MR found is returned
     assert.strictEqual(status.url, closedMrUrl1);
+  });
+});
+
+describe("GitLabProvider.getPrStatusByUrl", () => {
+  it("preserves comment-driven feedback semantics for canonical MR routing", async () => {
+    const provider = new GitLabProvider({ repoPath: "/fake", runCommand: mockRunCommand });
+
+    (provider as any).getPrByUrl = async () => ({
+      number: 24,
+      url: "https://gitlab.com/owner/repo/-/merge_requests/24",
+      title: "feat: canonical mr",
+      sourceBranch: "issue/244-canonical-pr-ledger",
+    });
+    (provider as any).glab = async () => JSON.stringify({
+      state: "opened",
+      title: "feat: canonical mr",
+      source_branch: "issue/244-canonical-pr-ledger",
+      web_url: "https://gitlab.com/owner/repo/-/merge_requests/24",
+    });
+    (provider as any).isMrApproved = async () => false;
+    (provider as any).hasUnresolvedDiscussions = async () => false;
+    (provider as any).hasConversationComments = async () => true;
+    (provider as any).isMrMergeable = async () => true;
+
+    const status = await provider.getPrStatusByUrl("https://gitlab.com/owner/repo/-/merge_requests/24");
+
+    assert.ok(status);
+    assert.strictEqual(status.state, PrState.HAS_COMMENTS);
+    assert.strictEqual(status.mergeable, true);
+  });
+
+  it("preserves unresolved-discussion changes-requested semantics", async () => {
+    const provider = new GitLabProvider({ repoPath: "/fake", runCommand: mockRunCommand });
+
+    (provider as any).getPrByUrl = async () => ({
+      number: 25,
+      url: "https://gitlab.com/owner/repo/-/merge_requests/25",
+      title: "feat: canonical mr",
+      sourceBranch: "issue/244-canonical-pr-ledger",
+    });
+    (provider as any).glab = async () => JSON.stringify({
+      state: "opened",
+      title: "feat: canonical mr",
+      source_branch: "issue/244-canonical-pr-ledger",
+      web_url: "https://gitlab.com/owner/repo/-/merge_requests/25",
+    });
+    (provider as any).isMrApproved = async () => false;
+    (provider as any).hasUnresolvedDiscussions = async () => true;
+    (provider as any).hasConversationComments = async () => false;
+    (provider as any).isMrMergeable = async () => undefined;
+
+    const status = await provider.getPrStatusByUrl("https://gitlab.com/owner/repo/-/merge_requests/25");
+
+    assert.ok(status);
+    assert.strictEqual(status.state, PrState.CHANGES_REQUESTED);
+    assert.strictEqual(status.mergeable, undefined);
+  });
+});
+
+describe("GitLabProvider.getPrReviewCommentsByUrl", () => {
+  it("reuses canonical MR comment retrieval semantics", async () => {
+    const provider = new GitLabProvider({ repoPath: "/fake", runCommand: mockRunCommand });
+
+    (provider as any).getPrByUrl = async () => ({
+      number: 26,
+      url: "https://gitlab.com/owner/repo/-/merge_requests/26",
+      title: "feat: canonical mr",
+      sourceBranch: "issue/244-canonical-pr-ledger",
+    });
+    (provider as any).glab = async ([, path]: string[]) => {
+      if (path === "projects/:id/merge_requests/26/discussions") {
+        return JSON.stringify([
+          {
+            notes: [
+              {
+                id: 101,
+                author: { username: "reviewer" },
+                body: "Please tighten this up",
+                resolvable: true,
+                resolved: false,
+                system: false,
+                created_at: "2026-05-31T00:00:00Z",
+                position: { new_path: "lib/providers/gitlab.ts", new_line: 451 },
+              },
+            ],
+          },
+        ]);
+      }
+      if (path === "projects/:id/merge_requests/26/notes") {
+        return JSON.stringify([
+          {
+            id: 102,
+            author: { username: "reviewer" },
+            system: false,
+            body: "Top-level follow-up",
+            created_at: "2026-05-31T00:01:00Z",
+          },
+        ]);
+      }
+      throw new Error(`unexpected glab path: ${path}`);
+    };
+
+    const comments = await provider.getPrReviewCommentsByUrl("https://gitlab.com/owner/repo/-/merge_requests/26");
+
+    assert.deepStrictEqual(comments, [
+      {
+        id: 101,
+        author: "reviewer",
+        body: "Please tighten this up",
+        state: "UNRESOLVED",
+        created_at: "2026-05-31T00:00:00Z",
+        path: "lib/providers/gitlab.ts",
+        line: 451,
+      },
+      {
+        id: 102,
+        author: "reviewer",
+        body: "Top-level follow-up",
+        state: "COMMENTED",
+        created_at: "2026-05-31T00:01:00Z",
+      },
+    ]);
+  });
+
+  it("throws when canonical MR comment retrieval fails after identity resolution", async () => {
+    const provider = new GitLabProvider({ repoPath: "/fake", runCommand: mockRunCommand });
+
+    (provider as any).getPrByUrl = async () => ({
+      number: 27,
+      url: "https://gitlab.com/owner/repo/-/merge_requests/27",
+      title: "feat: canonical mr",
+      sourceBranch: "issue/244-canonical-pr-ledger",
+    });
+    (provider as any).glab = async () => {
+      throw new Error("glab discussions failed");
+    };
+
+    await assert.rejects(
+      provider.getPrReviewCommentsByUrl("https://gitlab.com/owner/repo/-/merge_requests/27"),
+      /glab discussions failed/,
+    );
+  });
+});
+
+describe("GitLabProvider canonical URL helpers", () => {
+  it("throws when diff lookup fails after MR identity resolves", async () => {
+    const provider = new GitLabProvider({ repoPath: "/fake", runCommand: mockRunCommand });
+
+    (provider as any).getPrByUrl = async () => ({
+      number: 28,
+      url: "https://gitlab.com/owner/repo/-/merge_requests/28",
+      title: "feat: canonical mr",
+      sourceBranch: "issue/244-canonical-pr-ledger",
+    });
+    (provider as any).glab = async () => {
+      throw new Error("glab diff failed");
+    };
+
+    await assert.rejects(
+      provider.getPrDiffByUrl("https://gitlab.com/owner/repo/-/merge_requests/28"),
+      /glab diff failed/,
+    );
   });
 });

--- a/lib/providers/provider.ts
+++ b/lib/providers/provider.ts
@@ -44,12 +44,22 @@ export type PrState = (typeof PrState)[keyof typeof PrState];
 export type PrStatus = {
   state: PrState;
   url: string | null;
+  /** Provider-native PR/MR number or IID. */
+  number?: number;
   /** MR/PR title (e.g. "feat: add login page"). */
   title?: string;
   /** Source branch name (e.g. "feature/7-blog-cms"). */
   sourceBranch?: string;
   /** false = has merge conflicts. undefined = unknown or not applicable. */
   mergeable?: boolean;
+};
+
+export type PrIdentity = {
+  number: number;
+  url: string;
+  title?: string;
+  sourceBranch?: string;
+  repo?: string;
 };
 
 /** A review comment on a PR/MR. */
@@ -86,10 +96,16 @@ export interface IssueProvider {
   reopenIssue(issueId: number): Promise<void>;
   getMergedMRUrl(issueId: number): Promise<string | null>;
   getPrStatus(issueId: number): Promise<PrStatus>;
-  mergePr(issueId: number): Promise<void>;
+  getLinkedPrs(issueId: number): Promise<PrIdentity[]>;
+  getPrByUrl(prUrl: string): Promise<PrIdentity | null>;
+  getPrByNumber(prNumber: number): Promise<PrIdentity | null>;
+  getPrStatusByUrl(prUrl: string): Promise<PrStatus | null>;
+  mergePr(issueId: number, opts?: { prUrl?: string; prNumber?: number }): Promise<void>;
   getPrDiff(issueId: number): Promise<string | null>;
+  getPrDiffByUrl(prUrl: string): Promise<string | null>;
   /** Get review comments on the PR linked to an issue. */
   getPrReviewComments(issueId: number): Promise<PrReviewComment[]>;
+  getPrReviewCommentsByUrl(prUrl: string): Promise<PrReviewComment[]>;
   /**
    * Check if work for an issue is already present on the base branch via git history.
    * Used as a fallback when no PR exists (e.g., work committed directly to main).

--- a/lib/services/canonical-pr.test.ts
+++ b/lib/services/canonical-pr.test.ts
@@ -1,0 +1,135 @@
+import { afterEach, describe, it } from "node:test";
+import assert from "node:assert";
+import { mkdtemp, rm } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { PrState } from "../providers/provider.js";
+import { TestProvider } from "../testing/test-provider.js";
+import { loadCanonicalPrRecord, recordCanonicalPr, refreshCanonicalPrStatus, resolveCanonicalPrForIssue } from "./canonical-pr.js";
+
+const temps: string[] = [];
+
+async function makeWorkspace(): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), "canonical-pr-test-"));
+  temps.push(dir);
+  return dir;
+}
+
+afterEach(async () => {
+  await Promise.all(temps.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+});
+
+describe("canonical-pr ledger", () => {
+  it("records superseded canonical PRs when a replacement is recorded", async () => {
+    const workspaceDir = await makeWorkspace();
+
+    await recordCanonicalPr(workspaceDir, "test-project", 244, {
+      number: 245,
+      url: "https://example.com/pr/245",
+      sourceBranch: "issue/244-canonical-pr-ledger",
+      repo: "owner/repo",
+    }, PrState.OPEN);
+
+    const replacement = await recordCanonicalPr(workspaceDir, "test-project", 244, {
+      number: 246,
+      url: "https://example.com/pr/246",
+      sourceBranch: "issue/244-canonical-pr-ledger-v2",
+      repo: "owner/repo",
+    }, PrState.OPEN);
+
+    assert.equal(replacement.url, "https://example.com/pr/246");
+    assert.equal(replacement.supersededPrs.length, 1);
+    assert.equal(replacement.supersededPrs[0]?.url, "https://example.com/pr/245");
+    assert.equal(replacement.supersededPrs[0]?.reason, "replacement");
+  });
+
+  it("refreshes canonical PR status without clobbering supersession history", async () => {
+    const workspaceDir = await makeWorkspace();
+
+    await recordCanonicalPr(workspaceDir, "test-project", 244, {
+      number: 245,
+      url: "https://example.com/pr/245",
+      sourceBranch: "issue/244-canonical-pr-ledger",
+      repo: "owner/repo",
+    }, PrState.OPEN);
+    await recordCanonicalPr(workspaceDir, "test-project", 244, {
+      number: 246,
+      url: "https://example.com/pr/246",
+      sourceBranch: "issue/244-canonical-pr-ledger-v2",
+      repo: "owner/repo",
+    }, PrState.OPEN);
+
+    const refreshed = await refreshCanonicalPrStatus(workspaceDir, "test-project", 244, {
+      state: PrState.APPROVED,
+      url: "https://example.com/pr/246",
+      number: 246,
+      sourceBranch: "issue/244-canonical-pr-ledger-v2",
+    });
+
+    assert.equal(refreshed?.status, PrState.APPROVED);
+    assert.equal(refreshed?.supersededPrs.length, 1);
+    assert.equal(refreshed?.supersededPrs[0]?.url, "https://example.com/pr/245");
+  });
+
+  it("serializes concurrent updates so replacement and refresh do not lose data", async () => {
+    const workspaceDir = await makeWorkspace();
+
+    await recordCanonicalPr(workspaceDir, "test-project", 244, {
+      number: 245,
+      url: "https://example.com/pr/245",
+      sourceBranch: "issue/244-a",
+      repo: "owner/repo",
+    }, PrState.OPEN);
+
+    await Promise.all([
+      refreshCanonicalPrStatus(workspaceDir, "test-project", 244, {
+        state: PrState.CHANGES_REQUESTED,
+        url: "https://example.com/pr/245",
+        number: 245,
+        sourceBranch: "issue/244-a",
+      }),
+      recordCanonicalPr(workspaceDir, "test-project", 244, {
+        number: 246,
+        url: "https://example.com/pr/246",
+        sourceBranch: "issue/244-b",
+        repo: "owner/repo",
+      }, PrState.OPEN),
+    ]);
+
+    const record = await loadCanonicalPrRecord(workspaceDir, "test-project", 244);
+    assert.ok(record);
+    assert.equal(record?.url, "https://example.com/pr/246");
+    assert.equal(record?.supersededPrs.length, 1);
+    assert.equal(record?.supersededPrs[0]?.url, "https://example.com/pr/245");
+  });
+
+  it("fails closed when stored canonical PR is no longer linked to the issue", async () => {
+    const workspaceDir = await makeWorkspace();
+    const provider = new TestProvider();
+
+    await recordCanonicalPr(workspaceDir, "test-project", 244, {
+      number: 245,
+      url: "https://example.com/pr/245",
+      sourceBranch: "issue/244-a",
+      repo: "owner/repo",
+    }, PrState.OPEN);
+
+    provider.setLinkedPrs(244, [{
+      number: 246,
+      url: "https://example.com/pr/246",
+      sourceBranch: "issue/244-b",
+      repo: "owner/repo",
+    }]);
+    provider.prStatuses.set(244, {
+      state: PrState.OPEN,
+      url: "https://example.com/pr/246",
+      number: 246,
+      sourceBranch: "issue/244-b",
+    });
+
+    await assert.rejects(
+      resolveCanonicalPrForIssue({ workspaceDir, projectSlug: "test-project", issueId: 244, provider }),
+      /stored PR .* is not in the issue's current linked PR set/,
+    );
+  });
+});

--- a/lib/services/canonical-pr.ts
+++ b/lib/services/canonical-pr.ts
@@ -1,0 +1,271 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { DATA_DIR } from "../setup/migrate-layout.js";
+import type { IssueProvider, PrIdentity, PrStatus } from "../providers/provider.js";
+
+export type CanonicalPrRecord = {
+  issueId: number;
+  number: number;
+  url: string;
+  sourceBranch?: string;
+  repo?: string;
+  status: PrStatus["state"];
+  updatedAt: string;
+  supersededPrs: Array<{
+    number: number;
+    url: string;
+    sourceBranch?: string;
+    repo?: string;
+    supersededAt: string;
+    reason: "replacement" | "reconciliation";
+  }>;
+};
+
+type CanonicalPrStore = {
+  issues: Record<string, CanonicalPrRecord>;
+};
+
+const LOCK_RETRY_MS = 50;
+const LOCK_TIMEOUT_MS = 5_000;
+
+type CanonicalPrMutationResult<T> = {
+  store: CanonicalPrStore;
+  result: T;
+};
+
+function storePath(workspaceDir: string, projectSlug: string): string {
+  return path.join(workspaceDir, DATA_DIR, "pr-ledger", `${projectSlug}.json`);
+}
+
+function lockPath(workspaceDir: string, projectSlug: string): string {
+  return `${storePath(workspaceDir, projectSlug)}.lock`;
+}
+
+async function readStore(workspaceDir: string, projectSlug: string): Promise<CanonicalPrStore> {
+  const filePath = storePath(workspaceDir, projectSlug);
+  try {
+    const raw = await fs.readFile(filePath, "utf-8");
+    const parsed = JSON.parse(raw) as Partial<CanonicalPrStore>;
+    return { issues: parsed.issues ?? {} };
+  } catch {
+    return { issues: {} };
+  }
+}
+
+async function writeStore(workspaceDir: string, projectSlug: string, store: CanonicalPrStore): Promise<void> {
+  const filePath = storePath(workspaceDir, projectSlug);
+  await fs.mkdir(path.dirname(filePath), { recursive: true });
+  const tmpPath = `${filePath}.tmp`;
+  await fs.writeFile(tmpPath, JSON.stringify(store, null, 2) + "\n", "utf-8");
+  await fs.rename(tmpPath, filePath);
+}
+
+async function sleep(ms: number): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function acquireStoreLock(workspaceDir: string, projectSlug: string): Promise<() => Promise<void>> {
+  const filePath = storePath(workspaceDir, projectSlug);
+  const dir = path.dirname(filePath);
+  const lockDir = lockPath(workspaceDir, projectSlug);
+  const deadline = Date.now() + LOCK_TIMEOUT_MS;
+
+  await fs.mkdir(dir, { recursive: true });
+
+  while (true) {
+    try {
+      await fs.mkdir(lockDir);
+      await fs.writeFile(path.join(lockDir, "owner"), JSON.stringify({ pid: process.pid, acquiredAt: new Date().toISOString() }) + "\n", "utf-8");
+      return async () => {
+        await fs.rm(lockDir, { recursive: true, force: true });
+      };
+    } catch (err) {
+      const code = (err as NodeJS.ErrnoException).code;
+      if (code !== "EEXIST") throw err;
+      if (Date.now() >= deadline) {
+        throw new Error(`Timed out acquiring canonical PR ledger lock for project ${projectSlug}.`);
+      }
+      await sleep(LOCK_RETRY_MS);
+    }
+  }
+}
+
+async function mutateStore<T>(
+  workspaceDir: string,
+  projectSlug: string,
+  mutate: (store: CanonicalPrStore) => CanonicalPrMutationResult<T>,
+): Promise<T> {
+  const release = await acquireStoreLock(workspaceDir, projectSlug);
+  try {
+    const store = await readStore(workspaceDir, projectSlug);
+    const { store: nextStore, result } = mutate(store);
+    await writeStore(workspaceDir, projectSlug, nextStore);
+    return result;
+  } finally {
+    await release();
+  }
+}
+
+export async function loadCanonicalPrRecord(
+  workspaceDir: string,
+  projectSlug: string,
+  issueId: number,
+): Promise<CanonicalPrRecord | null> {
+  const store = await readStore(workspaceDir, projectSlug);
+  return store.issues[String(issueId)] ?? null;
+}
+
+export async function saveCanonicalPrRecord(
+  workspaceDir: string,
+  projectSlug: string,
+  record: CanonicalPrRecord,
+): Promise<void> {
+  await mutateStore(workspaceDir, projectSlug, (store) => {
+    store.issues[String(record.issueId)] = record;
+    return { store, result: undefined };
+  });
+}
+
+function samePr(a: { url?: string; number?: number }, b: { url?: string; number?: number }): boolean {
+  return (!!a.url && !!b.url && a.url === b.url) || (!!a.number && !!b.number && a.number === b.number);
+}
+
+function toRecord(issueId: number, pr: PrIdentity, status: PrStatus["state"], previous?: CanonicalPrRecord): CanonicalPrRecord {
+  const now = new Date().toISOString();
+  const supersededPrs = [...(previous?.supersededPrs ?? [])];
+  if (previous && !samePr(previous, pr)) {
+    supersededPrs.push({
+      number: previous.number,
+      url: previous.url,
+      sourceBranch: previous.sourceBranch,
+      repo: previous.repo,
+      supersededAt: now,
+      reason: "replacement",
+    });
+  }
+  return {
+    issueId,
+    number: pr.number,
+    url: pr.url,
+    sourceBranch: pr.sourceBranch,
+    repo: pr.repo,
+    status,
+    updatedAt: now,
+    supersededPrs,
+  };
+}
+
+export async function recordCanonicalPr(
+  workspaceDir: string,
+  projectSlug: string,
+  issueId: number,
+  pr: PrIdentity,
+  status: PrStatus["state"],
+): Promise<CanonicalPrRecord> {
+  return mutateStore(workspaceDir, projectSlug, (store) => {
+    const previous = store.issues[String(issueId)];
+    const next = toRecord(issueId, pr, status, previous);
+    store.issues[String(issueId)] = next;
+    return { store, result: next };
+  });
+}
+
+export async function refreshCanonicalPrStatus(
+  workspaceDir: string,
+  projectSlug: string,
+  issueId: number,
+  status: PrStatus,
+): Promise<CanonicalPrRecord | null> {
+  return mutateStore(workspaceDir, projectSlug, (store) => {
+    const existing = store.issues[String(issueId)];
+    if (!existing) return { store, result: null };
+    const updated: CanonicalPrRecord = {
+      ...existing,
+      status: status.state,
+      updatedAt: new Date().toISOString(),
+      sourceBranch: status.sourceBranch ?? existing.sourceBranch,
+      number: status.number ?? existing.number,
+    };
+    store.issues[String(issueId)] = updated;
+    return { store, result: updated };
+  });
+}
+
+export async function resolveCanonicalPrForIssue(opts: {
+  workspaceDir: string;
+  projectSlug: string;
+  issueId: number;
+  provider: IssueProvider;
+  allowBackfill?: boolean;
+}): Promise<CanonicalPrRecord> {
+  const { workspaceDir, projectSlug, issueId, provider, allowBackfill = true } = opts;
+  const existing = await loadCanonicalPrRecord(workspaceDir, projectSlug, issueId);
+  const linked = await provider.getLinkedPrs(issueId);
+
+  if (existing) {
+    if (linked.length === 0) {
+      throw new Error(`Canonical PR routing integrity failure for issue #${issueId}: stored PR ${existing.url} is no longer linked to the issue.`);
+    }
+    const stillLinked = linked.some((pr) => samePr(pr, existing));
+    if (!stillLinked) {
+      const linkedSummary = linked.map((pr) => pr.url).join(", ");
+      throw new Error(`Canonical PR routing integrity failure for issue #${issueId}: stored PR ${existing.url} is not in the issue's current linked PR set (${linkedSummary}).`);
+    }
+    const status = await provider.getPrStatusByUrl(existing.url);
+    if (!status) {
+      throw new Error(`Canonical PR routing integrity failure for issue #${issueId}: stored PR ${existing.url} no longer resolves.`);
+    }
+    return (await refreshCanonicalPrStatus(workspaceDir, projectSlug, issueId, status)) ?? existing;
+  }
+
+  if (linked.length !== 1 || !allowBackfill) {
+    const summary = linked.length === 0 ? "no linked PR found" : `${linked.length} linked PRs found`;
+    throw new Error(`Canonical PR routing integrity failure for issue #${issueId}: ${summary}. Operator must set or recreate a single canonical PR.`);
+  }
+
+  const status = await provider.getPrStatusByUrl(linked[0]!.url);
+  if (!status) {
+    throw new Error(`Canonical PR routing integrity failure for issue #${issueId}: linked PR ${linked[0]!.url} could not be resolved.`);
+  }
+  return recordCanonicalPr(workspaceDir, projectSlug, issueId, linked[0]!, status.state);
+}
+
+export async function resolveDeveloperCanonicalPr(opts: {
+  workspaceDir: string;
+  projectSlug: string;
+  issueId: number;
+  provider: IssueProvider;
+  explicitPrUrl?: string;
+}): Promise<CanonicalPrRecord> {
+  const { workspaceDir, projectSlug, issueId, provider, explicitPrUrl } = opts;
+  const linked = await provider.getLinkedPrs(issueId);
+  if (linked.length === 0) {
+    throw new Error(`Cannot mark work_finish(done) without an open PR. No PR is linked to issue #${issueId}.`);
+  }
+
+  let chosen: PrIdentity | null = null;
+  if (explicitPrUrl) {
+    chosen = linked.find((pr) => pr.url === explicitPrUrl) ?? await provider.getPrByUrl(explicitPrUrl);
+    if (!chosen || !linked.some((pr) => samePr(pr, chosen!))) {
+      throw new Error(`Canonical PR routing is ambiguous for issue #${issueId}: explicit prUrl ${explicitPrUrl} is not one of the issue-linked PRs.`);
+    }
+  } else if (linked.length === 1) {
+    chosen = linked[0]!;
+  } else {
+    throw new Error(`Canonical PR routing is ambiguous for issue #${issueId}: ${linked.length} linked PRs exist and no explicit prUrl was provided.`);
+  }
+
+  const existing = await loadCanonicalPrRecord(workspaceDir, projectSlug, issueId);
+  if (existing && !samePr(existing, chosen)) {
+    if (!explicitPrUrl) {
+      throw new Error(`Canonical PR routing is ambiguous for issue #${issueId}: existing canonical PR ${existing.url} differs from the newly discovered PR ${chosen.url}. Provide prUrl explicitly to supersede it.`);
+    }
+  }
+
+  const status = await provider.getPrStatusByUrl(chosen.url);
+  if (!status) {
+    throw new Error(`Canonical PR routing integrity failure for issue #${issueId}: ${chosen.url} could not be resolved.`);
+  }
+
+  return recordCanonicalPr(workspaceDir, projectSlug, issueId, chosen, status.state);
+}

--- a/lib/services/heartbeat/review.ts
+++ b/lib/services/heartbeat/review.ts
@@ -109,8 +109,32 @@ export async function reviewPass(opts: {
         });
         continue;
       }
-      const status = await provider.getPrStatusByUrl(canonical.url);
-      if (!status) continue;
+      let status = await provider.getPrStatusByUrl(canonical.url);
+      if (!status) {
+        const message = `Canonical PR routing integrity failure for issue #${issue.iid}: stored PR ${canonical.url} no longer resolves during review heartbeat.`;
+        const refiningLabel = findRefiningLabel(workflow);
+        if (refiningLabel && refiningLabel !== state.label) {
+          await provider.addComment(issue.iid, buildRefiningHoldComment({
+            role: "reviewer",
+            result: "blocked",
+            from: state.label,
+            to: refiningLabel,
+            summary: message,
+            source: "system",
+          }));
+          await provider.transitionLabel(issue.iid, state.label, refiningLabel);
+          transitions++;
+        }
+        await auditLog(workspaceDir, "review_transition", {
+          project: projectName,
+          issueId: issue.iid,
+          from: state.label,
+          to: refiningLabel ?? state.label,
+          reason: "canonical_pr_status_missing",
+          error: message,
+        });
+        continue;
+      }
       await refreshCanonicalPrStatus(workspaceDir, projectSlug, issue.iid, status).catch(() => {});
 
       // Fallback: no PR found, but work may have been committed directly to base branch.

--- a/lib/services/heartbeat/review.ts
+++ b/lib/services/heartbeat/review.ts
@@ -20,6 +20,15 @@ import type { RunCommand } from "../../context.js";
 import { log as auditLog } from "../../audit.js";
 import { recordLoopDiagnostic } from "../loop-diagnostics.js";
 import { recordAndApplyInterventionEvent } from "../../orchestrator-intervention/engine.js";
+import { loadCanonicalPrRecord, resolveCanonicalPrForIssue, refreshCanonicalPrStatus } from "../canonical-pr.js";
+import { buildRefiningHoldComment } from "../pipeline.js";
+
+function findRefiningLabel(workflow: WorkflowConfig): string | null {
+  for (const state of Object.values(workflow.states)) {
+    if (state.label === "Refining") return state.label;
+  }
+  return null;
+}
 
 /**
  * Scan review-type states and transition issues whose PR check condition is met.
@@ -71,7 +80,38 @@ export async function reviewPass(opts: {
       const isManaged = await provider.issueHasReaction(issue.iid, "eyes");
       if (!isManaged) continue;
 
-      const status = await provider.getPrStatus(issue.iid);
+      let canonical;
+      const projectSlug = project?.slug ?? projectName;
+      const existingCanonical = await loadCanonicalPrRecord(workspaceDir, projectSlug, issue.iid);
+      const linkedPrs = await provider.getLinkedPrs(issue.iid);
+      if (!existingCanonical && linkedPrs.length === 0) {
+        continue;
+      }
+      try {
+        canonical = await resolveCanonicalPrForIssue({ workspaceDir, projectSlug, issueId: issue.iid, provider });
+      } catch (err) {
+        const refiningLabel = findRefiningLabel(workflow);
+        if (refiningLabel && refiningLabel !== state.label) {
+          await provider.addComment(issue.iid, buildRefiningHoldComment({
+            role: "reviewer",
+            result: "blocked",
+            from: state.label,
+            to: refiningLabel,
+            summary: `Canonical PR routing integrity failed during review heartbeat: ${(err as Error).message ?? String(err)}`,
+            source: "system",
+          }));
+          await provider.transitionLabel(issue.iid, state.label, refiningLabel);
+          transitions++;
+        }
+        await auditLog(workspaceDir, "review_transition", {
+          project: projectName, issueId: issue.iid, from: state.label, to: refiningLabel ?? state.label,
+          reason: "canonical_pr_missing_or_ambiguous", error: (err as Error).message ?? String(err),
+        });
+        continue;
+      }
+      const status = await provider.getPrStatusByUrl(canonical.url);
+      if (!status) continue;
+      await refreshCanonicalPrStatus(workspaceDir, projectSlug, issue.iid, status).catch(() => {});
 
       // Fallback: no PR found, but work may have been committed directly to base branch.
       // Check git history for commits mentioning this issue number.
@@ -274,7 +314,11 @@ export async function reviewPass(opts: {
                 break;
               }
               try {
-                await provider.mergePr(issue.iid);
+                const latestCanonical = await resolveCanonicalPrForIssue({ workspaceDir, projectSlug, issueId: issue.iid, provider });
+                if (latestCanonical.url !== canonical.url) {
+                  throw new Error(`Canonical PR changed after approval for issue #${issue.iid}: approved ${canonical.url}, current ${latestCanonical.url}`);
+                }
+                await provider.mergePr(issue.iid, { prUrl: canonical.url, prNumber: canonical.number });
                 onMerge?.(issue.iid, status.url, status.title, status.sourceBranch);
               } catch (err) {
                 // Merge failed → fire MERGE_FAILED transition (developer fixes conflicts)

--- a/lib/services/pipeline.e2e.test.ts
+++ b/lib/services/pipeline.e2e.test.ts
@@ -17,6 +17,8 @@ import { projectTick } from "./tick.js";
 import { reviewPass } from "./heartbeat/review.js";
 import { DEFAULT_WORKFLOW, ReviewPolicy, type WorkflowConfig } from "../workflow/index.js";
 import { readProjects, getRoleWorker, getProject, countActiveSlots } from "../projects/index.js";
+import { PrState } from "../providers/provider.js";
+import { recordCanonicalPr } from "./canonical-pr.js";
 
 // ---------------------------------------------------------------------------
 // Test suite
@@ -850,6 +852,13 @@ describe("E2E pipeline", () => {
         runCommand: h.runCommand,
       });
 
+      h.provider.setPrStatus(100, {
+        state: "open",
+        url: "https://example.com/pr/100",
+        number: 100,
+        sourceBranch: "feature/100-dashboard",
+      });
+
       // 3. Developer done → To Review
       await executeCompletion({
         workspaceDir: h.workspaceDir,
@@ -1022,6 +1031,13 @@ describe("E2E pipeline", () => {
         runCommand: h.runCommand,
       });
 
+      h.provider.setPrStatus(300, {
+        state: "open",
+        url: "https://example.com/pr/300",
+        number: 300,
+        sourceBranch: "feature/300-payment-flow",
+      });
+
       // 2. Developer done → To Review
       await executeCompletion({
         workspaceDir: h.workspaceDir,
@@ -1177,6 +1193,19 @@ describe("E2E pipeline", () => {
     it("reviewPolicy: agent should dispatch reviewer", async () => {
       h = await createTestHarness();
       h.provider.seedIssue({ iid: 81, title: "Needs review", labels: ["To Review"] });
+      h.provider.setPrStatus(81, {
+        state: PrState.OPEN,
+        url: "https://example.com/pr/81",
+        number: 81,
+        sourceBranch: "issue/81-needs-review",
+      });
+      h.provider.prDiffs.set(81, "diff --git a/file.ts b/file.ts");
+      await recordCanonicalPr(h.workspaceDir, h.project.slug, 81, {
+        number: 81,
+        url: "https://example.com/pr/81",
+        title: "Needs review",
+        sourceBranch: "issue/81-needs-review",
+      }, PrState.OPEN);
 
       const result = await projectTick({
         workspaceDir: h.workspaceDir,
@@ -1294,6 +1323,18 @@ describe("E2E pipeline", () => {
       h = await createTestHarness();
       // Issue already has a developer:junior label from a previous dispatch
       h.provider.seedIssue({ iid: 401, title: "Re-dispatch", labels: ["To Improve", "developer:junior"] });
+      h.provider.setPrStatus(401, {
+        state: PrState.CHANGES_REQUESTED,
+        url: "https://example.com/pr/401",
+        number: 401,
+        sourceBranch: "issue/401-redispatch",
+      });
+      await recordCanonicalPr(h.workspaceDir, h.project.slug, 401, {
+        number: 401,
+        url: "https://example.com/pr/401",
+        title: "Re-dispatch",
+        sourceBranch: "issue/401-redispatch",
+      }, PrState.CHANGES_REQUESTED);
 
       await dispatchTask({
         workspaceDir: h.workspaceDir,
@@ -1339,6 +1380,19 @@ describe("E2E pipeline", () => {
     it("projectTick should dispatch reviewer when review:agent label present", async () => {
       h = await createTestHarness();
       h.provider.seedIssue({ iid: 403, title: "Junior fix", labels: ["To Review", "developer:junior", "review:agent"] });
+      h.provider.setPrStatus(403, {
+        state: PrState.OPEN,
+        url: "https://example.com/pr/403",
+        number: 403,
+        sourceBranch: "issue/403-junior-fix",
+      });
+      h.provider.prDiffs.set(403, "diff --git a/file.ts b/file.ts");
+      await recordCanonicalPr(h.workspaceDir, h.project.slug, 403, {
+        number: 403,
+        url: "https://example.com/pr/403",
+        title: "Junior fix",
+        sourceBranch: "issue/403-junior-fix",
+      }, PrState.OPEN);
 
       const result = await projectTick({
         workspaceDir: h.workspaceDir,

--- a/lib/services/pipeline.e2e.test.ts
+++ b/lib/services/pipeline.e2e.test.ts
@@ -822,6 +822,43 @@ describe("E2E pipeline", () => {
       const issue = await h.provider.getIssue(82);
       assert.ok(issue.labels.includes("To Review"), "Should remain in To Review");
     });
+
+    it("should move review issues to Refining when canonical PR re-resolution fails", async () => {
+      h.provider.seedIssue({ iid: 83, title: "Broken canonical PR", labels: ["To Review", "review:human"] });
+      h.provider.setLinkedPrs(83, [{
+        number: 83,
+        url: "https://example.com/pr/83",
+        title: "Broken canonical PR",
+        sourceBranch: "issue/83-broken-canonical-pr",
+      }]);
+      await recordCanonicalPr(h.workspaceDir, h.project.slug, 83, {
+        number: 83,
+        url: "https://example.com/pr/83",
+        title: "Broken canonical PR",
+        sourceBranch: "issue/83-broken-canonical-pr",
+      }, PrState.OPEN);
+
+      const transitions = await reviewPass({
+        workspaceDir: h.workspaceDir,
+        projectName: h.project.name,
+        project: h.project,
+        workflow: DEFAULT_WORKFLOW,
+        provider: h.provider,
+        repoPath: "/tmp/test-repo",
+        runCommand: h.runCommand,
+      });
+
+      assert.strictEqual(transitions, 1, "Should surface a visible integrity hold");
+
+      const issue = await h.provider.getIssue(83);
+      assert.ok(issue.labels.includes("Refining"), `Labels: ${issue.labels}`);
+      assert.ok(!issue.labels.includes("To Review"), "Should leave To Review after integrity failure");
+
+      const comments = h.provider.comments.get(83) ?? [];
+      assert.strictEqual(comments.length, 1, "Should leave a hold comment for the operator");
+      assert.match(comments[0]!.body, /Canonical PR routing integrity failed during review heartbeat/);
+      assert.match(comments[0]!.body, /stored PR https:\/\/example\.com\/pr\/83 no longer resolves/);
+    });
   });
 
   // =========================================================================

--- a/lib/services/pipeline.ts
+++ b/lib/services/pipeline.ts
@@ -29,6 +29,7 @@ import {
   type WorkflowConfig,
 } from "../workflow/index.js";
 import type { Channel } from "../projects/index.js";
+import { resolveCanonicalPrForIssue } from "./canonical-pr.js";
 
 export type { CompletionRule };
 
@@ -176,11 +177,11 @@ export async function executeCompletion(opts: {
         break;
       case Action.DETECT_PR:
         if (!prUrl) { try {
-          // Try open PR first (developer just finished — MR is still open), fall back to merged
-          const prStatus = await provider.getPrStatus(issueId);
-          prUrl = prStatus.url ?? await provider.getMergedMRUrl(issueId) ?? undefined;
-          prTitle = prStatus.title;
-          sourceBranch = prStatus.sourceBranch;
+          const canonical = await resolveCanonicalPrForIssue({ workspaceDir, projectSlug, issueId, provider });
+          const prStatus = await provider.getPrStatusByUrl(canonical.url);
+          prUrl = canonical.url;
+          prTitle = prStatus?.title ?? canonical.url;
+          sourceBranch = prStatus?.sourceBranch ?? canonical.sourceBranch;
         } catch (err) {
           auditLog(workspaceDir, "pipeline_warning", { step: "detectPr", issue: issueId, role, error: (err as Error).message ?? String(err) }).catch(() => {});
         } }
@@ -188,18 +189,18 @@ export async function executeCompletion(opts: {
       case Action.MERGE_PR:
         try {
           // Grab PR metadata before merging (the MR is still open at this point)
+          const canonical = await resolveCanonicalPrForIssue({ workspaceDir, projectSlug, issueId, provider });
+          const prStatus = await provider.getPrStatusByUrl(canonical.url);
+          prUrl = canonical.url;
           if (!prTitle) {
-            try {
-              const prStatus = await provider.getPrStatus(issueId);
-              prUrl = prUrl ?? prStatus.url ?? undefined;
-              prTitle = prStatus.title;
-              sourceBranch = prStatus.sourceBranch;
-            } catch { /* best-effort */ }
+            prTitle = prStatus?.title;
+            sourceBranch = prStatus?.sourceBranch ?? canonical.sourceBranch;
           }
-          await provider.mergePr(issueId);
+          await provider.mergePr(issueId, { prUrl: canonical.url, prNumber: canonical.number });
           mergedPr = true;
         } catch (err) {
           auditLog(workspaceDir, "pipeline_warning", { step: "mergePr", issue: issueId, role, error: (err as Error).message ?? String(err) }).catch(() => {});
+          throw err;
         }
         break;
     }

--- a/lib/testing/test-provider.ts
+++ b/lib/testing/test-provider.ts
@@ -9,6 +9,7 @@ import type {
   Issue,
   StateLabel,
   IssueComment,
+  PrIdentity,
   PrStatus,
 } from "../providers/provider.js";
 import { getStateLabels } from "../workflow/index.js";
@@ -66,6 +67,8 @@ export class TestProvider implements IssueProvider {
   prStatuses = new Map<number, PrStatus>();
   /** Merged MR URLs per issue. */
   mergedMrUrls = new Map<number, string>();
+  /** Linked PRs per issue. */
+  linkedPrs = new Map<number, PrIdentity[]>();
   /** Issue IDs where mergePr should fail (simulates merge conflicts). */
   mergePrFailures = new Set<number>();
   /** PR diffs per issue (for reviewer tests). */
@@ -103,6 +106,13 @@ export class TestProvider implements IssueProvider {
   /** Set PR status for an issue (used by review pass tests). */
   setPrStatus(issueId: number, status: PrStatus): void {
     this.prStatuses.set(issueId, status);
+    if (status.url) {
+      this.linkedPrs.set(issueId, [{ number: status.number ?? issueId, url: status.url, title: status.title, sourceBranch: status.sourceBranch }]);
+    }
+  }
+
+  setLinkedPrs(issueId: number, prs: PrIdentity[]): void {
+    this.linkedPrs.set(issueId, prs);
   }
 
   /** Get calls filtered by method name. */
@@ -124,6 +134,7 @@ export class TestProvider implements IssueProvider {
     this.labels.clear();
     this.prStatuses.clear();
     this.mergedMrUrls.clear();
+    this.linkedPrs.clear();
     this.mergePrFailures.clear();
     this.prDiffs.clear();
     this.calls = [];
@@ -248,7 +259,36 @@ export class TestProvider implements IssueProvider {
     return this.prStatuses.get(issueId) ?? { state: "closed", url: null };
   }
 
-  async mergePr(issueId: number): Promise<void> {
+  async getLinkedPrs(issueId: number): Promise<PrIdentity[]> {
+    return this.linkedPrs.get(issueId) ?? [];
+  }
+
+  async getPrByUrl(prUrl: string): Promise<PrIdentity | null> {
+    for (const prs of this.linkedPrs.values()) {
+      const match = prs.find((pr) => pr.url === prUrl);
+      if (match) return match;
+    }
+    return null;
+  }
+
+  async getPrByNumber(prNumber: number): Promise<PrIdentity | null> {
+    for (const prs of this.linkedPrs.values()) {
+      const match = prs.find((pr) => pr.number === prNumber);
+      if (match) return match;
+    }
+    return null;
+  }
+
+  async getPrStatusByUrl(prUrl: string): Promise<PrStatus | null> {
+    for (const [issueId, status] of this.prStatuses.entries()) {
+      if (status.url === prUrl) return { ...status, number: status.number ?? (await this.getPrByUrl(prUrl))?.number };
+      const linked = this.linkedPrs.get(issueId) ?? [];
+      if (linked.some((pr) => pr.url === prUrl)) return { ...status, number: status.number ?? linked.find((pr) => pr.url === prUrl)?.number };
+    }
+    return null;
+  }
+
+  async mergePr(issueId: number, _opts?: { prUrl?: string; prNumber?: number }): Promise<void> {
     this.calls.push({ method: "mergePr", args: { issueId } });
     if (this.mergePrFailures.has(issueId)) {
       throw new Error(`Merge conflict: cannot merge PR for issue #${issueId}`);
@@ -265,7 +305,18 @@ export class TestProvider implements IssueProvider {
     return this.prDiffs.get(issueId) ?? null;
   }
 
+  async getPrDiffByUrl(prUrl: string): Promise<string | null> {
+    for (const [issueId, prs] of this.linkedPrs.entries()) {
+      if (prs.some((pr) => pr.url === prUrl)) return this.prDiffs.get(issueId) ?? null;
+    }
+    return null;
+  }
+
   async getPrReviewComments(_issueId: number): Promise<import("../providers/provider.js").PrReviewComment[]> {
+    return [];
+  }
+
+  async getPrReviewCommentsByUrl(_prUrl: string): Promise<import("../providers/provider.js").PrReviewComment[]> {
     return [];
   }
 

--- a/lib/tools/worker/work-finish.test.ts
+++ b/lib/tools/worker/work-finish.test.ts
@@ -14,6 +14,9 @@ import assert from "node:assert";
 import { mkdtemp, writeFile, readFile, rm, mkdir } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
+import { TestProvider } from "../../testing/test-provider.js";
+import { PrState } from "../../providers/provider.js";
+import { validatePrExistsForDeveloper } from "./work-finish.js";
 
 // Helper to create a mock audit log with a merge_conflict transition
 async function createMockAuditLog(workspaceDir: string, issueId: number, hasMergeConflict: boolean): Promise<void> {
@@ -163,6 +166,34 @@ describe("work_finish: PR validation and conflict resolution", () => {
   });
 
   describe("validatePrExistsForDeveloper: conflict detection", () => {
+    it("rejects completion when current branch does not match canonical PR branch", async () => {
+      const provider = new TestProvider();
+      provider.setLinkedPrs(244, [{
+        number: 245,
+        url: "https://github.com/test/repo/pull/245",
+        sourceBranch: "issue/244-canonical-pr-ledger",
+        repo: "test/repo",
+      }]);
+      provider.prStatuses.set(244, {
+        state: PrState.OPEN,
+        url: "https://github.com/test/repo/pull/245",
+        number: 245,
+        sourceBranch: "issue/244-canonical-pr-ledger",
+      });
+
+      await assert.rejects(
+        validatePrExistsForDeveloper(
+          244,
+          "/tmp/repo",
+          provider,
+          async () => ({ stdout: "wrong-branch\n", stderr: "", exitCode: 0, code: 0, signal: null, killed: false, termination: "exit" } as any),
+          tempDir,
+          "devclaw",
+        ),
+        /current branch wrong-branch does not match canonical PR branch issue\/244-canonical-pr-ledger/,
+      );
+    });
+
     it("should validate error message format when PR still conflicting", async () => {
       // Test that our error message matches the expected pattern
       const errorMessage = 

--- a/lib/tools/worker/work-finish.ts
+++ b/lib/tools/worker/work-finish.ts
@@ -14,6 +14,7 @@ import type { ToolContext } from "../../types.js";
 import type { PluginContext, RunCommand } from "../../context.js";
 import { getRoleWorker, resolveRepoPath, findSlotByIssue } from "../../projects/index.js";
 import { executeCompletion, getRule } from "../../services/pipeline.js";
+import { resolveDeveloperCanonicalPr } from "../../services/canonical-pr.js";
 import { log as auditLog } from "../../audit.js";
 import { DATA_DIR } from "../../setup/migrate-layout.js";
 import { requireWorkspaceDir, resolveChannelId, resolveProject, resolveProvider } from "../helpers.js";
@@ -79,27 +80,47 @@ async function isConflictResolutionCycle(
  *   - We check `url === null` rather than the state field to be explicit:
  *     a null URL unambiguously means "nothing found", regardless of state label.
  */
-async function validatePrExistsForDeveloper(
+export async function validatePrExistsForDeveloper(
   issueId: number,
   repoPath: string,
   provider: Awaited<ReturnType<typeof resolveProvider>>["provider"],
   runCommand: RunCommand,
   workspaceDir: string,
   projectSlug: string,
+  prUrl?: string,
 ): Promise<void> {
   try {
-    const prStatus = await provider.getPrStatus(issueId);
+    let currentBranch = "";
+    try {
+      currentBranch = await getCurrentBranch(repoPath, runCommand);
+    } catch {
+      // Best-effort only. Detached HEAD or provider-only environments can leave this blank.
+    }
+
+    const canonicalPr = await resolveDeveloperCanonicalPr({
+      workspaceDir,
+      projectSlug,
+      issueId,
+      provider,
+      explicitPrUrl: prUrl,
+    });
+    const prStatus = await provider.getPrStatusByUrl(canonicalPr.url);
+
+    if (!prStatus) {
+      throw new Error(`Canonical PR routing integrity failure for issue #${issueId}: ${canonicalPr.url} could not be resolved.`);
+    }
+
+    const canonicalBranch = prStatus.sourceBranch ?? canonicalPr.sourceBranch;
+    if (currentBranch && canonicalBranch && currentBranch !== canonicalBranch) {
+      throw new Error(
+        `Canonical PR routing integrity failure for issue #${issueId}: current branch ${currentBranch} does not match canonical PR branch ${canonicalBranch} (${canonicalPr.url}).`,
+      );
+    }
 
     // url is null when getPrStatus found no open or merged PR for this issue.
     // This covers both "no PR ever created" and "PR was closed without merging".
     if (!prStatus.url) {
-      // Get current branch for a helpful gh pr create example
-      let branchName = "current-branch";
-      try {
-        branchName = await getCurrentBranch(repoPath, runCommand);
-      } catch {
-        // Fall back to generic placeholder
-      }
+      const branchName = currentBranch || "current-branch";
 
       throw new Error(
         `Cannot mark work_finish(done) without an open PR.\n\n` +
@@ -168,9 +189,13 @@ async function validatePrExistsForDeveloper(
       });
     }
   } catch (err) {
-    // Re-throw our own validation errors; swallow provider/network errors.
-    // Swallowing keeps work_finish unblocked when the API is unreachable.
-    if (err instanceof Error && (err.message.startsWith("Cannot mark work_finish(done)") || err.message.startsWith("Cannot complete work_finish(done)"))) {
+    // Re-throw explicit validation and routing-integrity failures.
+    // Swallow only transient provider/network errors so unrelated outages do not block completion.
+    if (err instanceof Error && (
+      err.message.startsWith("Cannot mark work_finish(done)") ||
+      err.message.startsWith("Cannot complete work_finish(done)") ||
+      err.message.startsWith("Canonical PR routing")
+    )) {
       throw err;
     }
     console.warn(`PR validation warning for issue #${issueId}:`, err);
@@ -294,7 +319,7 @@ export function createWorkFinishTool(ctx: PluginContext) {
 
       // For developers marking work as done, validate that a PR exists
       if (role === "developer" && result === "done") {
-        await validatePrExistsForDeveloper(issueId, repoPath, provider, ctx.runCommand, workspaceDir, project.slug);
+        await validatePrExistsForDeveloper(issueId, repoPath, provider, ctx.runCommand, workspaceDir, project.slug, prUrl);
       }
 
       const completion = await executeCompletion({


### PR DESCRIPTION
## Summary
- add a durable canonical PR ledger and route review and merge flows through the canonical PR identity
- fail closed when canonical PR resolution is missing, stale, ambiguous, or branch-mismatched
- tighten provider URL-scoped canonical helpers so provider/runtime failures stay loud instead of degrading into missing diff/comment context
- re-slice the PR onto a clean devclaw-local-dev base so only #244 files remain in scope

## Validation
- `npx tsx --test lib/dispatch/pr-context.test.ts lib/services/canonical-pr.test.ts lib/tools/worker/work-finish.test.ts lib/providers/provider-pr-status.test.ts`
- `npx tsx --test --test-name-pattern="reviewPolicy: agent should dispatch reviewer|dispatch should replace old role:level label|projectTick should dispatch reviewer when review:agent label present" lib/services/pipeline.e2e.test.ts`

Addresses issue #244
